### PR TITLE
fix(tools): surface coord errors / LLM empty-choice / git-fetch failure

### DIFF
--- a/tools/llm_morning_briefing.py
+++ b/tools/llm_morning_briefing.py
@@ -326,7 +326,15 @@ def llm_summarize(facts_md: str, endpoint: str, model: str) -> str:
     )
     with urllib.request.urlopen(req, timeout=300) as r:
         payload = json.loads(r.read().decode("utf-8"))
-    return payload["choices"][0]["message"]["content"]
+    # Defensive: a malformed LLM response (rate-limit, model-unloaded,
+    # truncated chunk) can produce an empty 'choices' array. Bubble
+    # up a clean error rather than an opaque IndexError.
+    choices = payload.get("choices") or []
+    if not choices:
+        raise RuntimeError(f"LLM returned no choices "
+                            f"(model={payload.get('model','?')}); "
+                            f"raw payload keys: {list(payload.keys())}")
+    return choices[0]["message"]["content"]
 
 
 # ─── Main ─────────────────────────────────────────────────────────────────────

--- a/tools/loop_start_check.py
+++ b/tools/loop_start_check.py
@@ -66,15 +66,29 @@ if _NSFW and Path(_NSFW).is_dir():
 
 
 def _coord_json(subcmd: str) -> dict:
+    """Call ``tools/claude_session.py <subcmd>`` and parse the JSON output.
+
+    Returns a dict that always carries ``_status``:
+      - 'ok'       → coord tool present + responded with valid JSON
+      - 'absent'   → coord tool not installed in this repo
+      - 'failed'   → coord tool ran but errored / produced non-JSON
+    Callers can distinguish 'no sessions registered' (legitimate quiet
+    state) from 'coord tool is broken' (alarming) without silently
+    treating both as empty dicts.
+    """
     if not COORD.is_file():
-        return {}
+        return {"_status": "absent"}
     try:
         p = subprocess.run([sys.executable, str(COORD), subcmd],
                            capture_output=True, text=True, timeout=10)
-        return json.loads(p.stdout or "{}")
+        data = json.loads(p.stdout or "{}")
+        if isinstance(data, dict):
+            data.setdefault("_status", "ok")
+            return data
+        return {"_status": "ok", "_raw": data}
     except (subprocess.CalledProcessError,
-            json.JSONDecodeError, FileNotFoundError):
-        return {}
+            json.JSONDecodeError, FileNotFoundError) as e:
+        return {"_status": "failed", "_error": f"{type(e).__name__}: {e}"}
 
 
 def _git_status(path: Path) -> list[str]:
@@ -111,8 +125,11 @@ def main() -> int:
                          "Exit 1 on collision with another session's lock.")
     args = ap.parse_args()
 
-    sessions = _coord_json("list").get("sessions", [])
-    locks    = _coord_json("locks").get("locks", [])
+    sessions_resp = _coord_json("list")
+    locks_resp    = _coord_json("locks")
+    coord_health = sessions_resp.get("_status", "ok")
+    sessions = sessions_resp.get("sessions", [])
+    locks    = locks_resp.get("locks", [])
 
     # Build a path → owning-session map from lock dicts. The coord
     # module's lock entries look like
@@ -143,6 +160,7 @@ def main() -> int:
         }
 
     summary = {
+        "coord_health": coord_health,
         "active_sessions": sessions,
         "locks": locks,
         "collisions": collisions,
@@ -155,6 +173,10 @@ def main() -> int:
 
     # Human-readable
     print(f"{BOLD}── loop start: parallel-session check ──{RESET}")
+    if coord_health != "ok":
+        print(f"  {YEL}~ coord tool: {coord_health}{RESET}")
+        if "_error" in sessions_resp:
+            print(f"    {DIM}{sessions_resp['_error'][:160]}{RESET}")
     print(f"  active sessions: {len(sessions)}")
     for s in sessions[:10]:
         if not isinstance(s, dict):

--- a/tools/sync_surfaces.py
+++ b/tools/sync_surfaces.py
@@ -155,8 +155,14 @@ def _sync_surface(label: str, sibling_root: Path, surface_rel: Path,
     stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     minute_stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M")
     branch = f"sync/auto-canon-{minute_stamp}"
-    # If branch exists locally, reuse it; otherwise create from origin/main
-    rc, _, _ = _run(["git", "fetch", "origin", "--quiet"], sibling_root)
+    # If branch exists locally, reuse it; otherwise create from origin/main.
+    # Surface a fetch failure loudly — silently proceeding to checkout off
+    # a stale origin/main produces a sync PR against the wrong base and
+    # turns the next round of cross_repo_drift into a confused mess.
+    rc_fetch, _, err_fetch = _run(["git", "fetch", "origin", "--quiet"], sibling_root)
+    if rc_fetch != 0:
+        print(f"  {YEL}~ git fetch returned {rc_fetch}: {err_fetch.strip()[:160]}{RESET}")
+        print(f"  {YEL}  continuing against possibly-stale origin/main{RESET}")
     rc, out, err = _run(["git", "checkout", "-B", branch, "origin/main"], sibling_root)
     if rc != 0:
         print(f"  {RED}✗ branch checkout failed: {err.strip()[:200]}{RESET}")


### PR DESCRIPTION
Explore-agent code review of recent tooling surfaced 10 latent issues; fixing the 3 most-impactful:

- **sync_surfaces.py**: git fetch return code was discarded — now warns loudly
- **llm_morning_briefing.py**: empty LLM 'choices' array would IndexError — now raises clean RuntimeError with payload keys
- **loop_start_check.py**: '_coord_json returned {}' meant both 'no sessions' and 'tool broken' — now distinguishes via _status field

Files unrelated to those tools (installer/, comfyui-spellcaster/) NOT touched. Coordination respected: parallel session's WIP areas untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)