### PR TITLE
feat(builders-manifest): backfill target_class for multi-stage builders (35 -> 62 of 73)

### DIFF
--- a/comfyui-spellcaster/spellcaster_core/builders_manifest.json
+++ b/comfyui-spellcaster/spellcaster_core/builders_manifest.json
@@ -271,6 +271,7 @@
       "label": "Text-to-image generation with ControlNet spatial constraint",
       "kind": "other",
       "model_family": "sdxl",
+      "target_class": "ControlNetApplyAdvanced",
       "input_slots": [
         "image_filename"
       ],
@@ -551,6 +552,7 @@
       "label": "Restore faces. Drop-in for _build_face_restore()",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "ReActorRestoreFace",
       "input_slots": [
         "image_filename"
       ],
@@ -610,6 +612,7 @@
       "label": "IPAdapter FaceID img2img. Drop-in for _build_faceid_img2img()",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "IPAdapterFaceID",
       "input_slots": [
         "target_filename",
         "face_ref_filename"
@@ -700,6 +703,7 @@
       "label": "Faceswap",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "ReActorFaceSwapOpt",
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -774,6 +778,7 @@
       "label": "ReActor face swap using a saved face model. Drop-in for _build_faceswap_model()",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "ReActorFaceSwapOpt",
       "input_slots": [
         "target_filename"
       ],
@@ -846,6 +851,7 @@
       "label": "Face swap using mtb facetools. Drop-in for _build_faceswap_mtb()",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "Face Swap (mtb)",
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -885,6 +891,7 @@
       "label": "Assemble a list of uploaded frame images into a single MP4 video",
       "kind": "other",
       "model_family": "video",
+      "target_class": "VHS_VideoCombine",
       "input_slots": [
         "frame_filenames"
       ],
@@ -1571,6 +1578,7 @@
       "label": "IC-Light relighting: adjust light sources and illumination",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "LoadAndApplyICLightUnet",
       "input_slots": [
         "image_filename"
       ],
@@ -1769,7 +1777,7 @@
       "label": "Inpainting: regenerate masked region using diffusion",
       "kind": "image",
       "model_family": "generic",
-      "target_class": "ImageCompositeMasked",
+      "target_class": "SetLatentNoiseMask",
       "input_slots": [
         "image_filename",
         "mask_filename"
@@ -1870,6 +1878,7 @@
       "label": "Fooocus-style inpaint: LaMa pre-fill + Fooocus head LoRA on SDXL",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "INPAINT_ApplyFooocusInpaint",
       "input_slots": [
         "image_filename",
         "mask_filename"
@@ -2016,7 +2025,7 @@
       "label": "Klein batch variations — N Klein renders from one reference in a single pass",
       "kind": "image",
       "model_family": "klein",
-      "target_class": "ImageFromBatch",
+      "target_class": "Flux2KleinEnhancer",
       "input_slots": [
         "image_filename"
       ],
@@ -2215,7 +2224,7 @@
       "label": "Klein Detail Enhancer — detect ANY region and re-generate at high detail",
       "kind": "image",
       "model_family": "klein",
-      "target_class": "GrowMaskWithBlur",
+      "target_class": "FaceDetailer",
       "input_slots": [
         "image_filename"
       ],
@@ -2472,6 +2481,7 @@
       "label": "Head swap with Klein Flux2 refinement",
       "kind": "image",
       "model_family": "klein",
+      "target_class": "IdentityFeatureTransfer",
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -3029,6 +3039,7 @@
       "label": "Klein Re-poser: change character pose using ReferenceLatent + BasicScheduler",
       "kind": "image",
       "model_family": "klein",
+      "target_class": "IdentityFeatureTransfer",
       "input_slots": [
         "image_filename"
       ],
@@ -3114,7 +3125,7 @@
       "label": "Klein SAM3 Inpaint — detect a region by text and inpaint it",
       "kind": "detect",
       "model_family": "klein",
-      "target_class": "ImageCropByMask",
+      "target_class": "SAM3Segment",
       "input_slots": [
         "image_filename",
         "ref_filename"
@@ -3273,7 +3284,7 @@
       "label": "Klein Virtual Try-On — 4-reference photoshoot composition",
       "kind": "image",
       "model_family": "klein",
-      "target_class": "EmptyLatentImage",
+      "target_class": "ReferenceLatent",
       "input_slots": [
         "face_filename"
       ],
@@ -3384,6 +3395,7 @@
       "label": "Object removal via LaMa inpainting (no diffusion)",
       "kind": "other",
       "model_family": "detect",
+      "target_class": "LamaRemover",
       "input_slots": [
         "image_filename",
         "mask_filename"
@@ -3434,6 +3446,7 @@
       "label": "Blend two images with adjustable opacity and blend mode",
       "kind": "other",
       "model_family": "detect",
+      "target_class": "ImageBlend",
       "input_slots": [
         "image_a_filename",
         "image_b_filename"
@@ -3468,7 +3481,7 @@
       "label": "LTX Video 2.3 generation — text-to-video or image-to-video",
       "kind": "video",
       "model_family": "ltx",
-      "target_class": "CFGZeroStar",
+      "target_class": "LTXVBaseSampler",
       "input_slots": [
         "image_filename"
       ],
@@ -3625,7 +3638,7 @@
       "label": "Lumina-Image 2.0 (Alpha-VLLM, 2024-12) text-to-image",
       "kind": "image",
       "model_family": "lumina2",
-      "target_class": "SaveImage",
+      "target_class": "CLIPTextEncodeLumina2",
       "input_slots": [],
       "params": [
         {
@@ -3769,7 +3782,7 @@
       "label": "Magic Eraser — SAM3 detect + LaMa inpaint",
       "kind": "image",
       "model_family": "detect",
-      "target_class": "GrowMaskWithBlur",
+      "target_class": "LamaRemover",
       "input_slots": [
         "image_filename"
       ],
@@ -4002,6 +4015,7 @@
       "label": "Canvas extension via outpainting",
       "kind": "image",
       "model_family": "generic",
+      "target_class": "ImagePadForOutpaint",
       "input_slots": [
         "image_filename"
       ],
@@ -4081,6 +4095,7 @@
       "label": "Complete old photo restoration: upscale + face enhance + sharpen",
       "kind": "other",
       "model_family": "sdxl",
+      "target_class": "ReActorRestoreFace",
       "input_slots": [
         "image_filename"
       ],
@@ -4131,6 +4146,7 @@
       "label": "Photobooth: generate passport-style headshots with extreme character fidelity",
       "kind": "other",
       "model_family": "sdxl",
+      "target_class": "ReActorFaceSwapOpt",
       "input_slots": [
         "ref_filename"
       ],
@@ -4303,7 +4319,7 @@
       "label": "Qwen Image Edit 2509 — instruction-driven edits via TextEncodeQwenImageEditPlus",
       "kind": "other",
       "model_family": "flux",
-      "target_class": "CFGNorm",
+      "target_class": "TextEncodeQwenImageEditPlus",
       "input_slots": [
         "image_filename",
         "image2_filename",
@@ -4568,7 +4584,7 @@
       "label": "SAM3 Extract — detect a subject, remove background",
       "kind": "detect",
       "model_family": "detect",
-      "target_class": "ImageCropByMask",
+      "target_class": "BiRefNetRMBG",
       "input_slots": [
         "image_filename"
       ],
@@ -4602,7 +4618,7 @@
       "label": "SAM3 Segment — detect a subject by text and return its mask",
       "kind": "detect",
       "model_family": "detect",
-      "target_class": "GrowMaskWithBlur",
+      "target_class": "SAM3Segment",
       "input_slots": [
         "image_filename"
       ],
@@ -4650,6 +4666,7 @@
       "label": "Build and save a ReActor face model. Drop-in for _build_save_face_model()",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "ReActorSaveFaceModel",
       "input_slots": [
         "source_filename"
       ],
@@ -4769,6 +4786,7 @@
       "label": "SeedVR2 AI video upscaler. Drop-in for _build_seedvr2_video_upscale()",
       "kind": "video",
       "model_family": "video",
+      "target_class": "SeedVR2VideoUpscaler",
       "input_slots": [
         "video_name"
       ],
@@ -4852,6 +4870,7 @@
       "label": "Style transfer via IPAdapter. Drop-in for _build_style_transfer()",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "IPAdapterAdvanced",
       "input_slots": [
         "target_filename",
         "style_ref_filename"
@@ -4962,6 +4981,7 @@
       "label": "SUPIR AI restoration - specialized 5-stage restoration pipeline",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "SUPIR_sample",
       "input_slots": [
         "image_filename"
       ],
@@ -5073,6 +5093,7 @@
       "label": "Super-resolution upscaling using a trained upscaler model",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "UpscaleModelLoader",
       "input_slots": [
         "image_filename"
       ],
@@ -5100,6 +5121,7 @@
       "label": "Upscale using two models and blend the results",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "UpscaleModelLoader",
       "input_slots": [
         "image_filename"
       ],
@@ -5136,6 +5158,7 @@
       "label": "Upscale + face swap a video. Drop-in for _build_video_reactor()",
       "kind": "video",
       "model_family": "video",
+      "target_class": "ReActorFaceSwapOpt",
       "input_slots": [
         "video_name"
       ],
@@ -5188,6 +5211,7 @@
       "label": "Upscale video. Drop-in for _build_video_upscale()",
       "kind": "video",
       "model_family": "video",
+      "target_class": "TS_Video_Upscale_With_Model",
       "input_slots": [
         "video_name"
       ],
@@ -5226,6 +5250,7 @@
       "label": "Wan 2.2 text-to-video — the T2V sibling of `build_wan_video`",
       "kind": "video",
       "model_family": "wan",
+      "target_class": "Wan22ImageToVideoLatent",
       "input_slots": [],
       "params": [
         {
@@ -5283,7 +5308,7 @@
       "label": "WAN 2.2 Animate — character animation via the native",
       "kind": "video",
       "model_family": "wan",
-      "target_class": "VHS_LoadVideoPath",
+      "target_class": "WanAnimateToVideo",
       "input_slots": [
         "reference_image",
         "clip_vision_image"
@@ -5429,6 +5454,7 @@
       "label": "Thin wrapper: delegates to build_wan_video with end_image_filename",
       "kind": "video",
       "model_family": "wan",
+      "target_class": "WanFirstLastFrameToVideo",
       "input_slots": [],
       "params": [
         {
@@ -5464,7 +5490,7 @@
       "label": "WAN 2.2 frame-by-frame video generation with dual-model architecture",
       "kind": "video",
       "model_family": "wan",
-      "target_class": "SkipLayerGuidanceSD3",
+      "target_class": "WanImageToVideo",
       "input_slots": [
         "image_filename",
         "ip_adapter_image",
@@ -5932,6 +5958,7 @@
       "label": "WaveSpeed AI upscale — fast one-node upscale to 2K/4K/8K",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "WavespeedImageUpscaleNode",
       "input_slots": [
         "image_filename"
       ],

--- a/plugins/gimp/comfyui-connector/spellcaster_core/builders_manifest.json
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/builders_manifest.json
@@ -271,6 +271,7 @@
       "label": "Text-to-image generation with ControlNet spatial constraint",
       "kind": "other",
       "model_family": "sdxl",
+      "target_class": "ControlNetApplyAdvanced",
       "input_slots": [
         "image_filename"
       ],
@@ -551,6 +552,7 @@
       "label": "Restore faces. Drop-in for _build_face_restore()",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "ReActorRestoreFace",
       "input_slots": [
         "image_filename"
       ],
@@ -610,6 +612,7 @@
       "label": "IPAdapter FaceID img2img. Drop-in for _build_faceid_img2img()",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "IPAdapterFaceID",
       "input_slots": [
         "target_filename",
         "face_ref_filename"
@@ -700,6 +703,7 @@
       "label": "Faceswap",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "ReActorFaceSwapOpt",
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -774,6 +778,7 @@
       "label": "ReActor face swap using a saved face model. Drop-in for _build_faceswap_model()",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "ReActorFaceSwapOpt",
       "input_slots": [
         "target_filename"
       ],
@@ -846,6 +851,7 @@
       "label": "Face swap using mtb facetools. Drop-in for _build_faceswap_mtb()",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "Face Swap (mtb)",
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -885,6 +891,7 @@
       "label": "Assemble a list of uploaded frame images into a single MP4 video",
       "kind": "other",
       "model_family": "video",
+      "target_class": "VHS_VideoCombine",
       "input_slots": [
         "frame_filenames"
       ],
@@ -1571,6 +1578,7 @@
       "label": "IC-Light relighting: adjust light sources and illumination",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "LoadAndApplyICLightUnet",
       "input_slots": [
         "image_filename"
       ],
@@ -1769,7 +1777,7 @@
       "label": "Inpainting: regenerate masked region using diffusion",
       "kind": "image",
       "model_family": "generic",
-      "target_class": "ImageCompositeMasked",
+      "target_class": "SetLatentNoiseMask",
       "input_slots": [
         "image_filename",
         "mask_filename"
@@ -1870,6 +1878,7 @@
       "label": "Fooocus-style inpaint: LaMa pre-fill + Fooocus head LoRA on SDXL",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "INPAINT_ApplyFooocusInpaint",
       "input_slots": [
         "image_filename",
         "mask_filename"
@@ -2016,7 +2025,7 @@
       "label": "Klein batch variations — N Klein renders from one reference in a single pass",
       "kind": "image",
       "model_family": "klein",
-      "target_class": "ImageFromBatch",
+      "target_class": "Flux2KleinEnhancer",
       "input_slots": [
         "image_filename"
       ],
@@ -2215,7 +2224,7 @@
       "label": "Klein Detail Enhancer — detect ANY region and re-generate at high detail",
       "kind": "image",
       "model_family": "klein",
-      "target_class": "GrowMaskWithBlur",
+      "target_class": "FaceDetailer",
       "input_slots": [
         "image_filename"
       ],
@@ -2472,6 +2481,7 @@
       "label": "Head swap with Klein Flux2 refinement",
       "kind": "image",
       "model_family": "klein",
+      "target_class": "IdentityFeatureTransfer",
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -3029,6 +3039,7 @@
       "label": "Klein Re-poser: change character pose using ReferenceLatent + BasicScheduler",
       "kind": "image",
       "model_family": "klein",
+      "target_class": "IdentityFeatureTransfer",
       "input_slots": [
         "image_filename"
       ],
@@ -3114,7 +3125,7 @@
       "label": "Klein SAM3 Inpaint — detect a region by text and inpaint it",
       "kind": "detect",
       "model_family": "klein",
-      "target_class": "ImageCropByMask",
+      "target_class": "SAM3Segment",
       "input_slots": [
         "image_filename",
         "ref_filename"
@@ -3273,7 +3284,7 @@
       "label": "Klein Virtual Try-On — 4-reference photoshoot composition",
       "kind": "image",
       "model_family": "klein",
-      "target_class": "EmptyLatentImage",
+      "target_class": "ReferenceLatent",
       "input_slots": [
         "face_filename"
       ],
@@ -3384,6 +3395,7 @@
       "label": "Object removal via LaMa inpainting (no diffusion)",
       "kind": "other",
       "model_family": "detect",
+      "target_class": "LamaRemover",
       "input_slots": [
         "image_filename",
         "mask_filename"
@@ -3434,6 +3446,7 @@
       "label": "Blend two images with adjustable opacity and blend mode",
       "kind": "other",
       "model_family": "detect",
+      "target_class": "ImageBlend",
       "input_slots": [
         "image_a_filename",
         "image_b_filename"
@@ -3468,7 +3481,7 @@
       "label": "LTX Video 2.3 generation — text-to-video or image-to-video",
       "kind": "video",
       "model_family": "ltx",
-      "target_class": "CFGZeroStar",
+      "target_class": "LTXVBaseSampler",
       "input_slots": [
         "image_filename"
       ],
@@ -3625,7 +3638,7 @@
       "label": "Lumina-Image 2.0 (Alpha-VLLM, 2024-12) text-to-image",
       "kind": "image",
       "model_family": "lumina2",
-      "target_class": "SaveImage",
+      "target_class": "CLIPTextEncodeLumina2",
       "input_slots": [],
       "params": [
         {
@@ -3769,7 +3782,7 @@
       "label": "Magic Eraser — SAM3 detect + LaMa inpaint",
       "kind": "image",
       "model_family": "detect",
-      "target_class": "GrowMaskWithBlur",
+      "target_class": "LamaRemover",
       "input_slots": [
         "image_filename"
       ],
@@ -4002,6 +4015,7 @@
       "label": "Canvas extension via outpainting",
       "kind": "image",
       "model_family": "generic",
+      "target_class": "ImagePadForOutpaint",
       "input_slots": [
         "image_filename"
       ],
@@ -4081,6 +4095,7 @@
       "label": "Complete old photo restoration: upscale + face enhance + sharpen",
       "kind": "other",
       "model_family": "sdxl",
+      "target_class": "ReActorRestoreFace",
       "input_slots": [
         "image_filename"
       ],
@@ -4131,6 +4146,7 @@
       "label": "Photobooth: generate passport-style headshots with extreme character fidelity",
       "kind": "other",
       "model_family": "sdxl",
+      "target_class": "ReActorFaceSwapOpt",
       "input_slots": [
         "ref_filename"
       ],
@@ -4303,7 +4319,7 @@
       "label": "Qwen Image Edit 2509 — instruction-driven edits via TextEncodeQwenImageEditPlus",
       "kind": "other",
       "model_family": "flux",
-      "target_class": "CFGNorm",
+      "target_class": "TextEncodeQwenImageEditPlus",
       "input_slots": [
         "image_filename",
         "image2_filename",
@@ -4568,7 +4584,7 @@
       "label": "SAM3 Extract — detect a subject, remove background",
       "kind": "detect",
       "model_family": "detect",
-      "target_class": "ImageCropByMask",
+      "target_class": "BiRefNetRMBG",
       "input_slots": [
         "image_filename"
       ],
@@ -4602,7 +4618,7 @@
       "label": "SAM3 Segment — detect a subject by text and return its mask",
       "kind": "detect",
       "model_family": "detect",
-      "target_class": "GrowMaskWithBlur",
+      "target_class": "SAM3Segment",
       "input_slots": [
         "image_filename"
       ],
@@ -4650,6 +4666,7 @@
       "label": "Build and save a ReActor face model. Drop-in for _build_save_face_model()",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "ReActorSaveFaceModel",
       "input_slots": [
         "source_filename"
       ],
@@ -4769,6 +4786,7 @@
       "label": "SeedVR2 AI video upscaler. Drop-in for _build_seedvr2_video_upscale()",
       "kind": "video",
       "model_family": "video",
+      "target_class": "SeedVR2VideoUpscaler",
       "input_slots": [
         "video_name"
       ],
@@ -4852,6 +4870,7 @@
       "label": "Style transfer via IPAdapter. Drop-in for _build_style_transfer()",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "IPAdapterAdvanced",
       "input_slots": [
         "target_filename",
         "style_ref_filename"
@@ -4962,6 +4981,7 @@
       "label": "SUPIR AI restoration - specialized 5-stage restoration pipeline",
       "kind": "image",
       "model_family": "sdxl",
+      "target_class": "SUPIR_sample",
       "input_slots": [
         "image_filename"
       ],
@@ -5073,6 +5093,7 @@
       "label": "Super-resolution upscaling using a trained upscaler model",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "UpscaleModelLoader",
       "input_slots": [
         "image_filename"
       ],
@@ -5100,6 +5121,7 @@
       "label": "Upscale using two models and blend the results",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "UpscaleModelLoader",
       "input_slots": [
         "image_filename"
       ],
@@ -5136,6 +5158,7 @@
       "label": "Upscale + face swap a video. Drop-in for _build_video_reactor()",
       "kind": "video",
       "model_family": "video",
+      "target_class": "ReActorFaceSwapOpt",
       "input_slots": [
         "video_name"
       ],
@@ -5188,6 +5211,7 @@
       "label": "Upscale video. Drop-in for _build_video_upscale()",
       "kind": "video",
       "model_family": "video",
+      "target_class": "TS_Video_Upscale_With_Model",
       "input_slots": [
         "video_name"
       ],
@@ -5226,6 +5250,7 @@
       "label": "Wan 2.2 text-to-video — the T2V sibling of `build_wan_video`",
       "kind": "video",
       "model_family": "wan",
+      "target_class": "Wan22ImageToVideoLatent",
       "input_slots": [],
       "params": [
         {
@@ -5283,7 +5308,7 @@
       "label": "WAN 2.2 Animate — character animation via the native",
       "kind": "video",
       "model_family": "wan",
-      "target_class": "VHS_LoadVideoPath",
+      "target_class": "WanAnimateToVideo",
       "input_slots": [
         "reference_image",
         "clip_vision_image"
@@ -5429,6 +5454,7 @@
       "label": "Thin wrapper: delegates to build_wan_video with end_image_filename",
       "kind": "video",
       "model_family": "wan",
+      "target_class": "WanFirstLastFrameToVideo",
       "input_slots": [],
       "params": [
         {
@@ -5464,7 +5490,7 @@
       "label": "WAN 2.2 frame-by-frame video generation with dual-model architecture",
       "kind": "video",
       "model_family": "wan",
-      "target_class": "SkipLayerGuidanceSD3",
+      "target_class": "WanImageToVideo",
       "input_slots": [
         "image_filename",
         "ip_adapter_image",
@@ -5932,6 +5958,7 @@
       "label": "WaveSpeed AI upscale — fast one-node upscale to 2K/4K/8K",
       "kind": "image",
       "model_family": "detect",
+      "target_class": "WavespeedImageUpscaleNode",
       "input_slots": [
         "image_filename"
       ],

--- a/tools/build_builders_manifest.py
+++ b/tools/build_builders_manifest.py
@@ -263,18 +263,121 @@ def _bucket_for(name: str) -> str:
 # override here AND verifying _infer_target_class() agrees (the
 # generator's CI mode flags drift between the two).
 
+# ---------------------------------------------------------------------------
+# Override table contract — read before adding entries
+# ---------------------------------------------------------------------------
+#
+# Each builder gets ONE workhorse class — the most distinctive ComfyUI
+# class_type whose absence on the user's install means this builder
+# cannot produce useful output. The C-side gate (
+# gimp_ai_comfy_method_target_class() in Voodoomancer) checks
+# /object_info for this class_type to decide whether to advertise the
+# method to GIMP at startup.
+#
+# Picking the right class for a multi-stage builder:
+#   1. SINGLE-WORKHORSE pipelines (rembg, lama_remove, supir, iclight,
+#      faceswap...) — pick the dominant operation node, NOT a generic
+#      loader (CheckpointLoaderSimple, SaveImage, VAEDecode etc.).
+#   2. MULTI-STAGE WITH SPECIFIC NODES (photobooth, magic_eraser,
+#      detail_hallucinate...) — pick the rarest custom-pack class in
+#      the pipeline (it's the most likely to be missing).
+#   3. GENERIC ARCH-UNIVERSAL (txt2img, img2img, klein_img2img,
+#      detail_hallucinate without upscale, klein_inpaint...) — these
+#      run on any sdxl/flux/klein arch and the only "gate" is the
+#      MODEL FILE not a node class. Leave null + document below; the
+#      C-side falls back to its hand-coded handler (Case-C).
+#   4. WRONG AUTO-INFERENCES — when _infer_target_class() walks a
+#      builder and surfaces the LAST `_add("X", ...)` call that
+#      happens to be GrowMaskWithBlur / SaveImage / ImageCropByMask /
+#      EmptyLatentImage / similar tail-of-graph node, add an override
+#      here pointing to the actual workhorse. The AST heuristic is
+#      good for 3-node graphs (rembg, depth_map_v3, color_match) but
+#      blind for anything with optional branches.
+#
+# Methods deliberately LEFT NULL — read these before re-adding any:
+#
+#   txt2img, img2img — arch-universal generic diffusion; gate is the
+#      model file, not a node class. C-side handles via Case-C.
+#   klein_img2img, klein_img2img_ref, klein_scene_img2img,
+#      klein_refine — pure Klein-flavored generic flux2 pipelines.
+#      The Klein-specific nodes (Flux2KleinEnhancer family) are only
+#      wired when `enhance=True`; the workhorse classes
+#      (SamplerCustomAdvanced / ReferenceLatent / CFGGuider) are
+#      shared with every other Flux/SDXL builder. Gate is the
+#      Klein model checkpoint file presence, not a node class.
+#   klein_inpaint — Klein-flavored inpaint; same arch-gating story.
+#      The distinguishing node (DifferentialDiffusion) is OPTIONAL.
+#   detail_hallucinate, seedv2r, colorize — multi-stage img2img with
+#      optional pre/post stages but the sampler core is the same
+#      generic Flux/SDXL pipeline. The optional nodes
+#      (UpscaleModelLoader for detail_hallucinate, LineArtPreprocessor
+#      for colorize) ARE relevant gates but only fire conditionally,
+#      so the manifest can't truthfully advertise them.
+#   pulid_flux — bifurcates between Flux1's ApplyPulidFlux and Flux2's
+#      ApplyPuLIDFlux2 at runtime based on the model arg. Without
+#      knowing which the caller will request, neither is a safe gate.
+#      C-side falls back to Case-C and the helper subprocess probes.
+
 _TARGET_CLASS_OVERRIDES: dict[str, str] = {
-    # Dispatcher-relevant single-class detect/generic builders. These are
-    # the methods Voodoomancer's manifest_node_map[] dispatches via the
-    # generic LoadImage -> Builder -> SaveImage path (PoC scope).
-    "color_match":      "ColorMatch",
-    "depth_map_v3":     "DepthAnything_V3",
-    "normal_map":       "NormalCrafterNode",
-    "rembg":            "Image Rembg (Remove Background)",
-    "rembg_birefnet":   "BiRefNetRMBG",
-    "rembg_v3":         "RMBG",
-    "ddcolor":          "DDColor_Colorize",
-    "lut":              "ImageApplyLUT+",
+    # ── Detect-family single-class builders (Wave 4 baseline) ───────────
+    "color_match":              "ColorMatch",
+    "depth_map_v3":             "DepthAnything_V3",
+    "normal_map":               "NormalCrafterNode",
+    "rembg":                    "Image Rembg (Remove Background)",
+    "rembg_birefnet":           "BiRefNetRMBG",
+    "rembg_v3":                 "RMBG",
+    "ddcolor":                  "DDColor_Colorize",
+    "lut":                      "ImageApplyLUT+",
+
+    # ── Wave 5 backfill: single-workhorse multi-stage builders ──────────
+    "controlnet_gen":           "ControlNetApplyAdvanced",
+    "face_restore":             "ReActorRestoreFace",
+    "faceid_img2img":           "IPAdapterFaceID",
+    "faceswap":                 "ReActorFaceSwapOpt",
+    "faceswap_model":           "ReActorFaceSwapOpt",
+    "faceswap_mtb":             "Face Swap (mtb)",
+    "frame_assembly":           "VHS_VideoCombine",
+    "iclight":                  "LoadAndApplyICLightUnet",
+    "inpaint_fooocus":          "INPAINT_ApplyFooocusInpaint",
+    "klein_headswap":           "IdentityFeatureTransfer",
+    "klein_repose":             "IdentityFeatureTransfer",
+    "lama_remove":              "LamaRemover",
+    "layer_blend":              "ImageBlend",
+    "outpaint":                 "ImagePadForOutpaint",
+    "photo_restore":            "ReActorRestoreFace",
+    "photobooth":               "ReActorFaceSwapOpt",
+    "save_face_model":          "ReActorSaveFaceModel",
+    "seedvr2_video_upscale":    "SeedVR2VideoUpscaler",
+    "style_transfer":           "IPAdapterAdvanced",
+    "supir":                    "SUPIR_sample",
+    "upscale":                  "UpscaleModelLoader",
+    "upscale_blend":            "UpscaleModelLoader",
+    "video_reactor":            "ReActorFaceSwapOpt",
+    "video_upscale":            "TS_Video_Upscale_With_Model",
+    "wan22_t2v":                "Wan22ImageToVideoLatent",
+    "wan_flf":                  "WanFirstLastFrameToVideo",
+    "wavespeed_upscale":        "WavespeedImageUpscaleNode",
+
+    # ── Wave 5 cleanup: fix wrong AST auto-inferences ───────────────────
+    # _infer_target_class() walks every _add() in textual order and
+    # returns the LAST hit. For builders with optional tail nodes
+    # (GrowMaskWithBlur, ImageCropByMask, SaveImage) the AST surfaces
+    # the wrong workhorse. Hand-corrected against live workflows.py.
+    "inpaint":                  "SetLatentNoiseMask",
+    "klein_batch_variations":   "Flux2KleinEnhancer",
+    "klein_detail":             "FaceDetailer",
+    "klein_face_detail":        "FaceDetailer",
+    "klein_generate_object":    "BiRefNetRMBG",
+    "klein_sam3_inpaint":       "SAM3Segment",
+    "klein_virtual_tryon":      "ReferenceLatent",
+    "ltx_video":                "LTXVBaseSampler",
+    "lumina2_txt2img":          "CLIPTextEncodeLumina2",
+    "magic_eraser":             "LamaRemover",
+    "qwen_edit":                "TextEncodeQwenImageEditPlus",
+    "sam3_extract":             "BiRefNetRMBG",
+    "sam3_segment":             "SAM3Segment",
+    "wan_animate_video":        "WanAnimateToVideo",
+    "wan_video":                "WanImageToVideo",
 }
 
 


### PR DESCRIPTION
## Summary

PR #40 shipped manifest v2 with `target_class` populated for 35 of 73 methods via the AST-walks-direct-`_add` heuristic + a small override table. The remaining 38 are multi-stage builders (klein/sdxl/wan/flux/etc.) that delegate every node call through NodeFactory helpers, so the heuristic returned None.

This pass hand-curates the override table against live `workflows.py`:

- **27 new `target_class` entries** for multi-stage builders with a clearly distinctive workhorse node (`ReActorFaceSwapOpt`, `LoadAndApplyICLightUnet`, `LamaRemover`, `IPAdapterAdvanced`, `WanAnimateToVideo`, etc.).
- **11 corrections** for wrong AST auto-inferences where the heuristic walked past the workhorse and surfaced a tail node (`GrowMaskWithBlur`, `SaveImage`, `ImageCropByMask`, `ImageCompositeMasked`, `SkipLayerGuidanceSD3`). Notable fixes: `wan_video` SkipLayerGuidanceSD3 -> WanImageToVideo, `lumina2_txt2img` SaveImage -> CLIPTextEncodeLumina2, `inpaint` ImageCompositeMasked -> SetLatentNoiseMask.
- **11 deliberately null** — arch-universal generic-diffusion pipelines whose gating is the model file, not a node class. Documented in the override-table header comment.

Final coverage: **62 / 73 methods (was 35 / 73)**.

### Methods left null (Case-C, hand-coded handler on C-side)

`txt2img`, `img2img`, `klein_img2img`, `klein_img2img_ref`, `klein_scene_img2img`, `klein_refine`, `klein_inpaint`, `colorize`, `detail_hallucinate`, `seedv2r`, `pulid_flux`

Reason: these run on any sdxl/flux/klein arch and the only meaningful gate is the model file (the in-pipeline classes — SamplerCustomAdvanced, ReferenceLatent, CFGGuider — are shared with every other diffusion builder, so target_class would advertise capability the C-side cannot truthfully verify). `pulid_flux` additionally bifurcates between Flux1's `ApplyPulidFlux` and Flux2's `ApplyPuLIDFlux2` at runtime based on the model arg.

### Verification

- Every new `target_class` value is a literal class name found in `workflows.py` + `node_factory.py` (machine-verified, 62/62).
- `tests/builders_manifest_drift.py` -> manifest fresh (73 methods).
- `tests/mirror_drift.py` -> 26/26 files byte-identical across both surfaces.
- `tests/cross_repo_drift.py` -> drift=0 missing=0.
- `tests/test_dynamic_dispatch.py` -> 30 passed, 1 skipped.

## Test plan

- [ ] Voodoomancer C-side (PR #62 consumer) gates the 27 newly-populated methods on their workhorse class_type instead of falling through to Case-C.
- [ ] No regressions in the 11 corrected entries (the static `manifest_node_map[]` fallback covered some of these correctly; the manifest now wins via SSoT and should agree).
- [ ] Methods left null behave identically to pre-PR (Voodoomancer falls back to hand-coded handler).

Generated with [Claude Code](https://claude.com/claude-code)