### PR TITLE
fix(sync_surfaces): per-minute branch stamp avoids stale-info collision

### DIFF
--- a/tools/sync_surfaces.py
+++ b/tools/sync_surfaces.py
@@ -149,8 +149,12 @@ def _sync_surface(label: str, sibling_root: Path, surface_rel: Path,
     print(f"  {GREEN}✓ copied {len(plan)} file(s) canon → surface {label}{RESET}")
 
     # 2. Create branch + commit
+    # Per-minute stamp so multiple runs in the same day don't collide
+    # on the same branch name (which fails with 'stale info' once the
+    # previous run's branch has been merged + deleted server-side).
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    branch = f"sync/auto-canon-{stamp}"
+    minute_stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M")
+    branch = f"sync/auto-canon-{minute_stamp}"
     # If branch exists locally, reuse it; otherwise create from origin/main
     rc, _, _ = _run(["git", "fetch", "origin", "--quiet"], sibling_root)
     rc, out, err = _run(["git", "checkout", "-B", branch, "origin/main"], sibling_root)


### PR DESCRIPTION
Auto-sync's second-of-day run failed on push: 'stale info — rejected'. Branch name now uses hour+minute timestamp so each run lands on a fresh ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)