### PR TITLE
fix(caps): align Klein/Flux model_family with arch_registry keys

### DIFF
--- a/comfyui-spellcaster/spellcaster_core/builders_manifest.json
+++ b/comfyui-spellcaster/spellcaster_core/builders_manifest.json
@@ -1943,7 +1943,7 @@
       "builder": "build_klein_auto_inpaint",
       "label": "Klein Auto-Inpaint — describe what to mask, then inpaint it",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "VAEEncodeForInpaint",
       "input_slots": [
         "image_filename"
@@ -2024,7 +2024,7 @@
       "builder": "build_klein_batch_variations",
       "label": "Klein batch variations — N Klein renders from one reference in a single pass",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "Flux2KleinEnhancer",
       "input_slots": [
         "image_filename"
@@ -2095,7 +2095,7 @@
       "builder": "build_klein_blend",
       "label": "Klein Blend: composite foreground onto background, then harmonize with Klein",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "AILab_ImageCombiner",
       "input_slots": [],
       "params": [
@@ -2188,7 +2188,7 @@
       "builder": "build_klein_color_match",
       "label": "Color-match a generated image to a reference photo",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "ColorMatchV2",
       "input_slots": [
         "target_filename",
@@ -2223,7 +2223,7 @@
       "builder": "build_klein_detail",
       "label": "Klein Detail Enhancer — detect ANY region and re-generate at high detail",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "FaceDetailer",
       "input_slots": [
         "image_filename"
@@ -2314,7 +2314,7 @@
       "builder": "build_klein_face_detail",
       "label": "Klein Face Detailer — detect faces and re-generate them at high detail",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "FaceDetailer",
       "input_slots": [
         "image_filename"
@@ -2401,7 +2401,7 @@
       "builder": "build_klein_generate_object",
       "label": "Klein Object Generator — generate any object/person as a transparent layer",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "BiRefNetRMBG",
       "input_slots": [],
       "params": [
@@ -2480,7 +2480,7 @@
       "builder": "build_klein_headswap",
       "label": "Head swap with Klein Flux2 refinement",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "IdentityFeatureTransfer",
       "input_slots": [
         "target_filename",
@@ -2592,7 +2592,7 @@
       "builder": "build_klein_img2img",
       "label": "Image-to-image with Flux 2 Klein (distilled fast model)",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "input_slots": [
         "image_filename"
       ],
@@ -2697,7 +2697,7 @@
       "builder": "build_klein_img2img_ref",
       "label": "Klein img2img with separate reference image",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "input_slots": [
         "image_filename",
         "ref_filename"
@@ -2818,7 +2818,7 @@
       "builder": "build_klein_inpaint",
       "label": "Klein Inpaint: regenerate masked area using FluxGuidance + SetLatentNoiseMask",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "input_slots": [
         "image_filename",
         "mask_filename"
@@ -2968,7 +2968,7 @@
       "builder": "build_klein_refine",
       "label": "Klein Multi-Reference Refiner — enhance detail using structural references",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "input_slots": [
         "image_filename"
       ],
@@ -3038,7 +3038,7 @@
       "builder": "build_klein_repose",
       "label": "Klein Re-poser: change character pose using ReferenceLatent + BasicScheduler",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "IdentityFeatureTransfer",
       "input_slots": [
         "image_filename"
@@ -3124,7 +3124,7 @@
       "builder": "build_klein_sam3_inpaint",
       "label": "Klein SAM3 Inpaint — detect a region by text and inpaint it",
       "kind": "detect",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "SAM3Segment",
       "input_slots": [
         "image_filename",
@@ -3217,7 +3217,7 @@
       "builder": "build_klein_scene_img2img",
       "label": "Klein scene img2img: harmonize a composited scene",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "input_slots": [
         "image_filename"
       ],
@@ -3283,7 +3283,7 @@
       "builder": "build_klein_virtual_tryon",
       "label": "Klein Virtual Try-On — 4-reference photoshoot composition",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "ReferenceLatent",
       "input_slots": [
         "face_filename"
@@ -4232,7 +4232,7 @@
       "builder": "build_pulid_flux",
       "label": "PuLID Flux — auto-detects Flux1 vs Flux2 (Klein). Drop-in for _build_pulid_flux()",
       "kind": "other",
-      "model_family": "flux",
+      "model_family": "flux1dev",
       "input_slots": [
         "target_filename",
         "face_ref_filename"
@@ -4318,7 +4318,7 @@
       "builder": "build_qwen_edit",
       "label": "Qwen Image Edit 2509 — instruction-driven edits via TextEncodeQwenImageEditPlus",
       "kind": "other",
-      "model_family": "flux",
+      "model_family": "flux1dev",
       "target_class": "TextEncodeQwenImageEditPlus",
       "input_slots": [
         "image_filename",

--- a/tools/build_builders_manifest.py
+++ b/tools/build_builders_manifest.py
@@ -133,20 +133,47 @@ def _input_slot_kind(name: str) -> str | None:
 #
 # Patterns are matched against the bare builder name (no ``build_`` prefix).
 # Examples:
-#   build_klein_repose        → klein
-#   build_pulid_flux          → flux
+#   build_klein_repose        → flux2klein
+#   build_pulid_flux          → flux1dev
 #   build_inpaint_fooocus     → sdxl  (Fooocus head is SDXL-only)
 #   build_wan_video           → wan
 #   build_seedvr2_video_upscale → video
+#
+# 2026-05-15 family↔arch alignment fix (PR fix/klein-pulid-arch-key-
+# alignment): families MUST match the keys emitted by the antenna's
+# ``archs`` capabilities block (architectures.py registry keys:
+# ``flux2klein``, ``flux1dev``, ``flux_kontext``, ``chroma``,
+# ``illustrious``, ``pony``, ``sdxl``, ``sd15``, ``zit``, ``wan``,
+# ``ltx``, ``cogvideo``, ``hunyuan_video``, ``hunyuan_3d``, ``framepack``,
+# ``mochi``, ``lumina2``). The previous values ("klein", "flux") were
+# semantic aliases that never matched any arch key, so the
+# voodoomaster gate's ``archs_block.get(family)`` always returned None
+# for klein/pulid_flux builders that intentionally lacked a
+# ``target_class`` (the audit-documented "arch-universal generic flux
+# pipelines gated by model files, not node classes" set). That made
+# the 6 builders report supported=False even when both Klein and Flux1
+# archs were live. Aligning the family string with the arch key is the
+# minimum-blast-radius fix: the gate code is untouched, the manifest
+# field still labels the model family, and downstream consumers
+# (Krita dispatch, gen_menu_icons, gimp-ai-manifest.c) either match on
+# builder NAME or treat model_family as an opaque error-message label.
 _MODEL_FAMILY_PATTERNS: tuple[tuple[str, str], ...] = (
-    # Klein family (Flux2-Klein architecture, Spellcaster-named)
-    (r"^klein_", "klein"),
-    # Explicit arch markers
-    (r"^pulid_flux", "flux"),
-    (r"^flux_", "flux"),
-    (r"_flux$", "flux"),
-    (r"_flux_", "flux"),
-    (r"^qwen_edit", "flux"),  # qwen-image-edit shares the flux loader path
+    # Klein family (Flux2-Klein architecture, Spellcaster-named) — emit
+    # the architectures.py key directly so voodoomaster's per-method
+    # ``supported`` gate finds it in ``archs.flux2klein``.
+    (r"^klein_", "flux2klein"),
+    # Explicit arch markers — emit the canonical Flux1 arch key. PuLID-
+    # Flux bifurcates Flux1/Flux2 at runtime based on the model arg
+    # (manifest gate is the model file presence, not a node class), so
+    # tying it to ``flux1dev`` is honest: when Flux1 is available the
+    # builder is supported, and the Klein variant uses the dedicated
+    # klein_* builders anyway. qwen-image-edit shares the Flux1 loader
+    # path so it lands on the same arch.
+    (r"^pulid_flux", "flux1dev"),
+    (r"^flux_", "flux1dev"),
+    (r"_flux$", "flux1dev"),
+    (r"_flux_", "flux1dev"),
+    (r"^qwen_edit", "flux1dev"),
     # Video architectures (each one has dedicated loader nodes)
     (r"^wan22_t2v", "wan"),
     (r"^wan_animate", "wan"),


### PR DESCRIPTION
## Summary

Mirror of spellcaster_NSFW PR fix/klein-pulid-arch-key-alignment. Fixes audit-item #1 (2026-05-15): voodoomaster's ``/v1/capabilities`` gate reports 6 Klein-identity / PuLID-Flux builders as ``supported=False`` on installs where the underlying archs ARE supported.

## Root cause

The voodoomaster gate (``methods_block`` in ``voodoomaster/capabilities/builders_manifest.py``) keys per-method ``supported`` off ``archs_block.get(method["model_family"])`` when the method intentionally lacks a ``target_class`` (the documented "arch-universal generic flux pipelines" set). The antenna's archs-block keys come from ``architectures.py``: ``flux2klein`` and ``flux1dev``. This generator emitted ``klein`` / ``flux`` — never matching any arch key.

## Fix

Emit the arch-registry key as ``model_family``. Gate untouched. Downstream consumers either match on builder NAME or treat ``model_family`` as an opaque label.

## Schema

SFW pack stays on schema v2 (no per-method ``nsfw`` flag); the NSFW pack is the v3 SSoT. SFW-channel clients are unaffected because voodoomaster's NSFW gate (``is_nsfw_method``) fires BEFORE the arch check and returns True for any klein_* / faceswap / headswap builder regardless of family string.

## Test plan

- [ ] ``python tools/build_builders_manifest.py --check`` — manifest matches regen output
- [ ] Cross-check: ``tests/builders_manifest_drift.py`` (if present in CI) stays green
- [ ] Confirm SFW-channel callers don't accidentally see klein_* methods as ``supported=True`` (NSFW gate still fires first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)