### PR TITLE
fix(model_detect): bucket LTX/Lumina/SUPIR/Wan before sd15 fallthrough

### DIFF
--- a/comfyui-spellcaster/spellcaster_core/model_detect.py
+++ b/comfyui-spellcaster/spellcaster_core/model_detect.py
@@ -92,7 +92,32 @@ CKPT_ARCH_RULES = [
     ("illu",        "illustrious"),
     ("pony",        "pony"),
     ("flux",        "flux1dev"),
-    # fallthrough → "sd15"
+    # Video / non-SD1.5 packs that historically fell through to sd15
+    # and broke the diagnostic with "clip input is invalid: None" when
+    # tested as an SD-1.5 txt2img workflow (LTX / Lumina / SUPIR /
+    # Wan checkpoints don't embed the standard SD-1.5 CLIP).
+    ("ltx",         "ltx"),
+    ("ltx-",        "ltx"),
+    ("lumina",      "lumina2"),
+    ("lumina2",     "lumina2"),
+    ("supir",       "supir"),
+    ("wan22",       "wan"),
+    ("wan_",        "wan"),
+    ("wan-",        "wan"),
+    ("cogvideo",    "cogvideo"),
+    ("framepack",   "framepack"),
+    ("hunyuan_video", "hunyuan_video"),
+    ("hunyuanvideo", "hunyuan_video"),
+    ("mochi",       "mochi"),
+    # SD-1.5 explicit catches BEFORE the fallthrough (older naming
+    # conventions). Without these, classification still works via the
+    # fallthrough; included for symmetry + explicit-is-better.
+    ("sd-1.5",      "sd15"),
+    ("sd_1_5",      "sd15"),
+    ("sd15",        "sd15"),
+    ("v1-5",        "sd15"),
+    # fallthrough → "sd15" (legacy; only safe when other detectors
+    # have already excluded video / non-standard archs above)
 ]
 
 # ── Best-model priority (highest first) ──

--- a/plugins/gimp/comfyui-connector/spellcaster_core/model_detect.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/model_detect.py
@@ -92,7 +92,32 @@ CKPT_ARCH_RULES = [
     ("illu",        "illustrious"),
     ("pony",        "pony"),
     ("flux",        "flux1dev"),
-    # fallthrough → "sd15"
+    # Video / non-SD1.5 packs that historically fell through to sd15
+    # and broke the diagnostic with "clip input is invalid: None" when
+    # tested as an SD-1.5 txt2img workflow (LTX / Lumina / SUPIR /
+    # Wan checkpoints don't embed the standard SD-1.5 CLIP).
+    ("ltx",         "ltx"),
+    ("ltx-",        "ltx"),
+    ("lumina",      "lumina2"),
+    ("lumina2",     "lumina2"),
+    ("supir",       "supir"),
+    ("wan22",       "wan"),
+    ("wan_",        "wan"),
+    ("wan-",        "wan"),
+    ("cogvideo",    "cogvideo"),
+    ("framepack",   "framepack"),
+    ("hunyuan_video", "hunyuan_video"),
+    ("hunyuanvideo", "hunyuan_video"),
+    ("mochi",       "mochi"),
+    # SD-1.5 explicit catches BEFORE the fallthrough (older naming
+    # conventions). Without these, classification still works via the
+    # fallthrough; included for symmetry + explicit-is-better.
+    ("sd-1.5",      "sd15"),
+    ("sd_1_5",      "sd15"),
+    ("sd15",        "sd15"),
+    ("v1-5",        "sd15"),
+    # fallthrough → "sd15" (legacy; only safe when other detectors
+    # have already excluded video / non-standard archs above)
 ]
 
 # ── Best-model priority (highest first) ──


### PR DESCRIPTION
Live validator surfaced the real bug behind 'txt2img_sd15: clip input is invalid: None': `classify_ckpt_model('LTX\ltx-video-2b-v0.9.5.safetensors')` returned `sd15` because video/Lumina/SUPIR checkpoints had no explicit rule and fell through to the sd15 default. The diagnostic then loaded LTX as SD-1.5 and ComfyUI rejected the workflow (LTX doesn't embed standard CLIP).

Added explicit rules for ltx/lumina/supir/wan/cogvideo/framepack/hunyuan_video/mochi before the fallthrough.

**Live verified on dev host:**
- sd15: was 7 mis-bucketed ckpts → now 4 actual SD-1.5 (dreamshaper, juggernaut, serenity)
- ltx: was 0 → 3
- wan: was 0 → 21
- lumina2: 0 → 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)