### PR TITLE
fix(installer): P0+P1+P2 bug fixes + live-server audit harness

### DIFF
--- a/.github/workflows/mirror-drift.yml
+++ b/.github/workflows/mirror-drift.yml
@@ -11,9 +11,9 @@ name: 6-surface mirror drift
 # silently overwrite surfaces 5 + 6 from a stale C.
 #
 # Cross-repo surfaces (2 = ComfyUI-Spellcaster, 3 = -NSFW, 5 =
-# Voodoomancer plugin, 6 = spellcaster_NSFW) are kept in sync by the
-# auto-patch bot; their drift surfaces here only when a developer
-# directly edits surface C / 1 inconsistently.
+# distro plugin, 6 = NSFW pack) are kept in sync by the auto-patch
+# bot; their drift surfaces here only when a developer directly
+# edits surface C / 1 inconsistently.
 
 on:
   pull_request:

--- a/.github/workflows/mirror-drift.yml
+++ b/.github/workflows/mirror-drift.yml
@@ -1,0 +1,40 @@
+name: 6-surface mirror drift
+
+# Per MIRROR_TARGETS.md, every `spellcaster_core/` module must be
+# byte-identical across surface C (`comfyui-spellcaster/`) and surface
+# 1 (`plugins/gimp/comfyui-connector/`) in this repo. Drift between
+# them is the recurring root cause for PRs that ship a fix to one
+# surface and forget the others — see PR #20 for the latest example.
+#
+# This job fails the build when any tracked file drifts, so the PR
+# author resolves it BEFORE the auto-patch bot has a chance to
+# silently overwrite surfaces 5 + 6 from a stale C.
+#
+# Cross-repo surfaces (2 = ComfyUI-Spellcaster, 3 = -NSFW, 5 =
+# Voodoomancer plugin, 6 = spellcaster_NSFW) are kept in sync by the
+# auto-patch bot; their drift surfaces here only when a developer
+# directly edits surface C / 1 inconsistently.
+
+on:
+  pull_request:
+    paths:
+      - "comfyui-spellcaster/spellcaster_core/**"
+      - "plugins/gimp/comfyui-connector/spellcaster_core/**"
+      - "tests/mirror_drift.py"
+      - "MIRROR_TARGETS.md"
+  push:
+    branches: [main]
+    paths:
+      - "comfyui-spellcaster/spellcaster_core/**"
+      - "plugins/gimp/comfyui-connector/spellcaster_core/**"
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: 6-surface mirror drift
+        run: python tests/mirror_drift.py

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ tests/*
 !tests/e2e_report.md
 !tests/installer_audit.py
 !tests/mirror_drift.py
+!tests/night_maintenance.py
 !tests/test_klein_enhancer.py
 !tests/test_quality_boost.py
 !tests/test_model_prompt_profiles.py

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ tests/*
 !tests/e2e_audit.py
 !tests/e2e_report.md
 !tests/installer_audit.py
+!tests/mirror_drift.py
 !tests/test_klein_enhancer.py
 !tests/test_quality_boost.py
 !tests/test_model_prompt_profiles.py

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ tests/*
 # ignored; whitelist the files that should travel with the repo)
 !tests/e2e_audit.py
 !tests/e2e_report.md
+!tests/installer_audit.py
 !tests/test_klein_enhancer.py
 !tests/test_quality_boost.py
 !tests/test_model_prompt_profiles.py

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -453,16 +453,19 @@ def _crashlog_dir() -> Path:
 
 def _write_crashlog(exc: BaseException) -> Path | None:
     import traceback as _tb
-    from datetime import datetime as _dt
+    from datetime import datetime as _dt, timezone as _tz
     try:
         d = _crashlog_dir()
         d.mkdir(parents=True, exist_ok=True)
-        stamp = _dt.now().strftime("%Y%m%d_%H%M%S")
+        # Use UTC (H3 hygiene): naive datetimes are ambiguous when crash
+        # logs are sent for triage across timezones.
+        _now = _dt.now(_tz.utc)
+        stamp = _now.strftime("%Y%m%d_%H%M%S")
         path = d / f"installer_crash_{stamp}.log"
         body = [
             "Spellcaster installer crash report",
             "=" * 60,
-            f"Time:       {_dt.now().isoformat(timespec='seconds')}",
+            f"Time:       {_now.isoformat(timespec='seconds')}",
             f"Python:     {sys.version.splitlines()[0]}",
             f"Platform:   {sys.platform}  {os.name}",
             f"Frozen:     {getattr(sys, 'frozen', False)}",

--- a/installer/build_installer.py
+++ b/installer/build_installer.py
@@ -86,6 +86,11 @@ def build(target_platform: str, onedir: bool = False):
         "--add-data", f"manifest.json{sep}.",       # install manifest (offline fallback)
         "--add-data", f"installer_gui.py{sep}.",    # GUI source (offline fallback)
         "--add-data", f"{REPO_ROOT / 'plugins'}{sep}plugins",  # plugin directory tree (repo root)
+        # comfyui-spellcaster pack: _find_spellcaster_core() in install.py
+        # looks here under BUNDLE_DIR (= _MEIPASS when frozen). Without
+        # this, every fresh install ships a non-functional GIMP plug-in
+        # because the spellcaster_core sibling tree is missing.
+        "--add-data", f"{REPO_ROOT / 'comfyui-spellcaster'}{sep}comfyui-spellcaster",
         "--distpath", str(REPO_ROOT / "dist"),      # output to repo-root dist/
         "--workpath", str(REPO_ROOT / "build"),     # build artefacts in repo-root build/
     ]
@@ -256,6 +261,9 @@ def build_validate(target_platform: str):
         # diagnostic.py + its sibling spellcaster_core modules ship inside
         # the bundled GIMP plugin tree.
         "--add-data", f"{REPO_ROOT / 'plugins'}{sep}plugins",
+        # comfyui-spellcaster pack — validate_install.py imports the same
+        # _find_spellcaster_core path; same regression closes here.
+        "--add-data", f"{REPO_ROOT / 'comfyui-spellcaster'}{sep}comfyui-spellcaster",
         "--distpath", str(REPO_ROOT / "dist"),
         "--workpath", str(REPO_ROOT / "build"),
     ]
@@ -326,6 +334,9 @@ def build_llm_variant(target_platform: str):
         "--add-data", f"install_with_llm.py{sep}.",
         "--add-data", f"installer_gui.py{sep}.",
         "--add-data", f"{REPO_ROOT / 'plugins'}{sep}plugins",
+        # comfyui-spellcaster pack — LLM variant runs the same install.py
+        # pipeline, same _find_spellcaster_core regression closes here.
+        "--add-data", f"{REPO_ROOT / 'comfyui-spellcaster'}{sep}comfyui-spellcaster",
         "--distpath", str(REPO_ROOT / "dist"),
         "--workpath", str(REPO_ROOT / "build"),
     ]
@@ -406,6 +417,9 @@ def build_remote_installer(target_platform: str):
         "--add-data", f"install_remote.py{sep}.",
         "--add-data", f"manifest.json{sep}.",
         "--add-data", f"{REPO_ROOT / 'plugins'}{sep}plugins",
+        # comfyui-spellcaster pack — install_remote.py also pulls
+        # spellcaster_core when bundling the GIMP plug-in (commit 1c0f035).
+        "--add-data", f"{REPO_ROOT / 'comfyui-spellcaster'}{sep}comfyui-spellcaster",
         "--distpath", str(REPO_ROOT / "dist"),
         "--workpath", str(REPO_ROOT / "build"),
     ]

--- a/installer/install.py
+++ b/installer/install.py
@@ -1272,14 +1272,29 @@ def git_clone(repo_url: str, dest: Path, dry_run: bool = False) -> bool:
         print(f"  {C_DIM}[dry-run] Would clone: {repo_url} → {dest}{C_RESET}")
         return True
     if dest.exists():
+        # Pull-or-print: report the user-visible status AFTER we know
+        # whether the pull succeeded. Previously we printed "✓ Updated"
+        # before catching the error and still returning True, so users
+        # on slow / detached / dirty trees got "✓ Updated" on a stale
+        # checkout (no actual update happened).
         print(f"  {C_YELLOW}Already exists:{C_RESET} {dest.name} — pulling latest…")
         try:
             subprocess.run(["git", "-C", str(dest), "pull", "--ff-only"],
                            capture_output=True, check=True, timeout=120)
             print(f"  {C_GREEN}✓ Updated {dest.name}{C_RESET}")
             return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return True  # pull failed but the repo exists — treat as success
+        except subprocess.CalledProcessError as _e:
+            stderr = _e.stderr.decode(errors='replace') if _e.stderr else ""
+            print(f"  {C_YELLOW}⚠ Pull failed — using existing checkout"
+                  f"{C_RESET}  {C_DIM}({stderr.splitlines()[0] if stderr else _e}){C_RESET}")
+            return True  # repo exists — install can proceed against current state
+        except FileNotFoundError:
+            # git binary missing entirely — current checkout is the
+            # best we can do; still report success so the install
+            # continues, but be honest about NOT updating.
+            print(f"  {C_YELLOW}⚠ git not installed — keeping existing checkout"
+                  f"{C_RESET}")
+            return True
     print(f"  {C_CYAN}Cloning:{C_RESET} {dest.name}")
     print(f"  {C_DIM}From: {repo_url}{C_RESET}")
     try:
@@ -3380,8 +3395,16 @@ def _find_spellcaster_core() -> Path | None:
 
     Searched in the comfyui-spellcaster folder relative to the installer
     or repo root.  Returns the directory path if found, else None.
+
+    When frozen (PyInstaller), looks inside ``BUNDLE_DIR`` (= ``_MEIPASS``)
+    so the comfyui-spellcaster/ tree bundled via build_installer.py's
+    ``--add-data`` flag is visible. Without this search root, the
+    self-update bootstrap path runs install.py from a temp fetch dir
+    whose parent has no comfyui-spellcaster/ — the pre-bootstrap
+    regression the May-7 1c0f035 fix tried to close.
     """
     search_roots = [
+        BUNDLE_DIR,                  # frozen: _MEIPASS root (PyInstaller bundle)
         SCRIPT_DIR.parent,           # repo root (installer/ is one level down)
         SCRIPT_DIR,                  # in case we're in the repo root
         SCRIPT_DIR.parent.parent,    # two levels up (dev layouts)

--- a/installer/install.py
+++ b/installer/install.py
@@ -5087,6 +5087,10 @@ def main():
     happen here — the historic `if __name__ == "__main__"` block at the
     bottom of this file never fires under bootstrap.
     """
+    # bootstrap.py injects `--bootstrapped` into sys.argv so a subprocess
+    # re-exec (rare) can skip the fetch. Our own argparser doesn't know
+    # about that flag — strip it here so argparse doesn't reject it.
+    sys.argv = [a for a in sys.argv if a != "--bootstrapped"]
     args = build_arg_parser().parse_args()
 
     is_frozen = getattr(sys, 'frozen', False)

--- a/installer/install_remote.py
+++ b/installer/install_remote.py
@@ -188,7 +188,13 @@ def scan_network_for_comfyui(port: int = 8188, timeout: float = 0.5) -> list[str
 
 
 def probe_server(server_url: str) -> dict:
-    """Probe a ComfyUI server — mirrors install.py step_probe_server()."""
+    """Probe a ComfyUI server — mirrors install.py step_probe_server().
+
+    Honors HTTP basic auth credentials embedded in the URL
+    (``user:pass@host``). Without this, every authed server returns
+    401 and the installer reports "unreachable" with no actionable
+    message. See install.py:_split_url_credentials for the helper.
+    """
     section("Probing Remote ComfyUI")
 
     result: dict[str, Any] = {
@@ -204,11 +210,21 @@ def probe_server(server_url: str) -> dict:
         "gpu_name": "",
     }
 
-    log_info(f"Connecting to {C_CYAN}{server_url}{C_RESET}...")
+    # Split credentials ONCE; only `clean_url` ever appears in log
+    # output, persisted settings, or .bat/.lnk shortcuts — keeps
+    # passwords out of screenshots, support tickets, and shell history.
+    clean_url, auth_header = _split_url_credentials(server_url)
+
+    def _auth(req):
+        if auth_header:
+            req.add_header("Authorization", auth_header)
+        return req
+
+    log_info(f"Connecting to {C_CYAN}{clean_url}{C_RESET}...")
 
     # Test connectivity via /system_stats
     try:
-        req = urllib.request.Request(f"{server_url}/system_stats")
+        req = _auth(urllib.request.Request(f"{clean_url}/system_stats"))
         with urllib.request.urlopen(req, timeout=10) as resp:
             stats = json.loads(resp.read().decode("utf-8"))
             device = stats.get("devices", [{}])[0]
@@ -222,12 +238,12 @@ def probe_server(server_url: str) -> dict:
                 log_info(f"Remote GPU: {gpu_name} — {vram_gb:.1f} GB VRAM")
         result["reachable"] = True
     except Exception as e:
-        log_err(f"Cannot reach ComfyUI at {server_url}: {e}")
+        log_err(f"Cannot reach ComfyUI at {clean_url}: {e}")
         return result
 
     # Fetch installed nodes
     try:
-        req = urllib.request.Request(f"{server_url}/object_info")
+        req = _auth(urllib.request.Request(f"{clean_url}/object_info"))
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = json.loads(resp.read().decode("utf-8"))
             result["available_nodes"] = set(data.keys())
@@ -244,7 +260,7 @@ def probe_server(server_url: str) -> dict:
     }
     for key, (node_type, param_name) in MODEL_QUERIES.items():
         try:
-            req = urllib.request.Request(f"{server_url}/object_info/{node_type}")
+            req = _auth(urllib.request.Request(f"{clean_url}/object_info/{node_type}"))
             with urllib.request.urlopen(req, timeout=10) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
                 items = (data.get(node_type, {})
@@ -260,7 +276,7 @@ def probe_server(server_url: str) -> dict:
     for node_type in ["UNETLoader", "UnetLoaderGGUF"]:
         if node_type in result["available_nodes"]:
             try:
-                req = urllib.request.Request(f"{server_url}/object_info/{node_type}")
+                req = _auth(urllib.request.Request(f"{clean_url}/object_info/{node_type}"))
                 with urllib.request.urlopen(req, timeout=10) as resp:
                     data = json.loads(resp.read().decode("utf-8"))
                     items = (data.get(node_type, {})
@@ -277,7 +293,7 @@ def probe_server(server_url: str) -> dict:
     for node_type in ["CLIPLoader", "DualCLIPLoader"]:
         if node_type in result["available_nodes"]:
             try:
-                req = urllib.request.Request(f"{server_url}/object_info/{node_type}")
+                req = _auth(urllib.request.Request(f"{clean_url}/object_info/{node_type}"))
                 with urllib.request.urlopen(req, timeout=10) as resp:
                     data = json.loads(resp.read().decode("utf-8"))
                     for pname in ["clip_name", "clip_name1"]:
@@ -401,12 +417,14 @@ def detect_nsfw_mode(server_info: dict) -> bool:
 _scan_gimp_versions       = install._scan_gimp_versions
 _win_registry_gimp        = install._win_registry_gimp
 find_default_gimp         = install.find_default_gimp
+find_all_gimp_dirs        = install.find_all_gimp_dirs
 find_default_darktable    = install.find_default_darktable
 _find_gimp_plugin_src     = install._find_gimp_plugin_src
 _find_darktable_plugin_src = install._find_darktable_plugin_src
 _find_tavern_src          = install._find_tavern_src
 _find_scaffold_src        = install._find_scaffold_src
 _classify_server_loras    = install._classify_server_loras
+_split_url_credentials    = install._split_url_credentials
 
 
 # ─── Settings writer ─────────────────────────────────────────────────────────
@@ -414,7 +432,14 @@ _classify_server_loras    = install._classify_server_loras
 def write_settings(paths: dict, server_url: str, llm_url: str,
                    server_info: dict, nsfw_mode: bool = False,
                    dry_run: bool = False) -> dict:
-    """Write spellcaster_settings.json — shared config all plugins read."""
+    """Write spellcaster_settings.json — shared config all plugins read.
+
+    HTTP basic auth credentials embedded in ``server_url`` are stripped
+    and stored in ``comfyui_auth_header`` instead so the user:pass
+    pair doesn't end up plain-text in a file the user might screenshot
+    or share. Plugin runtime sends the header as ``Authorization``
+    on every ComfyUI request.
+    """
     section("Writing Settings")
 
     lora_archs = {}
@@ -424,9 +449,10 @@ def write_settings(paths: dict, server_url: str, llm_url: str,
         except Exception as e:
             log_warn(f"LoRA classification failed: {e}")
 
+    clean_url, auth_header = _split_url_credentials(server_url)
     settings = {
         "version": VERSION,
-        "comfyui_url": server_url,
+        "comfyui_url": clean_url,
         "llm_url": llm_url,
         "server_reachable": server_info.get("reachable", False),
         "remote_install": True,
@@ -442,6 +468,8 @@ def write_settings(paths: dict, server_url: str, llm_url: str,
         },
         "lora_architectures": lora_archs,
     }
+    if auth_header:
+        settings["comfyui_auth_header"] = auth_header
 
     if dry_run:
         log_dim("[dry-run] Would write spellcaster_settings.json")
@@ -550,11 +578,21 @@ def install_gimp_plugin(gimp_path: Path, server_url: str, dry_run: bool = False)
         )
     log_ok(f"GIMP plugin → {dest}")
 
-    # Write config.json with remote server URL
+    # Write config.json with remote server URL. Strip any HTTP-basic-auth
+    # credentials and stash them in server_auth_header — keeps the
+    # password out of the on-disk config the user might screenshot.
+    # Mirrors install.py:4061-4071.
     config_path = dest / "config.json"
-    config_path.write_text(json.dumps({"server_url": server_url}, indent=4),
-                           encoding="utf-8")
-    log_ok("Wrote config.json")
+    clean_url, auth_header = _split_url_credentials(server_url)
+    cfg = {"server_url": clean_url}
+    if auth_header:
+        cfg["server_auth_header"] = auth_header
+        cfg["_note"] = ("server_auth_header was extracted from the URL "
+                        "you provided. The plugin sends it as the "
+                        "Authorization header on every ComfyUI request.")
+    config_path.write_text(json.dumps(cfg, indent=4), encoding="utf-8")
+    log_ok("Wrote config.json"
+           + (" (with basic auth header)" if auth_header else ""))
 
     # Unix: make executable
     if os.name != "nt":
@@ -707,18 +745,23 @@ def install_wizard_guild(server_url: str, llm_url: str,
         log_dim("Wizard Guild will run in SFW mode without the token.")
         log_dim("Use --nsfw-token <PAT> to enable NSFW auto-updates.")
 
-    # Write guild config
+    # Write guild config. Strip HTTP-basic-auth so the password isn't
+    # plain-text in guild_config.json (which gets distributed with the
+    # Wizard Guild folder). Auth lives in comfyui_auth_header instead.
+    clean_url, auth_header = _split_url_credentials(server_url)
     guild_config = dest / "guild_config.json"
     config_data = {
-        "comfyui_url": server_url,
+        "comfyui_url": clean_url,
         "kobold_url": llm_url or "http://127.0.0.1:5001",
         "prompt_enhance": bool(llm_url),
         "auto_update": True,
     }
+    if auth_header:
+        config_data["comfyui_auth_header"] = auth_header
     if not guild_config.exists():
         guild_config.write_text(json.dumps(config_data, indent=2),
                                 encoding="utf-8")
-        log_ok(f"Wrote guild_config.json (ComfyUI: {server_url})")
+        log_ok(f"Wrote guild_config.json (ComfyUI: {clean_url})")
     else:
         log_ok("guild_config.json preserved (existing)")
 
@@ -727,19 +770,22 @@ def install_wizard_guild(server_url: str, llm_url: str,
         for py in dest.glob("*.py"):
             py.chmod(0o755)
 
-    # Create launcher script
+    # Create launcher script. Pass clean_url on the command line — the
+    # launcher reads auth_header from guild_config.json so credentials
+    # never appear in .bat / .sh contents (which users sometimes share
+    # for screen-recording demos).
     launcher_path = dest / "guild_launcher.py"
     if sys.platform == "win32":
         bat_path = dest.parent / "wizard-guild.bat"
         bat_path.write_text(
-            f'@echo off\r\npython "{launcher_path}" --comfyui {server_url} %*\r\n',
+            f'@echo off\r\npython "{launcher_path}" --comfyui {clean_url} %*\r\n',
             encoding="utf-8"
         )
         log_ok(f"Launcher: {bat_path}")
     else:
         sh_path = dest.parent / "wizard-guild"
         sh_path.write_text(
-            f'#!/bin/sh\npython3 "{launcher_path}" --comfyui {server_url} "$@"\n',
+            f'#!/bin/sh\npython3 "{launcher_path}" --comfyui {clean_url} "$@"\n',
             encoding="utf-8"
         )
         sh_path.chmod(0o755)
@@ -751,7 +797,12 @@ def install_wizard_guild(server_url: str, llm_url: str,
 # ─── Desktop shortcuts ────────────────────────────────────────────────────────
 
 def create_shortcuts(launcher_path: Path, server_url: str, dry_run: bool = False):
-    """Create desktop shortcuts pointing at the remote ComfyUI."""
+    """Create desktop shortcuts pointing at the remote ComfyUI.
+
+    Strips any user:pass@ from the server URL before passing it into
+    .bat / .lnk / .desktop launchers — credentials live in the
+    plugin's config.json, not in shortcut metadata users might share.
+    """
     if not launcher_path or not launcher_path.exists():
         return
 
@@ -760,6 +811,11 @@ def create_shortcuts(launcher_path: Path, server_url: str, dry_run: bool = False
     if dry_run:
         log_dim("[dry-run] Would create desktop shortcuts")
         return
+
+    # Single split for every downstream shortcut writer. The launcher
+    # script reads config.json for the Authorization header, so the
+    # command-line argument only needs the bare URL.
+    server_url, _auth_unused = _split_url_credentials(server_url)
 
     icon_path = launcher_path.parent / "static" / "favicon.ico"
     if not icon_path.exists():
@@ -872,9 +928,13 @@ def print_summary(server_url: str, llm_url: str, paths: dict,
                   nsfw_mode: bool = False):
     section("INSTALLATION COMPLETE")
 
+    # Strip user:pass@ before displaying — terminal logs often go into
+    # screenshots / support tickets / shell history. The credential
+    # already lives in the plug-in's config.json (comfyui_auth_header).
+    display_url, _auth_unused = _split_url_credentials(server_url)
     edition = f"{C_RED}NSFW{C_RESET}" if nsfw_mode else f"{C_GREEN}SFW{C_RESET}"
     print(f"  {C_BOLD}Edition:{C_RESET}        {edition}")
-    print(f"  {C_BOLD}Remote ComfyUI:{C_RESET} {server_url}")
+    print(f"  {C_BOLD}Remote ComfyUI:{C_RESET} {display_url}")
     if llm_url:
         print(f"  {C_BOLD}LLM server:{C_RESET}     {llm_url}")
 
@@ -895,7 +955,7 @@ def print_summary(server_url: str, llm_url: str, paths: dict,
             print(f"    {C_DIM}... and {len(features) - 15} more{C_RESET}")
 
     print(f"\n  {C_BOLD}Next steps:{C_RESET}")
-    print(f"    1. Make sure ComfyUI is running on {server_url}")
+    print(f"    1. Make sure ComfyUI is running on {display_url}")
     if paths.get("gimp"):
         print(f"    2. Open GIMP 3 → Filters → Spellcaster")
     if paths.get("darktable"):
@@ -1035,7 +1095,13 @@ def main():
 
     paths: dict[str, Any] = {"gimp": None, "darktable": None, "tavern": None}
 
-    # GIMP
+    # GIMP — primary + multi-version enumeration
+    # Mirrors install.py:3957-3975. When GIMP 3.0 and 3.2 are installed
+    # side-by-side, both have their own plug-ins/ + pluginrc cache;
+    # remote-installed users used to get the plug-in into ONE version
+    # and silent emptiness in the other. The extra_gimp_dirs loop
+    # below the primary install fixes that.
+    extra_gimp_dirs: list[Path] = []
     if not args.skip_gimp:
         if args.gimp:
             gimp_path = Path(args.gimp).expanduser().resolve()
@@ -1053,6 +1119,32 @@ def main():
                     raw = input(f"    Enter GIMP plug-ins path (or Enter to skip): ").strip()
                     if raw:
                         paths["gimp"] = Path(raw).expanduser().resolve()
+        # Multi-GIMP detection (3.0 + 3.2 side-by-side, etc.).
+        # Runs even under --dry-run because this is pure enumeration
+        # (no disk writes); the dry-run output should still list every
+        # GIMP the real install would touch so users can verify the
+        # plan before committing.
+        if paths["gimp"]:
+            try:
+                primary_resolved = paths["gimp"].resolve()
+            except OSError:
+                primary_resolved = paths["gimp"]
+            try:
+                for d in find_all_gimp_dirs():
+                    try:
+                        rp = d.resolve()
+                    except OSError:
+                        rp = d
+                    if rp != primary_resolved and (rp.is_dir() or rp.parent.is_dir()):
+                        extra_gimp_dirs.append(d)
+                if extra_gimp_dirs:
+                    log_info(f"Detected {len(extra_gimp_dirs) + 1} GIMP "
+                             f"version(s) — will install plugin to all of them:")
+                    log_dim(f"  {paths['gimp']}")
+                    for d in extra_gimp_dirs:
+                        log_dim(f"  {d}")
+            except Exception:  # noqa: BLE001 — multi-detect is a nicety
+                extra_gimp_dirs = []
     else:
         log_dim("GIMP plugin: skipped (--skip-gimp)")
 
@@ -1078,6 +1170,12 @@ def main():
 
     if paths["gimp"]:
         install_gimp_plugin(paths["gimp"], server_url, args.dry_run)
+        # Mirror to every additional GIMP version detected. Each version
+        # has its own plug-ins/ folder; without this loop GIMP 3.0 users
+        # silently miss the plug-in when GIMP 3.2 is also installed.
+        for extra_dir in extra_gimp_dirs:
+            log_info(f"Mirroring plugin to: {extra_dir}")
+            install_gimp_plugin(extra_dir, server_url, args.dry_run)
 
     if paths["darktable"]:
         install_darktable_plugin(paths["darktable"], server_url, args.dry_run)

--- a/installer/install_remote.py
+++ b/installer/install_remote.py
@@ -1019,6 +1019,12 @@ def build_arg_parser():
 
 
 def main():
+    # bootstrap.py injects `--bootstrapped` into sys.argv so a subprocess
+    # re-exec can skip the fetch. Our argparser doesn't know about that
+    # flag — strip it here so argparse doesn't reject it (manifested as
+    # "unrecognized arguments: --bootstrapped" when the frozen .exe ran
+    # post-bootstrap, before 6b9ee5e).
+    sys.argv = [a for a in sys.argv if a != "--bootstrapped"]
     args = build_arg_parser().parse_args()
 
     banner()

--- a/installer/install_with_llm.py
+++ b/installer/install_with_llm.py
@@ -546,6 +546,10 @@ def _install_comfyui_native(args, comfyui_root, paths, server_url):
 
 
 def main():
+    # bootstrap.py injects `--bootstrapped` into sys.argv (recursion
+    # guard for re-exec'd subprocesses). Strip it before argparse —
+    # the parser doesn't know it and would reject every frozen run.
+    sys.argv = [a for a in sys.argv if a != "--bootstrapped"]
     args = install.build_arg_parser().parse_args()
     banner()
 

--- a/installer/validate_install.py
+++ b/installer/validate_install.py
@@ -73,6 +73,9 @@ def main() -> int:
                              "human-readable progress).")
     parser.add_argument("--no-save", action="store_true",
                         help="Do not persist the report to disk; stdout only.")
+    # Strip bootstrap.py's --bootstrapped flag (recursion guard for
+    # re-exec) so this parser doesn't reject it.
+    sys.argv = [a for a in sys.argv if a != "--bootstrapped"]
     args = parser.parse_args()
 
     server_url = (args.server_url

--- a/tests/installer_audit.py
+++ b/tests/installer_audit.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Audit harness — systematic live-server testing of the installer suite.
+
+Runs against a real ComfyUI instance (default: Theo on the LAN) and
+exercises every installer function whose correctness can be verified
+without writing to disk. Each check prints PASS / FAIL / SKIP with
+the relevant evidence so regressions are caught BEFORE they ship.
+
+Usage:
+    python audit_installer.py
+    python audit_installer.py --server http://192.168.86.28:8190
+    python audit_installer.py --server http://user:pass@host:8190 --auth
+
+Exit code 0 = all checks passed; 1 = any failure (CI-friendly).
+
+Covered:
+  - install.py:_split_url_credentials (auth split round-trip)
+  - install.py:_find_spellcaster_core (BUNDLE_DIR + repo-tree paths)
+  - install.py:find_all_gimp_dirs (every detected GIMP version)
+  - install_remote.py re-exports of the above
+  - install_remote.py:probe_server (live HTTP probe, with + without auth)
+  - install.py LoRA classifier (live server response → arch buckets)
+  - install_remote.py:detect_available_features (feature gating)
+  - install_remote.py:detect_nsfw_mode (NSFW edition detection)
+  - install_remote.py:write_settings credential-leak check
+    (auth_header never appears in URL fields)
+  - install.py:_split_url_credentials called consistently at all sites
+    (grep audit of file)
+  - bootstrap.py:_write_crashlog uses tz-aware UTC datetime
+  - PyInstaller spec files bundle comfyui-spellcaster/
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import io
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+# Resolve installer dir whether this file lives in tests/ or installer/.
+# Prefer the sibling ``installer/`` (when this file is in tests/); fall
+# back to its own directory (when copied into installer/).
+_FILE_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _FILE_DIR.parent if _FILE_DIR.name == "tests" else _FILE_DIR.parent
+HERE = (_REPO_ROOT / "installer") if (_REPO_ROOT / "installer").is_dir() else _FILE_DIR
+sys.path.insert(0, str(HERE))
+
+# ─── Console helpers ──────────────────────────────────────────────────────────
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+YELLOW = "\033[93m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+_results: list[tuple[str, str, str]] = []  # (status, name, detail)
+
+
+def _record(status: str, name: str, detail: str = "") -> None:
+    _results.append((status, name, detail))
+    icon = {"PASS": f"{GREEN}✓{RESET}",
+            "FAIL": f"{RED}✗{RESET}",
+            "SKIP": f"{YELLOW}~{RESET}"}[status]
+    print(f"  {icon} {name}")
+    if detail:
+        print(f"    {DIM}{detail}{RESET}")
+
+
+def section(label: str) -> None:
+    print(f"\n{BOLD}══ {label} ══{RESET}")
+
+
+# ─── Checks ───────────────────────────────────────────────────────────────────
+
+def check_split_credentials(install) -> None:
+    """install._split_url_credentials round-trip auth + no-auth cases."""
+    section("auth split round-trip")
+
+    cases = [
+        ("http://user:pw@host:8190",  "http://host:8190",        True),
+        ("http://host:8190",          "http://host:8190",        False),
+        ("https://u:p@example.com/x", "https://example.com/x",   True),
+        ("http://192.168.1.1:8188",   "http://192.168.1.1:8188", False),
+        ("http://just-user@host",     "http://host",             True),  # no password
+    ]
+    for raw, want_clean, want_auth in cases:
+        clean, auth = install._split_url_credentials(raw)
+        ok = clean == want_clean and (bool(auth) == want_auth)
+        if ok:
+            _record("PASS", f"split({raw!r})",
+                    f"clean={clean}  auth={'set' if auth else 'None'}")
+        else:
+            _record("FAIL", f"split({raw!r})",
+                    f"want=({want_clean!r}, auth={want_auth}); got=({clean!r}, auth={auth!r})")
+
+
+def check_find_spellcaster_core(install) -> None:
+    """install._find_spellcaster_core resolves to a real spellcaster_core."""
+    section("_find_spellcaster_core")
+
+    result = install._find_spellcaster_core()
+    if result is None:
+        _record("FAIL", "_find_spellcaster_core() returned None",
+                "build_installer.py is supposed to bundle comfyui-spellcaster/; "
+                "install.py search_roots include BUNDLE_DIR")
+        return
+    if not (result / "__init__.py").is_file():
+        _record("FAIL", f"_find_spellcaster_core() = {result}",
+                "but __init__.py missing")
+        return
+    if not (result / "workflows.py").is_file():
+        _record("FAIL", f"_find_spellcaster_core() = {result}",
+                "but workflows.py missing — bundle is incomplete")
+        return
+    # Sanity: must be the canonical surface (has nsfw_unlock_loras param)
+    src = (result / "workflows.py").read_text(encoding="utf-8", errors="replace")
+    if "nsfw_unlock_loras" not in src:
+        _record("FAIL", "spellcaster_core/workflows.py is stale",
+                "missing nsfw_unlock_loras param — surface drift vs canonical")
+        return
+    _record("PASS", f"_find_spellcaster_core() = {result.name}",
+            f"resolved to {result}")
+
+
+def check_multi_gimp(install) -> None:
+    """install.find_all_gimp_dirs enumerates plural versions when present."""
+    section("multi-GIMP detection")
+
+    dirs = install.find_all_gimp_dirs()
+    if not dirs:
+        _record("SKIP", "find_all_gimp_dirs()", "no GIMP installations detected")
+        return
+    detail = f"{len(dirs)} version(s): " + ", ".join(d.name for d in dirs)
+    _record("PASS", f"find_all_gimp_dirs() = {len(dirs)} dirs", detail)
+    if len(dirs) >= 2:
+        _record("PASS", "side-by-side GIMP scenario",
+                "install_remote.py multi-GIMP loop will mirror to all of these")
+    else:
+        _record("SKIP", "side-by-side GIMP scenario",
+                "only one version installed; can't exercise multi-GIMP path")
+
+
+def check_install_remote_reexports(install_remote) -> None:
+    """install_remote.py re-exports the helpers that fix P0-3 + P0-4."""
+    section("install_remote.py re-exports")
+
+    required = [
+        "_split_url_credentials",   # P0-3
+        "find_all_gimp_dirs",       # P0-4
+        "find_default_gimp",        # baseline
+        "_classify_server_loras",   # used by write_settings
+    ]
+    for name in required:
+        if hasattr(install_remote, name):
+            _record("PASS", f"install_remote.{name}",
+                    "re-exported from install")
+        else:
+            _record("FAIL", f"install_remote.{name}",
+                    "MISSING — calls will NameError at install time")
+
+
+def check_live_probe(install_remote, server_url: str) -> dict | None:
+    """install_remote.probe_server hits the live server."""
+    section(f"live probe against {server_url}")
+
+    # Capture probe output so it doesn't drown the audit log
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf):
+            info = install_remote.probe_server(server_url)
+    except Exception as e:
+        _record("FAIL", "probe_server raised", repr(e))
+        return None
+
+    if not info.get("reachable"):
+        _record("FAIL", "probe_server reachability",
+                f"server returned not reachable; URL was {server_url}")
+        return None
+
+    nodes = info.get("available_nodes", set())
+    _record("PASS", "probe_server reachability",
+            f"reachable=True; {len(nodes)} nodes; "
+            f"{info.get('gpu_name','?')} {info.get('vram_total',0)//(1024**3)} GB")
+
+    # Sanity-check the model lists came back
+    for key, want_min in [("checkpoints", 1), ("loras", 1)]:
+        n = len(info.get(key, []))
+        if n >= want_min:
+            _record("PASS", f"probe.{key}", f"{n} entries")
+        else:
+            _record("FAIL", f"probe.{key}", f"got {n}; expected >= {want_min}")
+
+    return info
+
+
+def check_lora_classifier(install, server_info: dict | None) -> None:
+    """install._classify_server_loras buckets server LoRAs by architecture."""
+    section("LoRA classifier")
+    if not server_info:
+        _record("SKIP", "_classify_server_loras", "no server_info from probe")
+        return
+    loras = server_info.get("loras", [])
+    if not loras:
+        _record("SKIP", "_classify_server_loras", "server has no LoRAs")
+        return
+    try:
+        archs = install._classify_server_loras(loras)
+    except Exception as e:
+        _record("FAIL", "_classify_server_loras raised", repr(e))
+        return
+    # Expect at least one arch bucket
+    total = sum(len(v) if isinstance(v, list) else 0 for v in archs.values())
+    if total == 0:
+        _record("FAIL", "_classify_server_loras", "0 LoRAs classified")
+        return
+    keys_with_data = [k for k, v in archs.items() if isinstance(v, list) and v]
+    _record("PASS", f"_classify_server_loras() classified {total}/{len(loras)}",
+            f"archs: {', '.join(keys_with_data[:6])}"
+            + ("…" if len(keys_with_data) > 6 else ""))
+
+
+def check_feature_detect(install_remote, server_info, manifest_path: Path) -> None:
+    """install_remote.detect_available_features against live server."""
+    section("feature detection")
+    if not server_info:
+        _record("SKIP", "detect_available_features", "no server_info")
+        return
+    if not manifest_path.is_file():
+        _record("FAIL", "manifest.json missing", str(manifest_path))
+        return
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    feats = install_remote.detect_available_features(manifest, server_info)
+    if not feats:
+        _record("FAIL", "detect_available_features", "returned 0 features")
+        return
+    _record("PASS", f"detect_available_features = {len(feats)}",
+            f"first 3: {feats[:3]}")
+
+
+def check_nsfw_detect(install_remote, server_info) -> None:
+    """install_remote.detect_nsfw_mode picks up adult LoRAs/models correctly."""
+    section("NSFW edition detection")
+    if not server_info:
+        _record("SKIP", "detect_nsfw_mode", "no server_info")
+        return
+    is_nsfw = install_remote.detect_nsfw_mode(server_info)
+    # On Theo we know there's at least one NSFW LoRA — expect True there.
+    # On a clean SFW server expect False. Either is acceptable; we just
+    # want to confirm the function runs and returns a bool.
+    _record("PASS", f"detect_nsfw_mode = {is_nsfw}",
+            "(boolean returned without raising)")
+
+
+def check_credential_leak_grep() -> None:
+    """Static grep: any remaining `server_url` in a persisted-string position."""
+    section("credential-leak static check")
+
+    install_remote = HERE / "install_remote.py"
+    src = install_remote.read_text(encoding="utf-8")
+
+    # Pattern: server_url being interpolated into a write context.
+    # The legitimate sites (now using clean_url / display_url) shouldn't trip.
+    bad = re.findall(
+        r'(?:json\.dumps|write_text|\.write\(|f["\'][^"\']*\{server_url\}'
+        r'[^"\']*["\'])',
+        src,
+    )
+    # Soft check — also look for direct f-strings containing {server_url}
+    # in any disk-write helper.
+    leaky_lines = []
+    for i, line in enumerate(src.splitlines(), 1):
+        if "server_url" in line and any(tok in line for tok in
+                                          ("config.json", "settings.json",
+                                           "guild_config", "write_text",
+                                           "json.dumps")):
+            # Allowlist: the audited functions that explicitly split first
+            if "_split_url_credentials" in line or "# clean" in line.lower():
+                continue
+            leaky_lines.append((i, line.strip()[:120]))
+
+    if not leaky_lines:
+        _record("PASS", "no leaky server_url in disk-write sites", "")
+    else:
+        for i, ln in leaky_lines[:5]:
+            _record("FAIL", f"install_remote.py:{i}", ln)
+
+
+def check_bootstrap_datetime() -> None:
+    """bootstrap.py crashlog uses tz-aware UTC datetimes (H3)."""
+    section("bootstrap.py H3 hygiene")
+    bp = (HERE / "bootstrap.py").read_text(encoding="utf-8")
+    # Bad pattern: _dt.now() without timezone arg
+    bad = re.findall(r"_dt\.now\(\s*\)", bp)
+    if bad:
+        _record("FAIL", "bootstrap.py crashlog datetime",
+                f"{len(bad)} naive _dt.now() call(s) — H3 violation")
+    else:
+        # And verify the good pattern is present
+        if re.search(r"_dt\.now\(\s*_tz\.utc\s*\)", bp):
+            _record("PASS", "bootstrap.py crashlog datetime",
+                    "uses _dt.now(_tz.utc)")
+        else:
+            _record("FAIL", "bootstrap.py crashlog datetime",
+                    "no tz-aware now() found")
+
+
+def check_specs_bundle_pack() -> None:
+    """PyInstaller .spec files bundle comfyui-spellcaster/."""
+    section("PyInstaller .spec bundles comfyui-spellcaster")
+    for spec in HERE.glob("*.spec"):
+        body = spec.read_text(encoding="utf-8", errors="replace")
+        if "comfyui-spellcaster" in body:
+            _record("PASS", f"{spec.name}", "bundles comfyui-spellcaster/")
+        else:
+            _record("FAIL", f"{spec.name}",
+                    "missing comfyui-spellcaster — frozen .exe will crash "
+                    "on _find_spellcaster_core")
+
+
+def check_build_installer_bundle_pack() -> None:
+    """build_installer.py adds --add-data for comfyui-spellcaster in ALL targets."""
+    section("build_installer.py bundles comfyui-spellcaster")
+    body = (HERE / "build_installer.py").read_text(encoding="utf-8")
+    # Count the --add-data calls and the comfyui-spellcaster references
+    add_data_count = body.count("--add-data")
+    pack_count = body.count("comfyui-spellcaster")
+    # 4 build targets × ~6 --add-data entries each ≈ 20-24; we just want
+    # pack_count >= 4 (one --add-data per target).
+    if pack_count >= 4:
+        _record("PASS", "build_installer.py --add-data",
+                f"comfyui-spellcaster referenced {pack_count} times "
+                f"({add_data_count} total --add-data)")
+    else:
+        _record("FAIL", "build_installer.py --add-data",
+                f"only {pack_count} comfyui-spellcaster reference(s) — "
+                f"expected >= 4 (one per build target)")
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--server", default="http://192.168.86.28:8190",
+                        help="ComfyUI URL for live probe (default: Theo)")
+    parser.add_argument("--auth", action="store_true",
+                        help="treat --server as containing user:pass@ "
+                             "(exercises the auth split path)")
+    parser.add_argument("--no-live", action="store_true",
+                        help="skip checks that hit the live server")
+    args = parser.parse_args()
+
+    # Force UTF-8 console on Windows (cp1252 chokes on ✓ / ✗)
+    if sys.platform == "win32":
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+    print(f"{BOLD}Spellcaster Installer Audit{RESET}")
+    print(f"  Target server: {args.server}")
+    print(f"  Live HTTP:     {'no' if args.no_live else 'yes'}")
+    print(f"  HERE:          {HERE}")
+
+    # Load modules under audit
+    import install
+    import install_remote
+
+    # ── Static + module-level checks ──
+    check_split_credentials(install)
+    check_find_spellcaster_core(install)
+    check_multi_gimp(install)
+    check_install_remote_reexports(install_remote)
+    check_credential_leak_grep()
+    check_bootstrap_datetime()
+    check_specs_bundle_pack()
+    check_build_installer_bundle_pack()
+
+    # ── Live-server checks ──
+    server_info = None
+    if not args.no_live:
+        server_info = check_live_probe(install_remote, args.server)
+        check_lora_classifier(install, server_info)
+        check_feature_detect(install_remote, server_info,
+                             HERE / "manifest.json")
+        check_nsfw_detect(install_remote, server_info)
+
+    # ── Tabulate ──
+    section("RESULTS")
+    p = sum(1 for s, *_ in _results if s == "PASS")
+    f = sum(1 for s, *_ in _results if s == "FAIL")
+    sk = sum(1 for s, *_ in _results if s == "SKIP")
+    total = p + f + sk
+    print(f"  {GREEN}PASS{RESET}: {p}/{total}    "
+          f"{RED}FAIL{RESET}: {f}    "
+          f"{YELLOW}SKIP{RESET}: {sk}")
+    if f:
+        print(f"\n  {BOLD}Failures:{RESET}")
+        for s, n, d in _results:
+            if s == "FAIL":
+                print(f"    {RED}✗{RESET} {n}")
+                if d:
+                    print(f"      {DIM}{d}{RESET}")
+    return 0 if f == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/installer_audit.py
+++ b/tests/installer_audit.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """Audit harness — systematic live-server testing of the installer suite.
 
-Runs against a real ComfyUI instance (default: Theo on the LAN) and
-exercises every installer function whose correctness can be verified
-without writing to disk. Each check prints PASS / FAIL / SKIP with
-the relevant evidence so regressions are caught BEFORE they ship.
+Runs against a real ComfyUI instance (default: ``${COMFYUI_HOST}``
+on the LAN) and exercises every installer function whose correctness
+can be verified without writing to disk. Each check prints
+PASS / FAIL / SKIP with the relevant evidence so regressions are
+caught BEFORE they ship.
 
 Usage:
-    python audit_installer.py
-    python audit_installer.py --server http://192.168.86.28:8190
-    python audit_installer.py --server http://user:pass@host:8190 --auth
+    python installer_audit.py
+    python installer_audit.py --server http://${COMFYUI_HOST}:8190
+    python installer_audit.py --server http://user:pass@host:8190 --auth
 
 Exit code 0 = all checks passed; 1 = any failure (CI-friendly).
 
@@ -35,6 +36,7 @@ import argparse
 import importlib
 import io
 import json
+import os
 import re
 import sys
 import urllib.error
@@ -250,9 +252,10 @@ def check_nsfw_detect(install_remote, server_info) -> None:
         _record("SKIP", "detect_nsfw_mode", "no server_info")
         return
     is_nsfw = install_remote.detect_nsfw_mode(server_info)
-    # On Theo we know there's at least one NSFW LoRA — expect True there.
-    # On a clean SFW server expect False. Either is acceptable; we just
-    # want to confirm the function runs and returns a bool.
+    # On the NSFW edition dev box we know there's at least one
+    # adult-only LoRA — expect True there. On a clean SFW server
+    # expect False. Either is acceptable; we just want to confirm
+    # the function runs and returns a bool.
     _record("PASS", f"detect_nsfw_mode = {is_nsfw}",
             "(boolean returned without raising)")
 
@@ -346,8 +349,16 @@ def check_build_installer_bundle_pack() -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("--server", default="http://192.168.86.28:8190",
-                        help="ComfyUI URL for live probe (default: Theo)")
+    # Default server resolves from environment, falling back to a
+    # sensible localhost guess. Set COMFYUI_HOST in the dev environment
+    # (or pass --server) to point at the LAN host. We intentionally
+    # avoid baking a private LAN IP into tracked code (H2 hygiene).
+    _default_server = os.environ.get(
+        "COMFYUI_AUDIT_URL",
+        f"http://{os.environ.get('COMFYUI_HOST','127.0.0.1')}:8190")
+    parser.add_argument("--server", default=_default_server,
+                        help="ComfyUI URL for live probe (default: "
+                             "$COMFYUI_AUDIT_URL or http://$COMFYUI_HOST:8190)")
     parser.add_argument("--auth", action="store_true",
                         help="treat --server as containing user:pass@ "
                              "(exercises the auth split path)")

--- a/tests/mirror_drift.py
+++ b/tests/mirror_drift.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Mirror-drift check — fails the build when 6-surface mirror has drifted.
+
+Per ``MIRROR_TARGETS.md``, the spellcaster_core/ package must be
+byte-identical across SIX surfaces. This check enforces it inside the
+spellcaster repo for the two in-repo surfaces (C and 1); cross-repo
+surfaces (2, 3, 5, 6) are caught by the same script run in a
+post-merge GitHub Action that fetches the sibling repos.
+
+Why this exists: PR #20 caught a 4-week-old drift between surfaces C
+and 1 where the ``disk_backup`` SaveImageWebsocket fix landed on
+surface 1 (the GIMP-side dev copy) but never propagated to surface C.
+The auto-patch bot then nearly overwrote 5 + 6 from C and would have
+silently regressed the inpaint resilience fix. A pre-merge drift
+check would have flagged the original PR.
+
+Behavior:
+- Exit 0 when every file in the mirror list is byte-identical between C and 1.
+- Exit 1 with a per-file diff summary when any file drifts.
+- ``--fix`` copies C → 1 (single direction; C is canonical per the doc).
+
+Usage:
+    python tests/mirror_drift.py
+    python tests/mirror_drift.py --fix       # SFW-canonical → GIMP-side
+    python tests/mirror_drift.py --quiet     # only print on failure
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+
+# Force UTF-8 console on Windows (cp1252 chokes on ✓ / ✗)
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+GREEN = "\033[92m"
+RED   = "\033[91m"
+YEL   = "\033[93m"
+DIM   = "\033[2m"
+BOLD  = "\033[1m"
+RESET = "\033[0m"
+
+SURFACE_C = REPO / "comfyui-spellcaster" / "spellcaster_core"
+SURFACE_1 = REPO / "plugins" / "gimp" / "comfyui-connector" / "spellcaster_core"
+
+# Files that MUST be byte-identical across all 6 surfaces. Sourced
+# from MIRROR_TARGETS.md §"Files in scope". Keep this list in sync
+# with that document.
+MIRROR_FILES = [
+    "workflows.py",
+    "node_factory.py",
+    "composites.py",
+    "architectures.py",
+    "prompt_enhance.py",
+    "video_presets.py",
+    "pipeline.py",
+    "diagnostic.py",
+    "preflight.py",
+    "model_detect.py",
+    "comfyui_llm.py",
+    "guild_llm.py",
+    "privacy.py",
+    "asset_gallery.py",
+    "event_bus.py",
+    "interface_registry.py",
+    "mailbox.py",
+    "cross_interface.py",
+    "lora_knowledge.py",
+    "lora_calibration_store.py",
+    "lora_scorer.py",
+    "faceswap_health.py",
+    "preflight_status.py",
+    "events.py",
+    "lora_calibrations_sfw.json",
+]
+
+
+def _md5(p: Path) -> str:
+    h = hashlib.md5()
+    h.update(p.read_bytes())
+    return h.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--fix", action="store_true",
+                        help="Copy surface C → surface 1 to resolve drift "
+                             "(C is canonical per MIRROR_TARGETS.md)")
+    parser.add_argument("--quiet", action="store_true",
+                        help="Only print on failure")
+    args = parser.parse_args()
+
+    if not SURFACE_C.is_dir():
+        print(f"{RED}✗{RESET} surface C missing: {SURFACE_C}")
+        return 2
+    if not SURFACE_1.is_dir():
+        print(f"{RED}✗{RESET} surface 1 missing: {SURFACE_1}")
+        return 2
+
+    drift: list[tuple[str, str, str]] = []  # (file, md5_c, md5_1)
+    missing: list[tuple[str, str]] = []     # (file, which_surface)
+    ok = 0
+
+    for rel in MIRROR_FILES:
+        c = SURFACE_C / rel
+        s1 = SURFACE_1 / rel
+        if not c.is_file() and not s1.is_file():
+            missing.append((rel, "both"))
+            continue
+        if not c.is_file():
+            missing.append((rel, "C"))
+            continue
+        if not s1.is_file():
+            missing.append((rel, "1"))
+            continue
+        hc = _md5(c)
+        h1 = _md5(s1)
+        if hc == h1:
+            ok += 1
+        else:
+            drift.append((rel, hc, h1))
+
+    total = len(MIRROR_FILES)
+    if not args.quiet or drift or missing:
+        print(f"{BOLD}6-surface mirror drift check{RESET}")
+        print(f"  C: {SURFACE_C}")
+        print(f"  1: {SURFACE_1}")
+        print(f"  OK: {ok}/{total}    "
+              f"DRIFT: {len(drift)}    "
+              f"MISSING: {len(missing)}")
+
+    if drift:
+        print(f"\n  {RED}{BOLD}DRIFT DETECTED{RESET}")
+        for rel, hc, h1 in drift:
+            print(f"    {RED}✗{RESET} {rel}")
+            print(f"      C={hc[:8]}  1={h1[:8]}")
+        if args.fix:
+            print(f"\n  {YEL}--fix: copying C → 1 (C is canonical){RESET}")
+            for rel, *_ in drift:
+                shutil.copy2(SURFACE_C / rel, SURFACE_1 / rel)
+                print(f"    {GREEN}→{RESET} {rel}")
+            print(f"\n  {GREEN}✓ surface 1 re-aligned with C{RESET}")
+            print(f"    Run again to confirm:  python tests/mirror_drift.py")
+            return 0  # we resolved the drift, the next run will be clean
+        else:
+            print(f"\n  Fix locally:")
+            print(f"    python tests/mirror_drift.py --fix")
+            print(f"  Or copy C surface manually to surface 1.")
+            print(f"  Cross-repo surfaces (2/3/5/6) are checked in CI "
+                  f"after merge; sync those via their respective repos.")
+
+    if missing:
+        print(f"\n  {YEL}{BOLD}MISSING FILES{RESET}")
+        for rel, which in missing:
+            print(f"    {YEL}~{RESET} {rel} (missing in {which})")
+
+    if drift or missing:
+        return 1
+    if not args.quiet:
+        print(f"\n  {GREEN}{BOLD}✓ All surfaces byte-identical{RESET}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/night_maintenance.py
+++ b/tests/night_maintenance.py
@@ -166,7 +166,15 @@ def check_extra_model_paths() -> tuple[bool, list[str]]:
 
 
 def check_log_errors() -> tuple[bool, list[str]]:
-    """Scan recent Voodoomaster + ComfyUI logs for fresh errors."""
+    """Scan recent Voodoomaster + ComfyUI logs for UNRECOVERED errors.
+
+    The watchdog soft-crash + auto-restart flow tags both the crash
+    detection AND the successful recovery — we only want to alert when
+    a crash was NOT followed by a ``restart-ok`` within the same log
+    window. Otherwise every transient ComfyUI accept-loop death (a
+    routine occurrence under heavy IO load) flags as a failure even
+    though the system self-healed.
+    """
     log_dir = Path.home() / ".voodoomaster"
     if not log_dir.is_dir():
         return True, [f"log dir absent ({log_dir}) — skip"]
@@ -180,13 +188,21 @@ def check_log_errors() -> tuple[bool, list[str]]:
         except OSError:
             continue
         tail = text.splitlines()[-200:]  # last 200 lines
-        err_lines = [ln for ln in tail
+        # Find the index of the latest "restart-ok" — any error event
+        # BEFORE that has been resolved (the system recovered). Only
+        # error events AFTER are unresolved and worth surfacing.
+        last_ok_idx = -1
+        for i, ln in enumerate(tail):
+            if "restart-ok" in ln or "boot start" in ln:
+                last_ok_idx = i
+        unresolved = tail[last_ok_idx + 1:] if last_ok_idx >= 0 else tail
+        err_lines = [ln for ln in unresolved
                      if any(kw in ln for kw in ("ERROR ", "Traceback",
                                                    "watchdog-gave-up",
                                                    "crashed-detected"))]
         if err_lines:
-            findings.append(f"{name}: {len(err_lines)} error-tagged "
-                           f"line(s) in last 200 — latest: "
+            findings.append(f"{name}: {len(err_lines)} unrecovered "
+                           f"error(s) in last 200 — latest: "
                            f"{err_lines[-1].strip()[:160]}")
     if findings:
         return False, ["log scan:"] + [f"  · {x}" for x in findings]

--- a/tests/night_maintenance.py
+++ b/tests/night_maintenance.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Night maintenance — composite verification across the ecosystem.
 
-Designed to be invoked by a Theo nightly cron (or a Voodoomaster
-dev-endpoint heartbeat) so the codebase + servers are continuously
-verified without operator action. Writes a dated report file the
-next morning's claude session reads to know what changed.
+Designed to be invoked by a nightly cron on the dev host (or a
+distro-runtime dev-endpoint heartbeat) so the codebase + servers are
+continuously verified without operator action. Writes a dated report
+file the next morning's claude session reads to know what changed.
 
 Checks (all non-destructive — no writes outside the report file):
 
@@ -12,7 +12,7 @@ Checks (all non-destructive — no writes outside the report file):
 2. tests/installer_audit.py         — installer functions vs live server
 3. live ComfyUI capability shape    — node count, feature flags, license
 4. extra_model_paths.yaml integrity — D: primary still has the expected dirs
-5. Voodoomaster caps server health  — backend.state=ready, license valid
+5. distro-runtime caps server health — backend.state=ready, license valid
 6. Recent error scan                — comfyui.log / launcher.log / dev_audit.log
 
 Usage:
@@ -26,10 +26,10 @@ Output:
     - Markdown report at --report path (default:
       ~/.voodoomaster/night_report_YYYYMMDD.md)
 
-Per Laborantin-aware practice (CLAUDE.md): the local LLM on Theo (LM
-Studio on :1234) can run this on a cron and the next claude session
-finds the night-report file ready to read instead of re-discovering
-everything from scratch.
+Per the local-LLM-aware delegation policy (CLAUDE.md): the local LLM
+on the dev host (LM Studio on :1234) can run this on a cron and the
+next claude session finds the night-report file ready to read instead
+of re-discovering everything from scratch.
 """
 from __future__ import annotations
 
@@ -53,8 +53,13 @@ if sys.platform == "win32":
 HERE = Path(__file__).resolve().parent
 REPO = HERE.parent
 
-DEFAULT_SERVER = "http://192.168.86.28:8190"
-DEFAULT_CAPS   = "http://192.168.86.28:8191"
+# Defaults come from environment so we never bake a LAN IP into
+# tracked code (H2 hygiene). Override with --server / --caps.
+_HOST = os.environ.get("COMFYUI_HOST", "127.0.0.1")
+DEFAULT_SERVER = os.environ.get("COMFYUI_AUDIT_URL",
+                                f"http://{_HOST}:8190")
+DEFAULT_CAPS   = os.environ.get("COMFYUI_CAPS_URL",
+                                f"http://{_HOST}:8191")
 
 
 def _default_report_path() -> Path:
@@ -151,7 +156,7 @@ def check_capabilities(caps_url: str) -> tuple[bool, list[str]]:
 
 def check_extra_model_paths() -> tuple[bool, list[str]]:
     """Verify D: primary still has the expected model categories."""
-    # Theo-specific layout: D:/AI/ComfyUI-models/<cat>/
+    # Dev-host layout convention: D:/AI/ComfyUI-models/<cat>/
     primary = Path("D:/AI/ComfyUI-models")
     if not primary.is_dir():
         return False, [f"primary model root missing: {primary}"]

--- a/tests/night_maintenance.py
+++ b/tests/night_maintenance.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Night maintenance — composite verification across the ecosystem.
+
+Designed to be invoked by a Theo nightly cron (or a Voodoomaster
+dev-endpoint heartbeat) so the codebase + servers are continuously
+verified without operator action. Writes a dated report file the
+next morning's claude session reads to know what changed.
+
+Checks (all non-destructive — no writes outside the report file):
+
+1. tests/mirror_drift.py            — 6-surface byte-identical invariant
+2. tests/installer_audit.py         — installer functions vs live server
+3. live ComfyUI capability shape    — node count, feature flags, license
+4. extra_model_paths.yaml integrity — D: primary still has the expected dirs
+5. Voodoomaster caps server health  — backend.state=ready, license valid
+6. Recent error scan                — comfyui.log / launcher.log / dev_audit.log
+
+Usage:
+    python tests/night_maintenance.py
+    python tests/night_maintenance.py --server http://<HOST>:8190 \\
+                                       --caps   http://<HOST>:8191
+    python tests/night_maintenance.py --report ~/.voodoomaster/night_report.md
+
+Output:
+    - Console summary (CI-friendly exit code: 0 all green, 1 any red)
+    - Markdown report at --report path (default:
+      ~/.voodoomaster/night_report_YYYYMMDD.md)
+
+Per Laborantin-aware practice (CLAUDE.md): the local LLM on Theo (LM
+Studio on :1234) can run this on a cron and the next claude session
+finds the night-report file ready to read instead of re-discovering
+everything from scratch.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Force UTF-8 on Windows
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+
+DEFAULT_SERVER = "http://192.168.86.28:8190"
+DEFAULT_CAPS   = "http://192.168.86.28:8191"
+
+
+def _default_report_path() -> Path:
+    if sys.platform == "win32":
+        base = Path(os.environ.get("USERPROFILE", Path.home()))
+    else:
+        base = Path.home()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d")
+    return base / ".voodoomaster" / f"night_report_{stamp}.md"
+
+
+def _http_json(url: str, timeout: float = 10.0) -> dict | None:
+    try:
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "spellcaster-night-maintenance",
+                          "Connection": "close"})
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.loads(r.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+# ─── Individual checks ────────────────────────────────────────────────────────
+
+def check_mirror_drift() -> tuple[bool, list[str]]:
+    """Wrapper around tests/mirror_drift.py."""
+    p = subprocess.run(
+        [sys.executable, str(HERE / "mirror_drift.py"), "--quiet"],
+        capture_output=True, text=True, timeout=60)
+    lines = (p.stdout + p.stderr).splitlines()
+    ok = (p.returncode == 0)
+    summary = "byte-identical" if ok else "DRIFT DETECTED"
+    if not ok:
+        # Surface the first few useful lines
+        for ln in lines:
+            if "✗" in ln or "DRIFT" in ln:
+                summary += f"  · {ln.strip()}"
+                break
+    return ok, [f"mirror_drift: {summary}"]
+
+
+def check_installer_audit(server: str) -> tuple[bool, list[str]]:
+    """Wrapper around tests/installer_audit.py."""
+    p = subprocess.run(
+        [sys.executable, str(HERE / "installer_audit.py"),
+         "--server", server],
+        capture_output=True, text=True, timeout=120)
+    ok = (p.returncode == 0)
+    # Extract the PASS/FAIL/SKIP summary line
+    summary_line = next(
+        (ln for ln in p.stdout.splitlines()
+         if "PASS" in ln and "/" in ln),
+        "no summary line found")
+    return ok, [f"installer_audit: {summary_line.strip()}"]
+
+
+def check_capabilities(caps_url: str) -> tuple[bool, list[str]]:
+    """Probe Voodoomaster caps server for the expected shape."""
+    healthz = _http_json(f"{caps_url}/healthz", timeout=5)
+    if not healthz:
+        return False, [f"caps server {caps_url}: no response"]
+    if not healthz.get("comfy_reachable"):
+        return False, [f"caps server: comfy_reachable=False"]
+
+    caps = _http_json(f"{caps_url}/v1/capabilities", timeout=30)
+    if not caps:
+        return False, ["caps payload: empty / failed"]
+
+    issues = []
+    nodes = caps.get("node_count", 0)
+    if nodes < 6000:
+        issues.append(f"node_count={nodes} (expected >= 6000)")
+    flags = caps.get("feature_flags", {})
+    expected_true = ["sam3", "klein_enhancer", "klein_identity",
+                     "ltx_video", "wan_video", "depth_anything_v3",
+                     "face_swap_reactor", "stable_avatar"]
+    missing_flags = [f for f in expected_true if not flags.get(f)]
+    if missing_flags:
+        issues.append(f"feature flags missing: {missing_flags}")
+    backend = caps.get("backend", {})
+    if backend.get("state") != "ready":
+        issues.append(f"backend.state={backend.get('state')!r} "
+                      f"(expected 'ready')")
+    license_info = caps.get("license", {})
+    if not license_info.get("activated"):
+        issues.append("license not activated")
+
+    if issues:
+        return False, ["capabilities:"] + [f"  · {x}" for x in issues]
+    return True, [f"capabilities: {nodes} nodes, "
+                  f"{len(flags)} flags all green, "
+                  f"backend ready, license active"]
+
+
+def check_extra_model_paths() -> tuple[bool, list[str]]:
+    """Verify D: primary still has the expected model categories."""
+    # Theo-specific layout: D:/AI/ComfyUI-models/<cat>/
+    primary = Path("D:/AI/ComfyUI-models")
+    if not primary.is_dir():
+        return False, [f"primary model root missing: {primary}"]
+    required_subdirs = ["checkpoints", "loras", "vae", "unet", "clip",
+                         "controlnet", "sam3", "depthanything3",
+                         "StableAvatar", "hyperswap"]
+    missing = [d for d in required_subdirs if not (primary / d).is_dir()]
+    if missing:
+        return False, [f"D: model root missing: {missing}"]
+    return True, [f"D: model root: {len(required_subdirs)} expected "
+                  f"dirs all present"]
+
+
+def check_log_errors() -> tuple[bool, list[str]]:
+    """Scan recent Voodoomaster + ComfyUI logs for fresh errors."""
+    log_dir = Path.home() / ".voodoomaster"
+    if not log_dir.is_dir():
+        return True, [f"log dir absent ({log_dir}) — skip"]
+    findings = []
+    for name in ("launcher.log", "comfyui.log"):
+        p = log_dir / name
+        if not p.is_file():
+            continue
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        tail = text.splitlines()[-200:]  # last 200 lines
+        err_lines = [ln for ln in tail
+                     if any(kw in ln for kw in ("ERROR ", "Traceback",
+                                                   "watchdog-gave-up",
+                                                   "crashed-detected"))]
+        if err_lines:
+            findings.append(f"{name}: {len(err_lines)} error-tagged "
+                           f"line(s) in last 200 — latest: "
+                           f"{err_lines[-1].strip()[:160]}")
+    if findings:
+        return False, ["log scan:"] + [f"  · {x}" for x in findings]
+    return True, ["log scan: no fresh errors in launcher.log / comfyui.log"]
+
+
+# ─── Report writer ────────────────────────────────────────────────────────────
+
+def write_report(path: Path, sections: list[tuple[str, bool, list[str]]],
+                 server: str, caps_url: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    lines = [
+        f"# Night maintenance report — {now}",
+        "",
+        f"- Server probed: `{server}`",
+        f"- Caps probed:   `{caps_url}`",
+        "",
+        "## Summary",
+        "",
+    ]
+    for name, ok, _ in sections:
+        icon = "OK" if ok else "FAIL"
+        lines.append(f"- `{name}`: **{icon}**")
+    lines += ["", "## Details", ""]
+    for name, ok, detail in sections:
+        lines.append(f"### {name} — {'OK' if ok else 'FAIL'}")
+        for d in detail:
+            lines.append(f"- {d}")
+        lines.append("")
+    lines.append("---")
+    lines.append("_Generated by `tests/night_maintenance.py`._")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--server", default=DEFAULT_SERVER,
+                    help="ComfyUI URL (default: %(default)s)")
+    ap.add_argument("--caps", default=DEFAULT_CAPS,
+                    help="Voodoomaster caps URL (default: %(default)s)")
+    ap.add_argument("--report", default=str(_default_report_path()),
+                    help="Markdown report path (default: per-day under "
+                         "~/.voodoomaster/)")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    if not args.quiet:
+        print(f"Night maintenance — {datetime.now(timezone.utc).isoformat(timespec='seconds')}")
+        print(f"  Server: {args.server}")
+        print(f"  Caps:   {args.caps}")
+        print(f"  Report: {args.report}")
+        print()
+
+    sections: list[tuple[str, bool, list[str]]] = []
+    checks = [
+        ("mirror-drift",     check_mirror_drift,    ()),
+        ("installer-audit",  check_installer_audit, (args.server,)),
+        ("capabilities",     check_capabilities,    (args.caps,)),
+        ("model-paths",      check_extra_model_paths, ()),
+        ("log-scan",         check_log_errors,      ()),
+    ]
+    for name, fn, fnargs in checks:
+        try:
+            ok, detail = fn(*fnargs)
+        except Exception as e:  # noqa: BLE001 — each check is best-effort
+            ok = False
+            detail = [f"{type(e).__name__}: {e}"]
+        sections.append((name, ok, detail))
+        if not args.quiet:
+            icon = "\033[92mOK  \033[0m" if ok else "\033[91mFAIL\033[0m"
+            print(f"  [{icon}] {name}")
+            for d in detail:
+                print(f"         {d}")
+
+    write_report(Path(args.report), sections, args.server, args.caps)
+    if not args.quiet:
+        print(f"\nReport written → {args.report}")
+
+    fail_count = sum(1 for _, ok, _ in sections if not ok)
+    return 0 if fail_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/llm_delegate.py
+++ b/tools/llm_delegate.py
@@ -2,7 +2,7 @@
 """Local-LLM delegation gateway.
 
 Per Laborantin-aware practice: tasks that don't require Claude-level
-reasoning should be delegated to Theo's local LLMs (LM Studio on
+reasoning should be delegated to the dev host's local LLMs (LM Studio on
 :1234). Frees Claude's context for the work only Claude can do.
 
 What counts as "safe to delegate":
@@ -24,8 +24,9 @@ What MUST NOT be delegated:
   - Anything that modifies a client (.claude/, VSCode settings,
     Antigravity — per user policy)
 
-Default endpoint: ``http://192.168.86.28:1234/v1/chat/completions``
-(LM Studio on Theo). Override with --endpoint.
+Default endpoint: ``http://${COMFYUI_HOST}:1234/v1/chat/completions``
+(LM Studio on the dev host). Override with --endpoint or set the
+``COMFYUI_HOST`` env var.
 
 Usage:
     # Polish docstrings on a single file
@@ -45,6 +46,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import urllib.error
 import urllib.request
@@ -58,7 +60,10 @@ if sys.platform == "win32":
     except Exception:
         pass
 
-DEFAULT_ENDPOINT = "http://192.168.86.28:1234/v1/chat/completions"
+DEFAULT_ENDPOINT = os.environ.get(
+    "LLM_ENDPOINT_URL",
+    f"http://{os.environ.get('COMFYUI_HOST','127.0.0.1')}:1234"
+    "/v1/chat/completions")
 DEFAULT_MODEL = "qwen2.5-coder-7b-instruct"   # fast + code-aware
 LARGE_MODEL   = "qwen3-30b-a3b"                # use for nuanced summarization
 
@@ -179,7 +184,7 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--endpoint", default=DEFAULT_ENDPOINT,
                     help="OpenAI-style /v1/chat/completions URL "
-                         "(default: LM Studio on Theo)")
+                         "(default: LM Studio on the dev host)")
     ap.add_argument("--model", default=DEFAULT_MODEL,
                     help=f"Model id (default: {DEFAULT_MODEL})")
     ap.add_argument("--max-tokens", type=int, default=None)

--- a/tools/llm_delegate.py
+++ b/tools/llm_delegate.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Local-LLM delegation gateway.
+
+Per Laborantin-aware practice: tasks that don't require Claude-level
+reasoning should be delegated to Theo's local LLMs (LM Studio on
+:1234). Frees Claude's context for the work only Claude can do.
+
+What counts as "safe to delegate":
+
+  - Docstring + comment polish on functions whose code is unchanged
+  - Test-fixture generation (parametrize inputs, no logic decisions)
+  - Boilerplate refactor *proposals* (caller reviews the diff)
+  - Log/report summarization
+  - Code-style cleanup (formatting, naming consistency)
+  - README / changelog drafts
+
+What MUST NOT be delegated:
+
+  - Architecture changes (interface choices, dependency direction)
+  - 6-surface mirror sync (must be byte-identical — human-verified)
+  - Security-sensitive code (auth, credential handling, crypto)
+  - ComfyUI workflow logic (one wrong node name = silent failure
+    per _DEV_HYGIENE.md H4)
+  - Anything that modifies a client (.claude/, VSCode settings,
+    Antigravity — per user policy)
+
+Default endpoint: ``http://192.168.86.28:1234/v1/chat/completions``
+(LM Studio on Theo). Override with --endpoint.
+
+Usage:
+    # Polish docstrings on a single file
+    python tools/llm_delegate.py polish-docs --file path/to/x.py
+
+    # Summarize a log file
+    python tools/llm_delegate.py summarize-log --file launcher.log
+
+    # Free-form prompt (echo to stdout, no file writes)
+    python tools/llm_delegate.py ask "<prompt>"
+
+Every mode writes the LLM response to stdout. File-mutation modes
+(``polish-docs``) emit a UNIFIED DIFF — apply with ``patch -p0``
+after human review. Never auto-apply.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Force UTF-8 on Windows
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+DEFAULT_ENDPOINT = "http://192.168.86.28:1234/v1/chat/completions"
+DEFAULT_MODEL = "qwen2.5-coder-7b-instruct"   # fast + code-aware
+LARGE_MODEL   = "qwen3-30b-a3b"                # use for nuanced summarization
+
+# Maximum file size we'll send to the LLM (bytes). Larger files get
+# refused with a helpful message — chunk them or use Claude.
+MAX_FILE_BYTES = 200_000
+
+
+def _post_chat(endpoint: str, model: str,
+               system: str, user: str,
+               max_tokens: int = 4096,
+               temperature: float = 0.2) -> str:
+    """POST to /v1/chat/completions and return the assistant text."""
+    body = json.dumps({
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": False,
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint,
+        data=body,
+        headers={"Content-Type": "application/json",
+                 "User-Agent": "spellcaster-llm-delegate",
+                 "Connection": "close"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=600) as r:
+        payload = json.loads(r.read().decode("utf-8"))
+    choices = payload.get("choices") or []
+    if not choices:
+        raise RuntimeError(f"LLM returned no choices: {payload}")
+    return choices[0]["message"]["content"]
+
+
+# ─── Modes ────────────────────────────────────────────────────────────────────
+
+def mode_polish_docs(args) -> int:
+    p = Path(args.file)
+    if not p.is_file():
+        print(f"file not found: {p}", file=sys.stderr)
+        return 1
+    if p.stat().st_size > MAX_FILE_BYTES:
+        print(f"file too large ({p.stat().st_size} > {MAX_FILE_BYTES} bytes); "
+              f"split before delegating", file=sys.stderr)
+        return 1
+    src = p.read_text(encoding="utf-8")
+
+    system = (
+        "You are a careful Python documentation editor. Improve docstrings "
+        "and comments WITHOUT changing any code. Preserve all imports, "
+        "function signatures, and logic. Output a unified diff (diff -u "
+        "style) that a human will review before applying. If no edits are "
+        "warranted, output exactly: NO CHANGES NEEDED."
+    )
+    user = (
+        f"File: {p.name}\n\n```python\n{src}\n```\n\n"
+        "Constraints:\n"
+        "- Don't expand short, clear identifiers into long phrases.\n"
+        "- Don't add module-level docstrings to files that don't have one.\n"
+        "- Don't rewrite working comments just to change wording.\n"
+        "- Add docstrings only where they explain WHY (intent), not WHAT.\n"
+    )
+    out = _post_chat(args.endpoint, args.model, system, user,
+                     max_tokens=8192)
+    print(out)
+    return 0
+
+
+def mode_summarize_log(args) -> int:
+    p = Path(args.file)
+    if not p.is_file():
+        print(f"file not found: {p}", file=sys.stderr)
+        return 1
+    text = p.read_text(encoding="utf-8", errors="replace")
+    # Send the last 4k lines so we summarize recent state, not the
+    # full history.
+    tail = "\n".join(text.splitlines()[-4000:])
+    if len(tail) > MAX_FILE_BYTES:
+        tail = tail[-MAX_FILE_BYTES:]
+    system = (
+        "You are a log triage assistant. Given the tail of a server log, "
+        "produce a short structured summary: (1) what's healthy, (2) "
+        "what's broken, (3) what's worth investigating. Prefer specific "
+        "timestamps and error counts over prose."
+    )
+    user = f"File: {p.name}\n\n```\n{tail}\n```"
+    out = _post_chat(args.endpoint, args.model, system, user,
+                     max_tokens=2048)
+    print(out)
+    return 0
+
+
+def mode_ask(args) -> int:
+    if not args.prompt:
+        print("ask: empty prompt", file=sys.stderr)
+        return 1
+    system = (
+        "You are a careful coding assistant. Answer concisely. If the "
+        "request would require modifying source code, output the diff "
+        "(diff -u format) for the caller to review — DO NOT pretend to "
+        "have applied changes."
+    )
+    out = _post_chat(args.endpoint, args.model, system, args.prompt,
+                     max_tokens=args.max_tokens or 2048,
+                     temperature=args.temperature or 0.3)
+    print(out)
+    return 0
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--endpoint", default=DEFAULT_ENDPOINT,
+                    help="OpenAI-style /v1/chat/completions URL "
+                         "(default: LM Studio on Theo)")
+    ap.add_argument("--model", default=DEFAULT_MODEL,
+                    help=f"Model id (default: {DEFAULT_MODEL})")
+    ap.add_argument("--max-tokens", type=int, default=None)
+    ap.add_argument("--temperature", type=float, default=None)
+
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("polish-docs",
+                       help="Suggest docstring/comment edits for a file")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=mode_polish_docs)
+
+    p = sub.add_parser("summarize-log",
+                       help="Triage-summarize a server log tail")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=mode_summarize_log)
+
+    p = sub.add_parser("ask",
+                       help="Free-form prompt → stdout")
+    p.add_argument("prompt", nargs="?", default="")
+    p.set_defaults(func=mode_ask)
+
+    args = ap.parse_args()
+    try:
+        return args.func(args)
+    except urllib.error.URLError as e:
+        print(f"LLM endpoint unreachable: {args.endpoint} — {e}",
+              file=sys.stderr)
+        return 2
+    except Exception as e:  # noqa: BLE001 — bubble up cleanly for shell use
+        print(f"{type(e).__name__}: {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/llm_delegate.py
+++ b/tools/llm_delegate.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Local-LLM delegation gateway.
 
-Per Laborantin-aware practice: tasks that don't require Claude-level
-reasoning should be delegated to the dev host's local LLMs (LM Studio on
+Per the local-LLM-aware delegation policy: tasks that don't require
+Claude-level reasoning should be delegated to the dev host's local
+LLMs (LM Studio on
 :1234). Frees Claude's context for the work only Claude can do.
 
 What counts as "safe to delegate":

--- a/tools/llm_morning_briefing.py
+++ b/tools/llm_morning_briefing.py
@@ -11,7 +11,7 @@ Workflow
 --------
 1. Collect *facts* about the ecosystem since the last briefing:
    - Last night_maintenance.py report (~/.voodoomaster/night_report_*.md)
-   - Recent git commits across spellcaster + Voodoomancer
+   - Recent git commits across spellcaster + distro-runtime
    - Open PR list (gh CLI if available)
    - Live caps server snapshot (node_count, flags, backend state)
    - Active claude_session.py sessions + their tasks
@@ -62,10 +62,16 @@ if sys.platform == "win32":
 
 REPO = Path(__file__).resolve().parent.parent
 DEFAULT_OUTPUT = REPO / "_dev_docs" / "morning_briefing.md"
-DEFAULT_LLM_ENDPOINT = "http://192.168.86.28:1234/v1/chat/completions"
-DEFAULT_LLM_MODEL = "qwen3-30b-a3b"  # nuanced summarization; slower but smarter
-
-DEFAULT_CAPS = "http://192.168.86.28:8191"
+# Defaults pulled from environment to avoid baking a LAN IP into
+# tracked code (H2 hygiene). Override with --llm-endpoint / --caps.
+_HOST = os.environ.get("COMFYUI_HOST", "127.0.0.1")
+DEFAULT_LLM_ENDPOINT = os.environ.get(
+    "LLM_ENDPOINT_URL",
+    f"http://{_HOST}:1234/v1/chat/completions")
+DEFAULT_LLM_MODEL = os.environ.get("LLM_BRIEFING_MODEL",
+                                    "qwen3-30b-a3b")
+DEFAULT_CAPS = os.environ.get("COMFYUI_CAPS_URL",
+                               f"http://{_HOST}:8191")
 
 
 # ─── Fact collectors ──────────────────────────────────────────────────────────
@@ -93,12 +99,16 @@ def collect_night_report() -> str:
 
 
 def collect_recent_commits() -> str:
+    # Sibling-repo names come from env so they aren't baked into
+    # tracked code (the leak-check regex blocks the distro-runtime
+    # name; per-dev override via DISTRO_REPO_NAME).
+    distro_name = os.environ.get("DISTRO_REPO_NAME", "")
     out_lines = []
-    for repo_label, repo_path in [
-        ("spellcaster", REPO),
-        ("Voodoomancer", Path.home() / "Voodoomancer"),
-        ("spellcaster_NSFW", Path.home() / "spellcaster_NSFW"),
-    ]:
+    targets = [("spellcaster", REPO),
+               ("spellcaster_NSFW", Path.home() / "spellcaster_NSFW")]
+    if distro_name:
+        targets.insert(1, ("distro-runtime", Path.home() / distro_name))
+    for repo_label, repo_path in targets:
         if not (repo_path / ".git").is_dir():
             continue
         try:
@@ -112,12 +122,14 @@ def collect_recent_commits() -> str:
 
 
 def collect_open_prs() -> str:
+    org = os.environ.get("GITHUB_ORG", "laboratoiresonore")
+    distro_name = os.environ.get("DISTRO_REPO_NAME", "")
     out_lines = []
-    for repo_slug, label in [
-        ("laboratoiresonore/spellcaster", "spellcaster"),
-        ("laboratoiresonore/Voodoomancer", "Voodoomancer"),
-        ("laboratoiresonore/spellcaster_NSFW", "spellcaster_NSFW"),
-    ]:
+    targets = [(f"{org}/spellcaster", "spellcaster"),
+               (f"{org}/spellcaster_NSFW", "spellcaster_NSFW")]
+    if distro_name:
+        targets.insert(1, (f"{org}/{distro_name}", "distro-runtime"))
+    for repo_slug, label in targets:
         try:
             p = subprocess.run(
                 ["gh", "-R", repo_slug, "pr", "list", "--state", "open",
@@ -237,7 +249,7 @@ def llm_summarize(facts_md: str, endpoint: str, model: str) -> str:
         "Claude Code session that is about to start. Read the fact "
         "dump and produce a STRUCTURED briefing under these headings:\n\n"
         "**HEALTH**: green / yellow / red across the stack (Voodoomaster, "
-        "Voodoomancer, spellcaster).\n\n"
+        "distro-runtime, spellcaster).\n\n"
         "**OVERNIGHT CHANGES**: 3-7 bullets summarizing what happened "
         "(commits, merged PRs, deploys).\n\n"
         "**STILL BROKEN OR IN FLIGHT**: open PRs, failing tests, "

--- a/tools/llm_morning_briefing.py
+++ b/tools/llm_morning_briefing.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""LLM-augmented morning briefing for Claude.
+
+Built per the 2026-05-13 user directive: "have the local LLM
+automatically run cycles that will augment app knowledge for Claude
+and otherwise do as much as it can dependably to enhance Claude's
+intervention for debugging and maintenance, on any app in the
+ecosystem."
+
+Workflow
+--------
+1. Collect *facts* about the ecosystem since the last briefing:
+   - Last night_maintenance.py report (~/.voodoomaster/night_report_*.md)
+   - Recent git commits across spellcaster + Voodoomancer
+   - Open PR list (gh CLI if available)
+   - Live caps server snapshot (node_count, flags, backend state)
+   - Active claude_session.py sessions + their tasks
+   - Recent unresolved log errors (filtered for recovered crashes)
+
+2. Hand the fact-dump to the local LLM with a system prompt asking
+   for a structured briefing:
+   - What changed overnight
+   - What's still broken or in flight
+   - Where Claude's attention is needed
+   - Open questions worth asking
+
+3. Write the result to ``<repo>/_dev_docs/morning_briefing.md`` so
+   the next Claude session can read it at start (per CLAUDE.md §2).
+
+Designed for unattended nightly execution (Windows Task Scheduler /
+NSSM / cron). All sub-checks are best-effort: a failure in any one
+section degrades to a "section unavailable" note rather than
+aborting the whole briefing — Claude needs SOMETHING in the morning
+even if the LLM is down or git is unreachable.
+
+Usage
+-----
+    python tools/llm_morning_briefing.py
+    python tools/llm_morning_briefing.py --output _dev_docs/morning_briefing.md
+    python tools/llm_morning_briefing.py --model qwen3-30b-a3b
+    python tools/llm_morning_briefing.py --no-llm  # raw facts only
+
+Exit codes: 0 normal; 1 if --no-llm and any fact-collector failed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = REPO / "_dev_docs" / "morning_briefing.md"
+DEFAULT_LLM_ENDPOINT = "http://192.168.86.28:1234/v1/chat/completions"
+DEFAULT_LLM_MODEL = "qwen3-30b-a3b"  # nuanced summarization; slower but smarter
+
+DEFAULT_CAPS = "http://192.168.86.28:8191"
+
+
+# ─── Fact collectors ──────────────────────────────────────────────────────────
+
+def _safe(fn, label):
+    """Call a fact-collector; on any exception return a placeholder block."""
+    try:
+        return fn()
+    except Exception as e:  # noqa: BLE001 — every collector is best-effort
+        return f"_({label} collector failed: {type(e).__name__}: {e})_"
+
+
+def collect_night_report() -> str:
+    today = datetime.now(timezone.utc).strftime("%Y%m%d")
+    path = Path.home() / ".voodoomaster" / f"night_report_{today}.md"
+    if not path.is_file():
+        # Try yesterday's
+        from datetime import timedelta
+        yest = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y%m%d")
+        path = Path.home() / ".voodoomaster" / f"night_report_{yest}.md"
+    if not path.is_file():
+        return "_(no night_maintenance report found in ~/.voodoomaster/)_"
+    text = path.read_text(encoding="utf-8")
+    return f"_Source: `{path}` — last modified {datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat(timespec='seconds')}_\n\n```\n{text[:4000]}\n```"
+
+
+def collect_recent_commits() -> str:
+    out_lines = []
+    for repo_label, repo_path in [
+        ("spellcaster", REPO),
+        ("Voodoomancer", Path.home() / "Voodoomancer"),
+        ("spellcaster_NSFW", Path.home() / "spellcaster_NSFW"),
+    ]:
+        if not (repo_path / ".git").is_dir():
+            continue
+        try:
+            p = subprocess.run(
+                ["git", "-C", str(repo_path), "log", "--oneline", "-15"],
+                capture_output=True, text=True, timeout=10, check=True)
+            out_lines.append(f"### {repo_label} ({repo_path})\n```\n{p.stdout.strip()}\n```")
+        except subprocess.CalledProcessError as e:
+            out_lines.append(f"### {repo_label}: git failed\n```\n{e.stderr}\n```")
+    return "\n\n".join(out_lines) if out_lines else "_(no git repos resolvable)_"
+
+
+def collect_open_prs() -> str:
+    out_lines = []
+    for repo_slug, label in [
+        ("laboratoiresonore/spellcaster", "spellcaster"),
+        ("laboratoiresonore/Voodoomancer", "Voodoomancer"),
+        ("laboratoiresonore/spellcaster_NSFW", "spellcaster_NSFW"),
+    ]:
+        try:
+            p = subprocess.run(
+                ["gh", "-R", repo_slug, "pr", "list", "--state", "open",
+                 "--json", "number,title,headRefName,mergeStateStatus",
+                 "--limit", "10"],
+                capture_output=True, text=True, timeout=15, check=True)
+            data = json.loads(p.stdout or "[]")
+        except (subprocess.CalledProcessError, json.JSONDecodeError, FileNotFoundError):
+            continue
+        if not data:
+            out_lines.append(f"- **{label}**: no open PRs")
+            continue
+        rows = [f"  - #{pr['number']} `{pr['headRefName']}` — {pr['title']}  ({pr['mergeStateStatus']})"
+                for pr in data]
+        out_lines.append(f"- **{label}** ({len(data)} open):\n" + "\n".join(rows))
+    return "\n".join(out_lines) if out_lines else "_(gh CLI unavailable or all repos clean)_"
+
+
+def collect_capabilities(caps_url: str) -> str:
+    try:
+        req = urllib.request.Request(
+            f"{caps_url}/healthz",
+            headers={"Connection": "close",
+                     "User-Agent": "spellcaster-morning-briefing"})
+        with urllib.request.urlopen(req, timeout=5) as r:
+            healthz = json.loads(r.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return f"_(caps server at {caps_url} unreachable)_"
+    try:
+        req = urllib.request.Request(
+            f"{caps_url}/v1/capabilities",
+            headers={"Connection": "close",
+                     "User-Agent": "spellcaster-morning-briefing"})
+        with urllib.request.urlopen(req, timeout=30) as r:
+            caps = json.loads(r.read().decode("utf-8"))
+    except Exception:
+        return f"_(caps payload fetch failed)_"
+    server = caps.get("server", {})
+    backend = caps.get("backend", {})
+    flags = caps.get("feature_flags", {})
+    license_info = caps.get("license", {})
+    lines = [
+        f"- ComfyUI: `{server.get('comfyui_version')}` on `{server.get('host')}:{server.get('port')}`",
+        f"- backend state: **{backend.get('state')}**",
+        f"- node_count: {caps.get('node_count')}",
+        f"- feature flags ON: {sum(1 for v in flags.values() if v)}/{len(flags)}",
+        f"- license: {license_info.get('tier','?')} / {license_info.get('channel','?')}",
+        f"- caps cache: {'fresh' if healthz.get('caps_cache',{}).get('fresh') else 'stale'} "
+        f"(age {healthz.get('caps_cache',{}).get('age_sec','?')}s)",
+    ]
+    return "\n".join(lines)
+
+
+def collect_active_sessions() -> str:
+    coord = REPO / "tools" / "claude_session.py"
+    if not coord.is_file():
+        return "_(tools/claude_session.py not present)_"
+    try:
+        p = subprocess.run(
+            [sys.executable, str(coord), "list"],
+            capture_output=True, text=True, timeout=5)
+        return f"```\n{p.stdout.strip()}\n```"
+    except subprocess.CalledProcessError as e:
+        return f"_(session list failed: {e.stderr})_"
+
+
+def collect_log_tail() -> str:
+    out_lines = []
+    log_dir = Path.home() / ".voodoomaster"
+    for name in ("launcher.log", "comfyui.log"):
+        path = log_dir / name
+        if not path.is_file():
+            continue
+        try:
+            tail = path.read_text(encoding="utf-8", errors="replace").splitlines()[-20:]
+        except OSError:
+            continue
+        out_lines.append(f"### {name} (last 20 lines)\n```\n" + "\n".join(tail) + "\n```")
+    return "\n\n".join(out_lines) if out_lines else "_(no log files in ~/.voodoomaster/)_"
+
+
+# ─── Briefing builder ─────────────────────────────────────────────────────────
+
+def build_facts(args) -> dict:
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "night_report": _safe(collect_night_report, "night_report"),
+        "recent_commits": _safe(collect_recent_commits, "recent_commits"),
+        "open_prs": _safe(collect_open_prs, "open_prs"),
+        "capabilities": _safe(lambda: collect_capabilities(args.caps), "capabilities"),
+        "active_sessions": _safe(collect_active_sessions, "active_sessions"),
+        "log_tail": _safe(collect_log_tail, "log_tail"),
+    }
+
+
+def facts_to_markdown(facts: dict) -> str:
+    return "\n\n".join([
+        f"# Morning briefing — {facts['generated_at']}",
+        "## Night maintenance report",
+        facts["night_report"],
+        "## Recent commits",
+        facts["recent_commits"],
+        "## Open PRs",
+        facts["open_prs"],
+        "## Live capabilities",
+        facts["capabilities"],
+        "## Active Claude sessions",
+        facts["active_sessions"],
+        "## Recent logs",
+        facts["log_tail"],
+    ])
+
+
+def llm_summarize(facts_md: str, endpoint: str, model: str) -> str:
+    system = (
+        "You are a senior engineer producing a morning briefing for a "
+        "Claude Code session that is about to start. Read the fact "
+        "dump and produce a STRUCTURED briefing under these headings:\n\n"
+        "**HEALTH**: green / yellow / red across the stack (Voodoomaster, "
+        "Voodoomancer, spellcaster).\n\n"
+        "**OVERNIGHT CHANGES**: 3-7 bullets summarizing what happened "
+        "(commits, merged PRs, deploys).\n\n"
+        "**STILL BROKEN OR IN FLIGHT**: open PRs, failing tests, "
+        "unresolved log errors — be specific about which file / which "
+        "PR / which timestamp.\n\n"
+        "**WHERE CLAUDE'S ATTENTION IS NEEDED**: 2-5 concrete tasks the "
+        "incoming Claude session should consider taking. Prefer "
+        "specifics over generalities.\n\n"
+        "**OPEN QUESTIONS**: things only a human can answer — flag "
+        "them so Claude knows to ask.\n\n"
+        "Be concise (under 500 words total). Use file paths verbatim. "
+        "Do NOT speculate or pad."
+    )
+    user = f"FACT DUMP\n\n{facts_md}"
+    body = json.dumps({
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "max_tokens": 2048,
+        "temperature": 0.2,
+        "stream": False,
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint, data=body,
+        headers={"Content-Type": "application/json",
+                 "User-Agent": "spellcaster-morning-briefing",
+                 "Connection": "close"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=300) as r:
+        payload = json.loads(r.read().decode("utf-8"))
+    return payload["choices"][0]["message"]["content"]
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    ap.add_argument("--llm-endpoint", default=DEFAULT_LLM_ENDPOINT)
+    ap.add_argument("--model", default=DEFAULT_LLM_MODEL)
+    ap.add_argument("--caps", default=DEFAULT_CAPS)
+    ap.add_argument("--no-llm", action="store_true",
+                    help="Skip LLM summarization; write raw facts only.")
+    args = ap.parse_args()
+
+    print(f"Morning briefing — {datetime.now(timezone.utc).isoformat(timespec='seconds')}")
+    facts = build_facts(args)
+    facts_md = facts_to_markdown(facts)
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.no_llm:
+        out.write_text(facts_md, encoding="utf-8")
+        print(f"Wrote raw facts → {out}")
+        return 0
+
+    print(f"Sending {len(facts_md)} chars to LLM at {args.llm_endpoint} ({args.model})…")
+    try:
+        summary = llm_summarize(facts_md, args.llm_endpoint, args.model)
+    except (urllib.error.URLError, OSError, KeyError) as e:
+        print(f"LLM call failed ({type(e).__name__}: {e}); writing raw facts.",
+              file=sys.stderr)
+        out.write_text(facts_md, encoding="utf-8")
+        return 1
+
+    final = "\n\n".join([
+        f"# Morning briefing — {facts['generated_at']}",
+        f"_Generated by `tools/llm_morning_briefing.py` (LLM: `{args.model}`)._",
+        "",
+        "## LLM summary",
+        "",
+        summary,
+        "",
+        "---",
+        "",
+        "## Source facts (for reference)",
+        "",
+        facts_md,
+    ])
+    out.write_text(final, encoding="utf-8")
+    print(f"Wrote briefing → {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/schedule_nightly.md
+++ b/tools/schedule_nightly.md
@@ -1,10 +1,10 @@
 # Nightly scheduling for `llm_morning_briefing.py` + `night_maintenance.py`
 
-Run this once on the Theo host (or any machine that should host the
+Run this once on the the dev host host (or any machine that should host the
 nightly cycle). Both scripts are best-effort — failures degrade
 gracefully — so a missed run is recoverable.
 
-## Windows Task Scheduler (Theo)
+## Windows Task Scheduler (the dev host)
 
 Per `~/.claude/projects/c--Users-legui/memory/feedback_taskscheduler_redirection.md`:
 Windows Task Scheduler does NOT shell-eval the Arguments field. Wrap
@@ -42,7 +42,7 @@ Reads the 03:00 night_report + recent commits + open PRs + live caps
 writes `<repo>/_dev_docs/morning_briefing.md` for the next Claude
 session to read at startup.
 
-The 1-hour gap between the two jobs gives Theo time to settle if the
+The 1-hour gap between the two jobs gives the dev host time to settle if the
 maintenance run hits any restart.
 
 ### Verify

--- a/tools/schedule_nightly.md
+++ b/tools/schedule_nightly.md
@@ -1,0 +1,84 @@
+# Nightly scheduling for `llm_morning_briefing.py` + `night_maintenance.py`
+
+Run this once on the Theo host (or any machine that should host the
+nightly cycle). Both scripts are best-effort — failures degrade
+gracefully — so a missed run is recoverable.
+
+## Windows Task Scheduler (Theo)
+
+Per `~/.claude/projects/c--Users-legui/memory/feedback_taskscheduler_redirection.md`:
+Windows Task Scheduler does NOT shell-eval the Arguments field. Wrap
+any `>>` / `2>&1` redirection inside `cmd.exe /c "..."` rather than
+embedding it as a flag.
+
+### night_maintenance.py — 03:00 local time
+
+```cmd
+schtasks /Create ^
+    /TN "Spellcaster Night Maintenance" ^
+    /TR "cmd.exe /c \"C:\Users\legui\AppData\Local\Programs\Python\Python311\python.exe C:\Users\legui\spellcaster\tests\night_maintenance.py >> C:\Users\legui\.voodoomaster\night_maintenance.log 2>&1\"" ^
+    /SC DAILY ^
+    /ST 03:00 ^
+    /F
+```
+
+Writes `~/.voodoomaster/night_report_YYYYMMDD.md` (markdown report).
+Also rotates an append-only log at `night_maintenance.log` for
+audit history.
+
+### llm_morning_briefing.py — 04:00 local time
+
+```cmd
+schtasks /Create ^
+    /TN "Spellcaster Morning Briefing" ^
+    /TR "cmd.exe /c \"C:\Users\legui\AppData\Local\Programs\Python\Python311\python.exe C:\Users\legui\spellcaster\tools\llm_morning_briefing.py --model qwen2.5-coder-7b-instruct >> C:\Users\legui\.voodoomaster\morning_briefing.log 2>&1\"" ^
+    /SC DAILY ^
+    /ST 04:00 ^
+    /F
+```
+
+Reads the 03:00 night_report + recent commits + open PRs + live caps
++ active sessions + log tails, sends the dump through LM Studio, and
+writes `<repo>/_dev_docs/morning_briefing.md` for the next Claude
+session to read at startup.
+
+The 1-hour gap between the two jobs gives Theo time to settle if the
+maintenance run hits any restart.
+
+### Verify
+
+```cmd
+schtasks /Query /TN "Spellcaster Night Maintenance" /V /FO LIST
+schtasks /Query /TN "Spellcaster Morning Briefing"   /V /FO LIST
+```
+
+### Delete
+
+```cmd
+schtasks /Delete /TN "Spellcaster Night Maintenance" /F
+schtasks /Delete /TN "Spellcaster Morning Briefing"   /F
+```
+
+## Linux / macOS cron alternative
+
+```cron
+# m h  dom mon dow  command
+0 3 * * *  /usr/bin/python3 /path/to/spellcaster/tests/night_maintenance.py >> ~/.voodoomaster/night_maintenance.log 2>&1
+0 4 * * *  /usr/bin/python3 /path/to/spellcaster/tools/llm_morning_briefing.py >> ~/.voodoomaster/morning_briefing.log 2>&1
+```
+
+## Model selection
+
+`llm_morning_briefing.py --model <name>` accepts any model id LM Studio
+exposes. Sensible defaults:
+
+- `qwen2.5-coder-7b-instruct` — fast (under a minute), good for the
+  structured briefing format. Recommended default.
+- `qwen3-30b-a3b` — slower (~5+ minutes), nuanced output. Use if the
+  briefing keeps surfacing the same blind spots.
+- `deepseek-r1-0528-qwen3-8b` — reasoning-tuned; experimentally
+  better when the briefing needs to PRIORITIZE among many concerns.
+
+Anything that takes longer than the 300 s timeout falls back to
+raw facts only (no LLM summary). The raw facts are still useful;
+the LLM polish is an enhancement, not a requirement.


### PR DESCRIPTION
## Summary

End-to-end audit of the unified installer found 10 concrete bugs ranked P0-P2. This PR fixes the 5 highest-impact ones and ships a live-server audit harness to catch regressions.

## Critical fixes (P0)

**P0-2 — Root cause of "installer doesn't work":** `build_installer.py` and `bootstrap.py` never bundled `comfyui-spellcaster/`, so the May-7 `_find_spellcaster_core()` lookup always returned None and every fresh GIMP install shipped a non-functional plug-in. Fixed by adding `--add-data` to all 4 build targets AND making `_find_spellcaster_core()` search `BUNDLE_DIR` (= `_MEIPASS`).

**P0-3 — Credential leak:** `install_remote.py` had zero basic-auth handling. Auth URLs failed every probe with 401; when they didn't, the credentialed URL got written into `spellcaster_settings.json`, plug-in `config.json`, `guild_config.json`, and the `.bat`/`.lnk` shortcuts in plaintext. Re-export `_split_url_credentials` and apply it at every persistence + Request site. Auth header now lives in a separate `comfyui_auth_header` field.

**P0-4 — Multi-GIMP miss:** `install_remote.py` only installed to `find_default_gimp()`. Users with GIMP 3.0 + 3.2 side-by-side got the plug-in into one version only. Added the same `find_all_gimp_dirs()` enumeration loop install.py uses.

## Lower priority (P1/P2)

**P1-6:** `install.py:git_clone` printed "✓ Updated" before catching pull failures. Fixed to print result AFTER the pull resolves and distinguish pull-failure (use existing checkout, warn) from git-missing (try ZIP fallback).

**P2-8:** `bootstrap.py` crashlog used naive `_dt.now()` — H3 hygiene violation. Fixed to `_dt.now(_tz.utc)`.

## Audit harness — `tests/installer_audit.py`

Live-server testing tool. Hits real ComfyUI and verifies every fixable function. Run:

\`\`\`
python tests/installer_audit.py --server http://<SERVER>:8190
\`\`\`

**Result on Theo (RTX 5060 Ti, ComfyUI 0.20.3): 24/24 PASS**

Covers: auth-split round-trip · spellcaster_core lookup · multi-GIMP detection · re-exports · live probe (6292 nodes) · LoRA classification (223/223) · feature detect (25 features) · NSFW detect · credential-leak grep · H3 datetime · all 4 .spec files + build_installer.py bundle check.

Exit 0 on pass, 1 on any failure → CI-friendly.

## Test plan

- [x] All 5 fixes have unit + integration coverage in the harness
- [x] Harness runs green against live Theo
- [x] install_remote.py dry-run against Theo completes end-to-end (probe + classify + 25 features detected + multi-GIMP enumeration shown)
- [x] Frozen-mode simulation: `_find_spellcaster_core()` resolves correctly from `_MEIPASS` when bootstrap fetch dir is separate

🤖 Generated with [Claude Code](https://claude.com/claude-code)