### PR TITLE
fix(diagnostic): node alternates + cold-load timeout + loop-start coord check

### DIFF
--- a/comfyui-spellcaster/spellcaster_core/diagnostic.py
+++ b/comfyui-spellcaster/spellcaster_core/diagnostic.py
@@ -174,7 +174,12 @@ CAPABILITY_TESTS = [
 
     ("rembg", "Background Removal",
      lambda m, s, i: build_rembg(i) if i else None,
-     ["ImageRembg"],
+     # Modern rembg packs ship under different node names. The tuple
+     # signals "ANY of these is sufficient" (vs a list which is
+     # "ALL of these required"). See _node_present() below.
+     [("RMBG", "BiRefNetRMBG", "ImageRembg",
+       "Image Rembg (Remove Background)",
+       "LayerMask: RemBgUltra V2")],
      ["studio_erasex"]),
 
     ("face_restore", "Face Restore (CodeFormer)",
@@ -195,7 +200,9 @@ CAPABILITY_TESTS = [
 
     ("ltx_t2v", "LTX T2V Video",
      None,  # Built dynamically
-     ["LTXVLoader"],
+     # LTXVLoader was the old pack's name; current pack ships
+     # LTXVImgToVideo + LTXVScheduler. Tuple = ANY of these.
+     [("LTXVImgToVideo", "LTXVLoader", "LTXVScheduler")],
      ["studio_videomancer", "model_ltx2"]),
 ]
 
@@ -204,8 +211,17 @@ CAPABILITY_TESTS = [
 #  Main diagnostic runner
 # ═══════════════════════════════════════════════════════════════════════
 
-def _submit_and_wait(server, workflow, timeout=120):
-    """Submit workflow, wait for result. Returns (ok, elapsed, error_msg)."""
+def _submit_and_wait(server, workflow, timeout=600):
+    """Submit workflow, wait for result. Returns (ok, elapsed, error_msg).
+
+    Default timeout is 600 s (10 min) because the first generation on
+    a freshly-booted ComfyUI cold-loads the checkpoint + CLIP + VAE
+    from disk, which takes 5–9 minutes on the RTX 5060 Ti / SD-1.5
+    path. A 120 s default was producing false 'Timeout' results on
+    every fresh-server diagnostic run (observed live 2026-05-13).
+    Callers expecting fast turnaround (subsequent same-arch tests,
+    or already-warm models) can pass a shorter timeout explicitly.
+    """
     try:
         from .preflight import preflight_workflow
         ok, workflow, report = preflight_workflow(workflow, server)
@@ -333,7 +349,14 @@ def run_diagnostic(server, callback=None, interactive=False):
     report.node_count = len(nodes)
     log(f"  {len(nodes)} nodes available")
 
-    critical = {
+    # Each entry is either a single node name (str) or a tuple of
+    # alternates. The capability is considered present if ANY of the
+    # alternates is installed. This handles upstream packs renaming
+    # nodes between versions — e.g. older rembg packs shipped
+    # ``ImageRembg`` (no longer in current Manager builds), modern
+    # alternatives include ``RMBG`` / ``BiRefNetRMBG`` / the labeled
+    # node ``Image Rembg (Remove Background)`` from rembg-comfy.
+    critical: dict[str | tuple[str, ...], str] = {
         "CheckpointLoaderSimple": "Model loading",
         "KSampler": "Standard sampling",
         "SaveImage": "Image saving",
@@ -341,14 +364,21 @@ def run_diagnostic(server, callback=None, interactive=False):
         "ImageUpscaleWithModel": "AI upscaling",
         "VHS_VideoCombine": "Video assembly",
         "ReActorFaceSwapOpt": "Face swap",
-        "ImageRembg": "Background removal",
+        ("RMBG", "BiRefNetRMBG", "ImageRembg",
+         "Image Rembg (Remove Background)",
+         "LayerMask: RemBgUltra V2"): "Background removal",
         "WanImageToVideo": "WAN I2V",
         "UnetLoaderGGUF": "GGUF model loading",
+        ("LTXVImgToVideo", "LTXVLoader",
+         "LTXVScheduler"): "LTX video loading",
     }
-    for ct, desc in critical.items():
-        if ct not in nodes:
-            report.missing_nodes.append(ct)
-            log(f"  MISSING: {ct} ({desc})")
+    for key, desc in critical.items():
+        names = (key,) if isinstance(key, str) else key
+        if not any(n in nodes for n in names):
+            # Report the primary (first) name as the canonical
+            # "missing" so downstream consumers don't see a tuple.
+            report.missing_nodes.append(names[0])
+            log(f"  MISSING: {' / '.join(names)} ({desc})")
 
     # Phase 3: Model inventory
     log("\nPhase 3: Model inventory")
@@ -370,7 +400,13 @@ def run_diagnostic(server, callback=None, interactive=False):
         if fast_arch in models:
             wf = _build_txt2img_test(fast_arch, models, server, None)
             if wf:
-                ok, elapsed, err = _submit_and_wait(server, wf, timeout=60)
+                # 600 s: this is the first-ever workflow on a freshly
+                # booted ComfyUI; cold-loading checkpoint + CLIP + VAE
+                # from disk takes 5-9 min on the RTX 5060 Ti SD-1.5
+                # path. Subsequent Phase-5 capability tests get the
+                # default (also 600 s) but typically complete in
+                # seconds because the same arch's models are warm.
+                ok, elapsed, err = _submit_and_wait(server, wf, timeout=600)
                 if ok:
                     # Get the output filename
                     log(f"  Generated test image in {elapsed:.0f}s ({fast_arch})")
@@ -407,11 +443,24 @@ def run_diagnostic(server, callback=None, interactive=False):
 
     # Phase 5: Capability tests
     log("\nPhase 5: Testing capabilities")
+    def _node_present(item, installed):
+        """An item is either a single node name (str — required) or a
+        tuple of alternates (any-of). Returns True when the
+        capability is satisfied."""
+        names = (item,) if isinstance(item, str) else item
+        return any(n in installed for n in names)
+
     for cap_id, cap_name, build_fn, required_nodes, related_wizards in CAPABILITY_TESTS:
         log(f"  {cap_name}...", end=" ")
 
-        # Check required nodes
-        missing = [n for n in required_nodes if n not in nodes]
+        # Check required nodes: each list entry is a single name (str)
+        # or a tuple of alternates. A missing entry is reported by its
+        # primary (first) name.
+        missing = []
+        for item in required_nodes:
+            if not _node_present(item, nodes):
+                primary = item if isinstance(item, str) else item[0]
+                missing.append(primary)
         if missing:
             report.broken.append((cap_id, f"Missing nodes: {', '.join(missing)}"))
             report.banish_wizards.extend(related_wizards)
@@ -443,7 +492,11 @@ def run_diagnostic(server, callback=None, interactive=False):
             continue
 
         # Submit and test
-        ok, elapsed, err = _submit_and_wait(server, wf, timeout=180)
+        # 600 s: each capability test that COLD-loads a different arch
+        # checkpoint (txt2img_sdxl after txt2img_sd15 etc.) needs 5-9 min
+        # to finish the first generation. 180 s here was producing
+        # false Timeout reports for every uncommon arch.
+        ok, elapsed, err = _submit_and_wait(server, wf, timeout=600)
         if ok:
             report.working.append(cap_id)
             report.timings[cap_id] = elapsed

--- a/plugins/gimp/comfyui-connector/spellcaster_core/diagnostic.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/diagnostic.py
@@ -174,7 +174,12 @@ CAPABILITY_TESTS = [
 
     ("rembg", "Background Removal",
      lambda m, s, i: build_rembg(i) if i else None,
-     ["ImageRembg"],
+     # Modern rembg packs ship under different node names. The tuple
+     # signals "ANY of these is sufficient" (vs a list which is
+     # "ALL of these required"). See _node_present() below.
+     [("RMBG", "BiRefNetRMBG", "ImageRembg",
+       "Image Rembg (Remove Background)",
+       "LayerMask: RemBgUltra V2")],
      ["studio_erasex"]),
 
     ("face_restore", "Face Restore (CodeFormer)",
@@ -195,7 +200,9 @@ CAPABILITY_TESTS = [
 
     ("ltx_t2v", "LTX T2V Video",
      None,  # Built dynamically
-     ["LTXVLoader"],
+     # LTXVLoader was the old pack's name; current pack ships
+     # LTXVImgToVideo + LTXVScheduler. Tuple = ANY of these.
+     [("LTXVImgToVideo", "LTXVLoader", "LTXVScheduler")],
      ["studio_videomancer", "model_ltx2"]),
 ]
 
@@ -204,8 +211,17 @@ CAPABILITY_TESTS = [
 #  Main diagnostic runner
 # ═══════════════════════════════════════════════════════════════════════
 
-def _submit_and_wait(server, workflow, timeout=120):
-    """Submit workflow, wait for result. Returns (ok, elapsed, error_msg)."""
+def _submit_and_wait(server, workflow, timeout=600):
+    """Submit workflow, wait for result. Returns (ok, elapsed, error_msg).
+
+    Default timeout is 600 s (10 min) because the first generation on
+    a freshly-booted ComfyUI cold-loads the checkpoint + CLIP + VAE
+    from disk, which takes 5–9 minutes on the RTX 5060 Ti / SD-1.5
+    path. A 120 s default was producing false 'Timeout' results on
+    every fresh-server diagnostic run (observed live 2026-05-13).
+    Callers expecting fast turnaround (subsequent same-arch tests,
+    or already-warm models) can pass a shorter timeout explicitly.
+    """
     try:
         from .preflight import preflight_workflow
         ok, workflow, report = preflight_workflow(workflow, server)
@@ -333,7 +349,14 @@ def run_diagnostic(server, callback=None, interactive=False):
     report.node_count = len(nodes)
     log(f"  {len(nodes)} nodes available")
 
-    critical = {
+    # Each entry is either a single node name (str) or a tuple of
+    # alternates. The capability is considered present if ANY of the
+    # alternates is installed. This handles upstream packs renaming
+    # nodes between versions — e.g. older rembg packs shipped
+    # ``ImageRembg`` (no longer in current Manager builds), modern
+    # alternatives include ``RMBG`` / ``BiRefNetRMBG`` / the labeled
+    # node ``Image Rembg (Remove Background)`` from rembg-comfy.
+    critical: dict[str | tuple[str, ...], str] = {
         "CheckpointLoaderSimple": "Model loading",
         "KSampler": "Standard sampling",
         "SaveImage": "Image saving",
@@ -341,14 +364,21 @@ def run_diagnostic(server, callback=None, interactive=False):
         "ImageUpscaleWithModel": "AI upscaling",
         "VHS_VideoCombine": "Video assembly",
         "ReActorFaceSwapOpt": "Face swap",
-        "ImageRembg": "Background removal",
+        ("RMBG", "BiRefNetRMBG", "ImageRembg",
+         "Image Rembg (Remove Background)",
+         "LayerMask: RemBgUltra V2"): "Background removal",
         "WanImageToVideo": "WAN I2V",
         "UnetLoaderGGUF": "GGUF model loading",
+        ("LTXVImgToVideo", "LTXVLoader",
+         "LTXVScheduler"): "LTX video loading",
     }
-    for ct, desc in critical.items():
-        if ct not in nodes:
-            report.missing_nodes.append(ct)
-            log(f"  MISSING: {ct} ({desc})")
+    for key, desc in critical.items():
+        names = (key,) if isinstance(key, str) else key
+        if not any(n in nodes for n in names):
+            # Report the primary (first) name as the canonical
+            # "missing" so downstream consumers don't see a tuple.
+            report.missing_nodes.append(names[0])
+            log(f"  MISSING: {' / '.join(names)} ({desc})")
 
     # Phase 3: Model inventory
     log("\nPhase 3: Model inventory")
@@ -370,7 +400,13 @@ def run_diagnostic(server, callback=None, interactive=False):
         if fast_arch in models:
             wf = _build_txt2img_test(fast_arch, models, server, None)
             if wf:
-                ok, elapsed, err = _submit_and_wait(server, wf, timeout=60)
+                # 600 s: this is the first-ever workflow on a freshly
+                # booted ComfyUI; cold-loading checkpoint + CLIP + VAE
+                # from disk takes 5-9 min on the RTX 5060 Ti SD-1.5
+                # path. Subsequent Phase-5 capability tests get the
+                # default (also 600 s) but typically complete in
+                # seconds because the same arch's models are warm.
+                ok, elapsed, err = _submit_and_wait(server, wf, timeout=600)
                 if ok:
                     # Get the output filename
                     log(f"  Generated test image in {elapsed:.0f}s ({fast_arch})")
@@ -407,11 +443,24 @@ def run_diagnostic(server, callback=None, interactive=False):
 
     # Phase 5: Capability tests
     log("\nPhase 5: Testing capabilities")
+    def _node_present(item, installed):
+        """An item is either a single node name (str — required) or a
+        tuple of alternates (any-of). Returns True when the
+        capability is satisfied."""
+        names = (item,) if isinstance(item, str) else item
+        return any(n in installed for n in names)
+
     for cap_id, cap_name, build_fn, required_nodes, related_wizards in CAPABILITY_TESTS:
         log(f"  {cap_name}...", end=" ")
 
-        # Check required nodes
-        missing = [n for n in required_nodes if n not in nodes]
+        # Check required nodes: each list entry is a single name (str)
+        # or a tuple of alternates. A missing entry is reported by its
+        # primary (first) name.
+        missing = []
+        for item in required_nodes:
+            if not _node_present(item, nodes):
+                primary = item if isinstance(item, str) else item[0]
+                missing.append(primary)
         if missing:
             report.broken.append((cap_id, f"Missing nodes: {', '.join(missing)}"))
             report.banish_wizards.extend(related_wizards)
@@ -443,7 +492,11 @@ def run_diagnostic(server, callback=None, interactive=False):
             continue
 
         # Submit and test
-        ok, elapsed, err = _submit_and_wait(server, wf, timeout=180)
+        # 600 s: each capability test that COLD-loads a different arch
+        # checkpoint (txt2img_sdxl after txt2img_sd15 etc.) needs 5-9 min
+        # to finish the first generation. 180 s here was producing
+        # false Timeout reports for every uncommon arch.
+        ok, elapsed, err = _submit_and_wait(server, wf, timeout=600)
         if ok:
             report.working.append(cap_id)
             report.timings[cap_id] = elapsed

--- a/tools/loop_start_check.py
+++ b/tools/loop_start_check.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Loop-start coordination check — what is every other Claude doing right now?
+
+Built 2026-05-13 per the user directive: "you must automatically and
+systematically find out what other claude sessions do so as not to
+interfere with their work."
+
+Designed to be the first thing a Claude session calls at the start
+of every ``/loop`` iteration. Cheap (~1 s) and prints a compact
+human-readable + machine-parsable report:
+
+    1. Active sessions registered via tools/claude_session.py
+    2. Active file locks (so this session knows what NOT to edit)
+    3. Untracked / modified files in spellcaster + siblings — strong
+       signal that a parallel session has WIP there
+    4. Recent commits on origin/main across the 3 repos — what
+       landed since the last iteration
+
+If another session has claimed a file this iteration plans to edit,
+print a COLLISION line so the caller can pick a different concern.
+
+Usage:
+
+    python tools/loop_start_check.py
+    python tools/loop_start_check.py --json
+    python tools/loop_start_check.py --intent comfyui-spellcaster/spellcaster_core/workflows.py
+
+The ``--intent`` flag declares the file(s) this session is about
+to touch; the script exits 1 (collision) if any are locked by
+another active session.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+GREEN = "\033[92m"
+RED   = "\033[91m"
+YEL   = "\033[93m"
+DIM   = "\033[2m"
+BOLD  = "\033[1m"
+RESET = "\033[0m"
+
+REPO = Path(__file__).resolve().parent.parent
+COORD = REPO / "tools" / "claude_session.py"
+
+# Sibling repos: env-driven so the leak-check regex doesn't flag this
+# file. Set DISTRO_REPO_PATH and NSFW_REPO_PATH in the dev environment.
+_DISTRO = os.environ.get("DISTRO_REPO_PATH", "")
+_NSFW   = os.environ.get("NSFW_REPO_PATH", "")
+SIBLINGS = [("spellcaster", REPO)]
+if _DISTRO and Path(_DISTRO).is_dir():
+    SIBLINGS.append(("distro-runtime", Path(_DISTRO)))
+if _NSFW and Path(_NSFW).is_dir():
+    SIBLINGS.append(("nsfw-pack", Path(_NSFW)))
+
+
+def _coord_json(subcmd: str) -> dict:
+    if not COORD.is_file():
+        return {}
+    try:
+        p = subprocess.run([sys.executable, str(COORD), subcmd],
+                           capture_output=True, text=True, timeout=10)
+        return json.loads(p.stdout or "{}")
+    except (subprocess.CalledProcessError,
+            json.JSONDecodeError, FileNotFoundError):
+        return {}
+
+
+def _git_status(path: Path) -> list[str]:
+    try:
+        p = subprocess.run(["git", "-C", str(path), "status", "-sb"],
+                           capture_output=True, text=True, timeout=10,
+                           check=True)
+        return p.stdout.splitlines()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+
+def _git_log(path: Path, n: int = 3) -> list[str]:
+    try:
+        # Best-effort fetch (don't fail loud if offline)
+        subprocess.run(["git", "-C", str(path), "fetch", "origin", "--quiet"],
+                       capture_output=True, text=True, timeout=15)
+        p = subprocess.run(["git", "-C", str(path), "log", "--oneline",
+                            f"-{n}", "origin/main"],
+                           capture_output=True, text=True, timeout=10,
+                           check=True)
+        return p.stdout.splitlines()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--json", action="store_true",
+                    help="emit a machine-readable JSON blob instead of "
+                         "the human-readable summary")
+    ap.add_argument("--intent", nargs="*", default=[],
+                    help="file path(s) this session plans to edit. "
+                         "Exit 1 on collision with another session's lock.")
+    args = ap.parse_args()
+
+    sessions = _coord_json("list").get("sessions", [])
+    locks    = _coord_json("locks").get("locks", [])
+
+    # Build a path → owning-session map from lock dicts. The coord
+    # module's lock entries look like
+    # {"file": "...", "sid": "...", "task": "...", ...}
+    locked_by: dict[str, dict] = {}
+    for entry in locks:
+        if not isinstance(entry, dict):
+            continue
+        f = entry.get("file") or entry.get("path") or ""
+        if f:
+            locked_by[str(Path(f).resolve())] = entry
+
+    # Collision check on caller's intent
+    collisions: list[dict] = []
+    for path_str in args.intent:
+        resolved = str(Path(path_str).resolve())
+        if resolved in locked_by:
+            collisions.append({"intent": path_str,
+                                "locked_by": locked_by[resolved]})
+
+    # Per-repo git status / log
+    repo_status: dict[str, dict] = {}
+    for label, path in SIBLINGS:
+        repo_status[label] = {
+            "path": str(path),
+            "status": _git_status(path),
+            "recent_commits": _git_log(path, 3),
+        }
+
+    summary = {
+        "active_sessions": sessions,
+        "locks": locks,
+        "collisions": collisions,
+        "repos": repo_status,
+    }
+
+    if args.json:
+        print(json.dumps(summary, indent=2, default=str))
+        return 1 if collisions else 0
+
+    # Human-readable
+    print(f"{BOLD}── loop start: parallel-session check ──{RESET}")
+    print(f"  active sessions: {len(sessions)}")
+    for s in sessions[:10]:
+        if not isinstance(s, dict):
+            continue
+        sid = s.get("sid", "?")
+        task = s.get("task", "")[:80]
+        age = s.get("age_s", "?")
+        files = s.get("files", [])
+        print(f"    [{sid}] age={age}s")
+        if task:
+            print(f"      task: {task}")
+        for f in files[:6]:
+            print(f"      file: {f}")
+    print(f"  active locks: {len(locks)}")
+    for entry in locks[:10]:
+        if isinstance(entry, dict):
+            print(f"    {entry.get('file','?')}  (sid={entry.get('sid','?')})")
+    if collisions:
+        print(f"\n  {RED}{BOLD}COLLISION{RESET}")
+        for c in collisions:
+            lb = c["locked_by"]
+            print(f"    {RED}✗{RESET} intent={c['intent']}")
+            print(f"      held by [{lb.get('sid','?')}] task={lb.get('task','?')}")
+    print(f"\n{BOLD}── repos ──{RESET}")
+    for label, info in repo_status.items():
+        print(f"  {label}: {info['path']}")
+        wip = [ln for ln in info['status']
+               if ln.startswith(('?? ', ' M ', 'M ', 'A '))]
+        if wip:
+            print(f"    WIP (untracked/modified):")
+            for ln in wip[:10]:
+                print(f"      {ln}")
+        if info['recent_commits']:
+            print(f"    recent commits on origin/main:")
+            for ln in info['recent_commits']:
+                print(f"      {ln}")
+
+    return 1 if collisions else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Validator on the dev host reported 10 capabilities broken. Triage: 4 timeouts (false positives — 60s/180s too short for cold model loads, 600s now), 2 missing-node false positives (`ImageRembg`/`LTXVLoader` outdated names — now any-of-alternates), 4 secondary failures (cascading from the first generation timing out).

`tools/loop_start_check.py` added per the new directive: every `/loop` iteration should auto-check what other Claude sessions are doing. Shows active sessions, file locks, per-repo WIP, recent commits. `--intent <paths>` flags collisions.

## Test plan

- [x] In-repo mirror_drift: byte-identical (C ⇄ 1)
- [x] Coord helper smoke-tested: 0 collisions on intent=diagnostic.py
- [ ] Validator full re-run (~30+ min cold-loads) — verifies false negatives are now true positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)