### PR TITLE
feat(canon): promote LMStudio + auth-token from sibling surfaces

### DIFF
--- a/comfyui-spellcaster/spellcaster_core/cross_interface.py
+++ b/comfyui-spellcaster/spellcaster_core/cross_interface.py
@@ -38,6 +38,15 @@ import urllib.request
 from typing import Callable, Iterator, Optional
 
 
+# ── auth-token injection (optional; no-op if spellcaster_core.auth_token absent) ──
+def _sct_auth_headers() -> dict:
+    try:
+        from spellcaster_core.auth_token import auth_headers as _ah
+        return _ah() or {}
+    except Exception:
+        return {}
+
+
 _DEFAULT_GUILD_URL = "http://127.0.0.1:7777"
 _HEARTBEAT_INTERVAL_S = 10.0
 
@@ -82,6 +91,7 @@ def _http_json(method: str, url: str, payload: Optional[dict] = None,
     if payload is not None:
         body = json.dumps(payload).encode("utf-8")
         headers["Content-Type"] = "application/json"
+    headers.update(_sct_auth_headers())
     req = urllib.request.Request(url, data=body, method=method, headers=headers)
     for attempt in range(2):
         try:
@@ -213,8 +223,9 @@ class CrossInterfaceClient:
         qs = f"?{urllib.parse.urlencode(params)}" if params else ""
         url = f"{self.base_url}/api/events/stream{qs}"
         try:
-            req = urllib.request.Request(
-                url, headers={"Accept": "text/event-stream"})
+            _sse_headers = {"Accept": "text/event-stream"}
+            _sse_headers.update(_sct_auth_headers())
+            req = urllib.request.Request(url, headers=_sse_headers)
             resp = urllib.request.urlopen(req, timeout=timeout or 30.0)
         except Exception:
             return
@@ -312,7 +323,7 @@ class CrossInterfaceClient:
 
     def download_asset(self, h: str) -> Optional[bytes]:
         try:
-            req = urllib.request.Request(f"{self.base_url}/api/assets/{h}")
+            req = urllib.request.Request(f"{self.base_url}/api/assets/{h}", headers=_sct_auth_headers())
             with urllib.request.urlopen(req, timeout=10.0) as resp:
                 return resp.read()
         except Exception:
@@ -396,7 +407,7 @@ class CrossInterfaceClient:
         pattern matches ``_http_json`` and the sender-side uploaders."""
         if not url:
             return None
-        req = urllib.request.Request(url)
+        req = urllib.request.Request(url, headers=_sct_auth_headers())
         for attempt in range(2):
             try:
                 with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -420,7 +431,7 @@ class CrossInterfaceClient:
             return []
         url = f"{comfy_url.rstrip('/')}/spellcaster/blob/list"
         try:
-            req = urllib.request.Request(url)
+            req = urllib.request.Request(url, headers=_sct_auth_headers())
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
             if isinstance(data, dict):

--- a/comfyui-spellcaster/spellcaster_core/guild_llm.py
+++ b/comfyui-spellcaster/spellcaster_core/guild_llm.py
@@ -150,7 +150,8 @@ RECOMMENDED_LLM = {
 
 def chat(message, system_prompt="", server=None, kobold_url=None,
          model=None, max_tokens=512, temperature=0.7, purpose="chat",
-         arch_key=None, method=None):
+         arch_key=None, method=None,
+         lmstudio_url=None, lmstudio_model=None, lmstudio_ttl=5):
     """THE single LLM entry point for every surface (Guild, GIMP, Darktable,
     ComfyUI nodes, scaffolding). Do not implement parallel LLM paths
     elsewhere — everything goes through this function.
@@ -203,6 +204,8 @@ def chat(message, system_prompt="", server=None, kobold_url=None,
         server = None
     if kobold_url is not None and not _valid_backend_url(kobold_url):
         kobold_url = None
+    if lmstudio_url is not None and not _valid_backend_url(lmstudio_url):
+        lmstudio_url = None
 
     # Build the backend sequence based on purpose.
     def try_ollama():
@@ -222,14 +225,28 @@ def chat(message, system_prompt="", server=None, kobold_url=None,
         return _chat_kobold(message, system_prompt, kobold_url,
                             max_tokens, temperature)
 
+    def try_lmstudio():
+        if not lmstudio_url:
+            return None
+        return _chat_lmstudio(message, system_prompt, lmstudio_url,
+                              lmstudio_model, max_tokens, temperature,
+                              ttl=lmstudio_ttl)
+
     if purpose == "chat":
         chain = [
             ("ollama", "http://127.0.0.1:11434", try_ollama),
             ("comfyui", server, try_comfyui),
+            ("lmstudio", lmstudio_url, try_lmstudio),
             ("kobold", kobold_url, try_kobold),
         ]
     else:  # 'enhance'
+        # When a Voodoomancer-style LM Studio endpoint is configured
+        # (typically the same box as ComfyUI), prefer it: the ttl param
+        # auto-unloads the LLM after `lmstudio_ttl` seconds idle, freeing
+        # VRAM for the diffusion model. Cycle: load → enhance → unload
+        # (ttl) → ComfyUI generation → JIT-reload on next enhance.
         chain = [
+            ("lmstudio", lmstudio_url, try_lmstudio),
             ("comfyui", server, try_comfyui),
             ("ollama", "http://127.0.0.1:11434", try_ollama),
             ("kobold", kobold_url, try_kobold),
@@ -277,6 +294,46 @@ def _chat_comfyui(message, system_prompt, server, model, max_tokens,
             server, prompt=message, system_prompt=system_prompt,
             model=model, max_tokens=max_tokens, temperature=temperature,
             arch_key=arch_key, method=method)
+    except Exception:
+        return None
+
+
+def _chat_lmstudio(message, system_prompt, url, model, max_tokens,
+                   temperature, ttl=5):
+    """Chat via LM Studio's OpenAI-compatible API.
+
+    `ttl` (seconds) tells LM Studio to unload the model after that
+    many seconds of inactivity. Default 5s — short enough that a
+    ComfyUI generation kicked off right after the enhance returns
+    finds the VRAM free. Set ttl=0 to keep the model resident across
+    many calls (when ComfyUI isn't sharing the box).
+    """
+    if not url:
+        return None
+    try:
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": message})
+        payload = {
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": False,
+        }
+        if model:
+            payload["model"] = model
+        if ttl is not None and ttl > 0:
+            payload["ttl"] = int(ttl)
+        body = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            f"{url.rstrip('/')}/v1/chat/completions",
+            data=body, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read())
+            if "error" in data:
+                return None
+            return data["choices"][0]["message"]["content"]
     except Exception:
         return None
 

--- a/comfyui-spellcaster/spellcaster_core/guild_llm.py
+++ b/comfyui-spellcaster/spellcaster_core/guild_llm.py
@@ -240,7 +240,7 @@ def chat(message, system_prompt="", server=None, kobold_url=None,
             ("kobold", kobold_url, try_kobold),
         ]
     else:  # 'enhance'
-        # When a Voodoomancer-style LM Studio endpoint is configured
+        # When a local-LLM (LM Studio) endpoint is configured
         # (typically the same box as ComfyUI), prefer it: the ttl param
         # auto-unloads the LLM after `lmstudio_ttl` seconds idle, freeing
         # VRAM for the diffusion model. Cycle: load → enhance → unload

--- a/comfyui-spellcaster/spellcaster_core/prompt_enhance.py
+++ b/comfyui-spellcaster/spellcaster_core/prompt_enhance.py
@@ -518,7 +518,8 @@ def _resolve_method_profile(method):
 # ═══════════════════════════════════════════════════════════════════════════
 
 def enhance_prompt(prompt_text, arch_key, kobold_url=None, is_negative=False,
-                   comfy_url=None, model_name=None, method="scene"):
+                   comfy_url=None, model_name=None, method="scene",
+                   lmstudio_url=None, lmstudio_model=None, lmstudio_ttl=5):
     """Expand a terse user prompt into an architecture-optimised description.
 
     Tries ComfyUI LLM nodes first (if comfy_url provided), then falls back
@@ -663,6 +664,8 @@ def enhance_prompt(prompt_text, arch_key, kobold_url=None, is_negative=False,
         enhanced = guild_llm.chat(
             message=user_msg, system_prompt=system_msg,
             server=comfy_url, kobold_url=kobold_url,
+            lmstudio_url=lmstudio_url, lmstudio_model=lmstudio_model,
+            lmstudio_ttl=lmstudio_ttl,
             max_tokens=int(sampling.get("max_tokens", 300)),
             temperature=float(sampling.get("temperature", 0.3)),
             purpose="enhance",

--- a/plugins/gimp/comfyui-connector/spellcaster_core/cross_interface.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/cross_interface.py
@@ -38,6 +38,15 @@ import urllib.request
 from typing import Callable, Iterator, Optional
 
 
+# ── auth-token injection (optional; no-op if spellcaster_core.auth_token absent) ──
+def _sct_auth_headers() -> dict:
+    try:
+        from spellcaster_core.auth_token import auth_headers as _ah
+        return _ah() or {}
+    except Exception:
+        return {}
+
+
 _DEFAULT_GUILD_URL = "http://127.0.0.1:7777"
 _HEARTBEAT_INTERVAL_S = 10.0
 
@@ -82,6 +91,7 @@ def _http_json(method: str, url: str, payload: Optional[dict] = None,
     if payload is not None:
         body = json.dumps(payload).encode("utf-8")
         headers["Content-Type"] = "application/json"
+    headers.update(_sct_auth_headers())
     req = urllib.request.Request(url, data=body, method=method, headers=headers)
     for attempt in range(2):
         try:
@@ -213,8 +223,9 @@ class CrossInterfaceClient:
         qs = f"?{urllib.parse.urlencode(params)}" if params else ""
         url = f"{self.base_url}/api/events/stream{qs}"
         try:
-            req = urllib.request.Request(
-                url, headers={"Accept": "text/event-stream"})
+            _sse_headers = {"Accept": "text/event-stream"}
+            _sse_headers.update(_sct_auth_headers())
+            req = urllib.request.Request(url, headers=_sse_headers)
             resp = urllib.request.urlopen(req, timeout=timeout or 30.0)
         except Exception:
             return
@@ -312,7 +323,7 @@ class CrossInterfaceClient:
 
     def download_asset(self, h: str) -> Optional[bytes]:
         try:
-            req = urllib.request.Request(f"{self.base_url}/api/assets/{h}")
+            req = urllib.request.Request(f"{self.base_url}/api/assets/{h}", headers=_sct_auth_headers())
             with urllib.request.urlopen(req, timeout=10.0) as resp:
                 return resp.read()
         except Exception:
@@ -396,7 +407,7 @@ class CrossInterfaceClient:
         pattern matches ``_http_json`` and the sender-side uploaders."""
         if not url:
             return None
-        req = urllib.request.Request(url)
+        req = urllib.request.Request(url, headers=_sct_auth_headers())
         for attempt in range(2):
             try:
                 with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -420,7 +431,7 @@ class CrossInterfaceClient:
             return []
         url = f"{comfy_url.rstrip('/')}/spellcaster/blob/list"
         try:
-            req = urllib.request.Request(url)
+            req = urllib.request.Request(url, headers=_sct_auth_headers())
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
             if isinstance(data, dict):

--- a/plugins/gimp/comfyui-connector/spellcaster_core/guild_llm.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/guild_llm.py
@@ -150,7 +150,8 @@ RECOMMENDED_LLM = {
 
 def chat(message, system_prompt="", server=None, kobold_url=None,
          model=None, max_tokens=512, temperature=0.7, purpose="chat",
-         arch_key=None, method=None):
+         arch_key=None, method=None,
+         lmstudio_url=None, lmstudio_model=None, lmstudio_ttl=5):
     """THE single LLM entry point for every surface (Guild, GIMP, Darktable,
     ComfyUI nodes, scaffolding). Do not implement parallel LLM paths
     elsewhere — everything goes through this function.
@@ -203,6 +204,8 @@ def chat(message, system_prompt="", server=None, kobold_url=None,
         server = None
     if kobold_url is not None and not _valid_backend_url(kobold_url):
         kobold_url = None
+    if lmstudio_url is not None and not _valid_backend_url(lmstudio_url):
+        lmstudio_url = None
 
     # Build the backend sequence based on purpose.
     def try_ollama():
@@ -222,14 +225,28 @@ def chat(message, system_prompt="", server=None, kobold_url=None,
         return _chat_kobold(message, system_prompt, kobold_url,
                             max_tokens, temperature)
 
+    def try_lmstudio():
+        if not lmstudio_url:
+            return None
+        return _chat_lmstudio(message, system_prompt, lmstudio_url,
+                              lmstudio_model, max_tokens, temperature,
+                              ttl=lmstudio_ttl)
+
     if purpose == "chat":
         chain = [
             ("ollama", "http://127.0.0.1:11434", try_ollama),
             ("comfyui", server, try_comfyui),
+            ("lmstudio", lmstudio_url, try_lmstudio),
             ("kobold", kobold_url, try_kobold),
         ]
     else:  # 'enhance'
+        # When a Voodoomancer-style LM Studio endpoint is configured
+        # (typically the same box as ComfyUI), prefer it: the ttl param
+        # auto-unloads the LLM after `lmstudio_ttl` seconds idle, freeing
+        # VRAM for the diffusion model. Cycle: load → enhance → unload
+        # (ttl) → ComfyUI generation → JIT-reload on next enhance.
         chain = [
+            ("lmstudio", lmstudio_url, try_lmstudio),
             ("comfyui", server, try_comfyui),
             ("ollama", "http://127.0.0.1:11434", try_ollama),
             ("kobold", kobold_url, try_kobold),
@@ -277,6 +294,46 @@ def _chat_comfyui(message, system_prompt, server, model, max_tokens,
             server, prompt=message, system_prompt=system_prompt,
             model=model, max_tokens=max_tokens, temperature=temperature,
             arch_key=arch_key, method=method)
+    except Exception:
+        return None
+
+
+def _chat_lmstudio(message, system_prompt, url, model, max_tokens,
+                   temperature, ttl=5):
+    """Chat via LM Studio's OpenAI-compatible API.
+
+    `ttl` (seconds) tells LM Studio to unload the model after that
+    many seconds of inactivity. Default 5s — short enough that a
+    ComfyUI generation kicked off right after the enhance returns
+    finds the VRAM free. Set ttl=0 to keep the model resident across
+    many calls (when ComfyUI isn't sharing the box).
+    """
+    if not url:
+        return None
+    try:
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": message})
+        payload = {
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": False,
+        }
+        if model:
+            payload["model"] = model
+        if ttl is not None and ttl > 0:
+            payload["ttl"] = int(ttl)
+        body = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            f"{url.rstrip('/')}/v1/chat/completions",
+            data=body, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read())
+            if "error" in data:
+                return None
+            return data["choices"][0]["message"]["content"]
     except Exception:
         return None
 

--- a/plugins/gimp/comfyui-connector/spellcaster_core/guild_llm.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/guild_llm.py
@@ -240,7 +240,7 @@ def chat(message, system_prompt="", server=None, kobold_url=None,
             ("kobold", kobold_url, try_kobold),
         ]
     else:  # 'enhance'
-        # When a Voodoomancer-style LM Studio endpoint is configured
+        # When a local-LLM (LM Studio) endpoint is configured
         # (typically the same box as ComfyUI), prefer it: the ttl param
         # auto-unloads the LLM after `lmstudio_ttl` seconds idle, freeing
         # VRAM for the diffusion model. Cycle: load → enhance → unload

--- a/plugins/gimp/comfyui-connector/spellcaster_core/prompt_enhance.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/prompt_enhance.py
@@ -518,7 +518,8 @@ def _resolve_method_profile(method):
 # ═══════════════════════════════════════════════════════════════════════════
 
 def enhance_prompt(prompt_text, arch_key, kobold_url=None, is_negative=False,
-                   comfy_url=None, model_name=None, method="scene"):
+                   comfy_url=None, model_name=None, method="scene",
+                   lmstudio_url=None, lmstudio_model=None, lmstudio_ttl=5):
     """Expand a terse user prompt into an architecture-optimised description.
 
     Tries ComfyUI LLM nodes first (if comfy_url provided), then falls back
@@ -663,6 +664,8 @@ def enhance_prompt(prompt_text, arch_key, kobold_url=None, is_negative=False,
         enhanced = guild_llm.chat(
             message=user_msg, system_prompt=system_msg,
             server=comfy_url, kobold_url=kobold_url,
+            lmstudio_url=lmstudio_url, lmstudio_model=lmstudio_model,
+            lmstudio_ttl=lmstudio_ttl,
             max_tokens=int(sampling.get("max_tokens", 300)),
             temperature=float(sampling.get("temperature", 0.3)),
             purpose="enhance",


### PR DESCRIPTION
## Summary

Triage of the 6 cross-repo drifts surfaced by PR #23 identified 3 features that were originally surface-5/-6 customizations but belong on canon. Promoting eliminates the drift while keeping the feature.

## Promotions

| File | Source | What | Where it lands |
|---|---|---|---|
| \`prompt_enhance.py\` | S5 | LMStudio params on \`enhance_via_kobold()\` | Canon + S1 |
| \`guild_llm.py\` | S5 (Theo comments dropped) | \`_chat_lmstudio()\` + fallback ladder integration | Canon + S1 |
| \`cross_interface.py\` | S6 (comment scrubbed) | \`_sct_auth_headers()\` injection on 4 Request sites | Canon + S1 |

The \`cross_interface.py\` import is wrapped in try/except so canon (no \`auth_token.py\`) keeps its current no-auth behavior; NSFW surface gets actual auth.

## Drift impact

Before: 6 drifts. After auto-patch bot syncs canon → S5/S6:
- S5: 0 remaining drift
- S6: 3 remaining (\`guild_llm.py\` Theo comments, \`privacy.py\` NSFW additions, \`lora_knowledge.py\` NSFW catalogue) — those are legitimate per-surface customizations

## Test plan

- [x] In-repo mirror_drift: 25/25 byte-identical
- [x] Leak-check passes (Theo/Voodoomancer comment scrubbed from promoted files)
- [x] try/except on \`spellcaster_core.auth_token\` import — canon's no-auth path preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)