### PR TITLE
feat(replay-bridge): per-character portrait consistency proxy helpers (audit #5)

### DIFF
--- a/_dev_docs/WHIMWEAVER_REPLAY_BRIDGE_PROPOSAL.md
+++ b/_dev_docs/WHIMWEAVER_REPLAY_BRIDGE_PROPOSAL.md
@@ -1,0 +1,267 @@
+# Whimweaver replay-value bridge surface — proposal
+
+Status: **proposal**, scaffolding shipped spellcaster-side only.
+Audit item: **#5** from the 2026-05-15 spellcaster audit.
+Authors: spellcaster master dev. Reviewers: whimweaver team.
+
+## Why this exists
+
+Whimweaver's characters have "infinite memory + HIGH replay value", so
+the same character will show up across many sessions and conversations.
+Today, every time a portrait of that character is regenerated we lose
+identity continuity: the face drifts, the wardrobe drifts, sometimes the
+gender drifts. Players notice. The audit flagged this as the biggest
+remaining replay-value blocker.
+
+The fix is a thin proxy surface on spellcaster's side that whimweaver
+can call to:
+
+1. recover the portrait history for a known character;
+2. pick the right identity-preserving builder (PuLID-Flux → Klein
+   img2img_ref → Klein headswap → Klein img2img → SDXL img2img) and
+   produce a ready-to-submit kwargs packet;
+3. promote one portrait to "canonical" so subsequent regenerations
+   always condition on the same anchor face.
+
+Critically, **whimweaver owns the reservoir on disk**. Spellcaster only
+reads and rewrites the JSONL files it points to. No portrait bytes are
+copied between repos — they live wherever whimweaver puts them and
+spellcaster gets paths.
+
+## Helper API
+
+All three helpers live in
+`comfyui-spellcaster/spellcaster_core/asset_gallery.py` so they ride
+along with the existing hash-indexed gallery import surface. They are
+re-exportable through whimweaver's existing
+`app.services.spellcaster_proxy` shim with no changes to that shim
+(PEP-562 module `__getattr__` already forwards arbitrary names through
+to `spellcaster_core.*`).
+
+### `get_character_portrait_history`
+
+```python
+def get_character_portrait_history(
+    character_id: str,
+    *,
+    reservoir_root,         # path-like; whimweaver owns its location
+    limit: int = 20,
+) -> list[dict]: ...
+```
+
+Returns a list of portrait records, newest first. Each record carries:
+
+| Field                | Type            | Notes |
+|----------------------|-----------------|-------|
+| `portrait_id`        | `str`           | unique within the character |
+| `image_path`         | `str`           | absolute path OR a gallery-hash `gallery://sha256:…` URI |
+| `builder`            | `str`           | the `build_*` name that produced it |
+| `model_family`       | `str`           | e.g. `flux2_klein`, `flux1_dev`, `sdxl` |
+| `prompt_seed`        | `int`           | seed used at generation |
+| `parent_portrait_id` | `str \| None`   | the reference portrait this one was conditioned on |
+| `generated_at`       | `float`         | unix ts |
+| `canonical`          | `bool`          | the seed portrait the consistency loop references |
+
+Returns `[]` when the reservoir file is missing — first-call safe.
+
+### `build_consistent_portrait_for_character`
+
+```python
+def build_consistent_portrait_for_character(
+    character_id: str,
+    prompt: str,
+    *,
+    reservoir_root,
+    builder_hint: str | None = None,
+    feature_caps: dict | None = None,    # /v1/capabilities payload
+) -> dict: ...
+```
+
+Returns:
+
+```python
+{
+  "builder": "build_pulid_flux",          # chosen builder name
+  "builder_args": {                       # kwargs whimweaver splats
+    "face_ref_filename": "...path...",
+    "prompt_text": "...",
+    "negative_text": "",
+    "seed": 1234,
+  },
+  "reference_portrait_id": "...",         # which past portrait we picked
+  "reference_image_path": "...path...",
+  "fallback_chain": [                     # builders considered, in order
+    "build_pulid_flux",
+    "build_klein_img2img_ref",
+    "build_klein_headswap",
+    "build_klein_img2img",
+    "build_sdxl_img2img",
+  ],
+}
+```
+
+Strategy:
+
+1. Read history. Pick the **canonical** portrait if one exists; else
+   pick the newest portrait; else `None`.
+2. Walk the builder preference order. Honor `builder_hint` when the
+   capability map allows it. Skip identity-preserving builders when no
+   reference is available.
+3. Translate to a kwargs packet. Seed defaults to the reference
+   portrait's seed so re-rolls converge.
+
+The helper does **not** submit to ComfyUI — that stays whimweaver's
+job through the existing proxy + submitter.
+
+### `mark_canonical_portrait`
+
+```python
+def mark_canonical_portrait(
+    character_id: str,
+    portrait_id: str,
+    *,
+    reservoir_root,
+) -> bool: ...
+```
+
+Sets `canonical=True` on the named portrait and `canonical=False` on
+every other portrait for the same character. Atomic rewrite via
+tempfile + `os.replace`. Returns `True` on success, `False` if the file
+or id is missing.
+
+## Proposed reservoir layout (whimweaver-owned)
+
+```
+<reservoir_root>/
+  <character_id>/
+    portraits.jsonl              # one record per line, append-only
+    blobs/                       # whimweaver-internal — spellcaster doesn't touch
+      <portrait_id>.png
+    notes.md                     # optional, whimweaver-owned
+```
+
+`portraits.jsonl` line schema (one JSON object per line):
+
+```json
+{
+  "portrait_id":        "p-2026-05-15-001",
+  "image_path":         "C:/whimweaver/.../blobs/p-2026-05-15-001.png",
+  "builder":            "build_pulid_flux",
+  "model_family":       "flux1_dev",
+  "prompt_seed":        1234,
+  "parent_portrait_id": null,
+  "generated_at":       1747353600.0,
+  "canonical":          true
+}
+```
+
+Append-only writes from whimweaver. Spellcaster only rewrites when
+flipping the `canonical` flag (atomic — via tempfile + `os.replace`).
+
+Crash safety: a half-written tail line is tolerated by the reader; a
+torn rewrite is impossible because we go through `os.replace`.
+
+## How whimweaver calls in
+
+Suggested `character_manager.py` integration sketch (whimweaver-side,
+not shipped here):
+
+```python
+from pathlib import Path
+from app.services import spellcaster_proxy as sc
+
+RESERVOIR_ROOT = Path(settings.whimweaver_data_dir) / "characters"
+
+
+def get_portrait_for_turn(character_id: str, scene_prompt: str) -> Path:
+    # 1) Ask spellcaster which builder to use.
+    plan = sc.build_consistent_portrait_for_character(
+        character_id=character_id,
+        prompt=scene_prompt,
+        reservoir_root=RESERVOIR_ROOT,
+        feature_caps=current_caps_cache(),
+    )
+
+    # 2) Resolve the actual builder and submit through the existing proxy.
+    builder_fn = getattr(sc, plan["builder"])
+    workflow   = builder_fn(**plan["builder_args"])
+    image_path = comfy_submitter.submit_and_collect(workflow)
+
+    # 3) Append the new portrait to the reservoir (whimweaver-owned writer).
+    portrait_id = f"p-{datetime.utcnow().strftime('%Y-%m-%d-%H%M%S')}"
+    append_portrait_record(
+        character_id, {
+            "portrait_id":        portrait_id,
+            "image_path":         str(image_path),
+            "builder":            plan["builder"],
+            "model_family":       resolve_family(plan["builder"]),
+            "prompt_seed":        plan["builder_args"].get("seed"),
+            "parent_portrait_id": plan["reference_portrait_id"],
+            "generated_at":       time.time(),
+            "canonical":          False,
+        },
+    )
+
+    # 4) First portrait ever → promote it to canonical.
+    if plan["reference_portrait_id"] is None:
+        sc.mark_canonical_portrait(
+            character_id, portrait_id, reservoir_root=RESERVOIR_ROOT
+        )
+
+    return image_path
+```
+
+## Identity-similarity test plan (follow-up)
+
+After whimweaver wires this in, we should land a smoke test that
+exercises continuity:
+
+1. Spin up a fresh character `ada-lovelace`.
+2. Drive a 3-turn conversation with the same character. At each turn,
+   call `get_portrait_for_turn(...)` with a different scene prompt.
+3. Run face-CLIP on the resulting 3 portraits. Assert that pairwise
+   similarity between portrait 1 ↔ 2 and 1 ↔ 3 is `> 0.85` (the
+   threshold the audit recommended).
+4. Repeat with `canonical` flipped to portrait 2 and verify the next
+   portrait pulls toward portrait 2 instead of portrait 1.
+
+This test belongs in whimweaver's repo (it owns the reservoir writer)
+but should import the spellcaster helpers via the proxy. We are NOT
+shipping it as part of this PR — that crosses the spellcaster-only
+scope of the audit item.
+
+## Open questions for the whimweaver team
+
+1. **Reservoir root** — is `<whimweaver_data_dir>/characters/` the
+   right home, or should this live under
+   `<whimweaver_data_dir>/replay/characters/` to leave room for other
+   per-character assets (voice, music, lore deltas)?
+2. **portrait_id format** — happy with the timestamp scheme above, or
+   do you want a content-hash so collisions are impossible across
+   parallel agents?
+3. **gallery URIs vs raw paths** — whimweaver currently stores raw
+   paths. Would you rather store `gallery://sha256:…` URIs and let
+   spellcaster's `AssetGallery` deduplicate? That would mean piping
+   bytes through `AssetGallery.put(...)` on every save.
+4. **Feature caps wiring** — whimweaver caches `/v1/capabilities`
+   somewhere already; can we agree on a function name on the
+   whimweaver side (e.g. `current_caps_cache()`) so the proxy call
+   doesn't have to round-trip HTTP on every portrait?
+5. **Canonical drift** — should we expose a helper that
+   auto-promotes a "better" portrait to canonical once we have N
+   variations and a face-CLIP score? Out of scope for this PR.
+6. **NSFW divergence** — `asset_gallery.py` is currently byte-identical
+   in `spellcaster` and `spellcaster_NSFW`. We're mirroring this change
+   into NSFW. If NSFW ever diverges these helpers should stay in sync.
+
+## Files touched
+
+- `comfyui-spellcaster/spellcaster_core/asset_gallery.py` — added the
+  three helpers + private support functions (~270 LOC).
+- `_dev_docs/WHIMWEAVER_REPLAY_BRIDGE_PROPOSAL.md` — this doc.
+
+Mirrored into `spellcaster_NSFW` at the same path so both ecosystems
+expose the same proxy surface.
+
+No whimweaver code changes. The audit constraint "No whimweaver code
+changes from spellcaster master" is respected.

--- a/comfyui-spellcaster/spellcaster_core/asset_gallery.py
+++ b/comfyui-spellcaster/spellcaster_core/asset_gallery.py
@@ -350,3 +350,318 @@ def _guess_ext(data: bytes, default: str = "bin") -> str:
     if stripped in (b"{", b"["):
         return "json"
     return default
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Whimweaver replay-value bridge surface (proxy helpers)
+# ────────────────────────────────────────────────────────────────────────
+#
+# These three helpers expose just enough of spellcaster's identity-
+# preserving pipeline for whimweaver's "infinite memory + HIGH replay
+# value" character system. Whimweaver owns the on-disk reservoir layout
+# (one JSONL per character at `<reservoir_root>/<character_id>/
+# portraits.jsonl`); these helpers only read/write that file.
+#
+# The functions are deliberately I/O-cheap and import-cheap — no ComfyUI
+# submission happens here. They return a builder-name + builder-kwargs
+# dict that whimweaver passes to its existing spellcaster_proxy +
+# ComfyUI submitter.
+#
+# See `_dev_docs/WHIMWEAVER_REPLAY_BRIDGE_PROPOSAL.md` for full schema +
+# integration notes.
+
+
+_PORTRAITS_FILENAME = "portraits.jsonl"
+
+
+# Builder routing order — best identity preservation first. We prefer
+# PuLID-Flux for face-locked generation, then Klein img2img_ref with
+# identity_lock=True, then Klein headswap, then plain Klein img2img,
+# then SDXL img2img as a last resort.
+_BUILDER_PREFERENCE: tuple[str, ...] = (
+    "build_pulid_flux",
+    "build_klein_img2img_ref",
+    "build_klein_headswap",
+    "build_klein_img2img",
+    "build_sdxl_img2img",
+)
+
+
+def _portraits_path(reservoir_root, character_id: str) -> str:
+    """Resolve the JSONL path for a character. `reservoir_root` may be a
+    Path or a str — we accept either to keep the proxy boundary thin."""
+    root = os.fspath(reservoir_root)
+    return os.path.join(root, character_id, _PORTRAITS_FILENAME)
+
+
+def _read_portrait_records(portraits_path: str) -> list[dict]:
+    """Load every JSON line. Skips blank/corrupt lines silently — the
+    whimweaver writer is append-only and a half-written tail line is
+    expected on crash."""
+    if not os.path.isfile(portraits_path):
+        return []
+    records: list[dict] = []
+    try:
+        with open(portraits_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except (json.JSONDecodeError, ValueError):
+                    # Tolerate one bad tail line (crash mid-write).
+                    continue
+    except OSError:
+        return []
+    return records
+
+
+def _write_portrait_records_atomic(portraits_path: str,
+                                   records: list[dict]) -> bool:
+    """Rewrite the JSONL atomically via tempfile + os.replace."""
+    parent = os.path.dirname(portraits_path)
+    try:
+        os.makedirs(parent, exist_ok=True)
+    except OSError:
+        return False
+    fd, tmp = tempfile.mkstemp(prefix=".tmp_portraits_", dir=parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            for r in records:
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+        os.replace(tmp, portraits_path)
+        return True
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return False
+
+
+def get_character_portrait_history(
+    character_id: str,
+    *,
+    reservoir_root,
+    limit: int = 20,
+) -> list[dict]:
+    """Return portrait records for a character, newest first.
+
+    Each record carries:
+      - portrait_id          (str, unique within the character)
+      - image_path           (str, abs path or gallery-hash:// URI)
+      - builder              (str, one of the build_* names)
+      - model_family         (str, e.g. "flux2_klein", "flux1_dev", "sdxl")
+      - prompt_seed          (int)
+      - parent_portrait_id   (str | None, points to the reference portrait
+                              this one was conditioned on)
+      - generated_at         (float, unix ts)
+      - canonical            (bool, the seed portrait for the consistency
+                              loop — there should be at most one True)
+
+    Returns [] when the reservoir file is missing or empty.
+    """
+    if not character_id:
+        return []
+    portraits_path = _portraits_path(reservoir_root, character_id)
+    records = _read_portrait_records(portraits_path)
+    records.sort(key=lambda r: r.get("generated_at", 0.0), reverse=True)
+    if limit > 0:
+        records = records[:limit]
+    return records
+
+
+def _pick_reference_portrait(records: list[dict]) -> dict | None:
+    """Return the portrait whimweaver should condition on:
+      1. The first record marked canonical=True (newest if multiple).
+      2. Otherwise the newest record overall.
+      3. None if records is empty."""
+    if not records:
+        return None
+    canonical = [r for r in records if r.get("canonical")]
+    if canonical:
+        canonical.sort(key=lambda r: r.get("generated_at", 0.0), reverse=True)
+        return canonical[0]
+    return records[0]  # newest by virtue of caller sorting
+
+
+def _builder_supported(builder: str, feature_caps: dict | None) -> bool:
+    """Cheap capability check. The /v1/capabilities payload exposes a
+    `builders` map (builder_name → {available: bool, ...}) per the
+    spellcaster manifest. We default to True when caps are absent so
+    proxy callers without /v1/capabilities still get a usable result."""
+    if not feature_caps:
+        return True
+    builders = feature_caps.get("builders") or {}
+    if not isinstance(builders, dict):
+        return True
+    entry = builders.get(builder)
+    if entry is None:
+        # Not listed = assume unavailable (caps was provided, builder
+        # missing means the host doesn't ship it).
+        return False
+    if isinstance(entry, dict):
+        return bool(entry.get("available", True))
+    return bool(entry)
+
+
+def build_consistent_portrait_for_character(
+    character_id: str,
+    prompt: str,
+    *,
+    reservoir_root,
+    builder_hint: str | None = None,
+    feature_caps: dict | None = None,
+) -> dict:
+    """Pick the best identity-preserving builder for this character and
+    return a submission packet for whimweaver to dispatch.
+
+    Returns a dict shaped like:
+        {
+          "builder":              "build_pulid_flux" | "build_klein_*" | ...,
+          "builder_args":         {kwargs ready to pass through proxy},
+          "reference_portrait_id": str | None,
+          "reference_image_path": str | None,
+          "fallback_chain":       [str, ...],   # builders considered, in order
+        }
+
+    `builder_hint` (optional) lets the caller force-prefer a specific
+    builder name — it is honored when feature_caps allow it, otherwise
+    we fall through the default preference order.
+
+    This function does NOT submit anything to ComfyUI. The caller is
+    expected to import `spellcaster_proxy.<builder>` and submit the
+    resulting workflow themselves.
+    """
+    if not character_id:
+        raise ValueError("character_id is required")
+    if not prompt:
+        raise ValueError("prompt is required")
+
+    history = get_character_portrait_history(
+        character_id, reservoir_root=reservoir_root, limit=20
+    )
+    ref = _pick_reference_portrait(history)
+    ref_id = ref.get("portrait_id") if ref else None
+    ref_path = ref.get("image_path") if ref else None
+
+    # Build the preference order. Honor builder_hint when supported.
+    pref: list[str] = list(_BUILDER_PREFERENCE)
+    if builder_hint and builder_hint in pref:
+        pref.remove(builder_hint)
+        pref.insert(0, builder_hint)
+
+    # If no reference image is on file, the identity-preserving builders
+    # have nothing to lock onto — fall back to plain image-to-image or
+    # text-to-image. We expose this via the chain anyway so the caller
+    # can decide.
+    if ref_path is None:
+        pref = [b for b in pref if b not in (
+            "build_pulid_flux",
+            "build_klein_img2img_ref",
+            "build_klein_headswap",
+        )]
+        if not pref:
+            pref = ["build_klein_img2img"]
+
+    # Pick the first builder the caps allow.
+    chosen: str | None = None
+    for b in pref:
+        if _builder_supported(b, feature_caps):
+            chosen = b
+            break
+    if chosen is None:
+        # Caps blocked everything in our preference order. Fall back to
+        # the most permissive option so callers can at least try.
+        chosen = pref[0]
+
+    builder_args = _builder_args_for(
+        chosen, prompt=prompt, ref_path=ref_path, ref=ref,
+    )
+
+    return {
+        "builder": chosen,
+        "builder_args": builder_args,
+        "reference_portrait_id": ref_id,
+        "reference_image_path": ref_path,
+        "fallback_chain": pref,
+    }
+
+
+def _builder_args_for(builder: str, *, prompt: str,
+                      ref_path: str | None, ref: dict | None) -> dict:
+    """Translate the chosen builder into a kwargs dict whimweaver can
+    splat onto the proxy call. We pass only minimal fields here — the
+    caller layers their own seed, model, lora, and dimension policy on
+    top. The seed (when ref exists) defaults to the reference portrait's
+    seed so re-rolls tend to converge."""
+    seed = (ref or {}).get("prompt_seed") if ref else None
+
+    if builder == "build_pulid_flux":
+        return {
+            "face_ref_filename": ref_path,
+            "prompt_text": prompt,
+            "negative_text": "",
+            "seed": seed,
+        }
+    if builder == "build_klein_img2img_ref":
+        return {
+            "ref_filename": ref_path,
+            "image_filename": ref_path,  # caller may override with a base
+            "prompt_text": prompt,
+            "seed": seed,
+            "identity_lock": True,
+        }
+    if builder == "build_klein_headswap":
+        return {
+            "target_filename": ref_path,  # caller usually overrides w/ new body
+            "source_filename": ref_path,
+            "prompt": prompt,
+            "seed": seed,
+            "use_identity_lock": True,
+        }
+    if builder == "build_klein_img2img":
+        return {
+            "image_filename": ref_path,
+            "prompt_text": prompt,
+            "seed": seed,
+        }
+    # SDXL fallback — caller wires the actual SDXL builder name in their
+    # workflows module if they want it; we expose a generic shape.
+    return {
+        "image_filename": ref_path,
+        "prompt_text": prompt,
+        "seed": seed,
+    }
+
+
+def mark_canonical_portrait(
+    character_id: str,
+    portrait_id: str,
+    *,
+    reservoir_root,
+) -> bool:
+    """Set canonical=True on the named portrait and canonical=False on
+    every other portrait for the same character.
+
+    Returns True when the target portrait_id was found and the file was
+    rewritten successfully; False otherwise (missing file, missing id,
+    or write failure)."""
+    if not character_id or not portrait_id:
+        return False
+    portraits_path = _portraits_path(reservoir_root, character_id)
+    records = _read_portrait_records(portraits_path)
+    if not records:
+        return False
+    found = False
+    for r in records:
+        if r.get("portrait_id") == portrait_id:
+            r["canonical"] = True
+            found = True
+        else:
+            if r.get("canonical"):
+                r["canonical"] = False
+    if not found:
+        return False
+    return _write_portrait_records_atomic(portraits_path, records)


### PR DESCRIPTION
## Summary

Spellcaster-side scaffolding for audit item #5 (2026-05-15): the **whimweaver replay-value bridge surface**. Adds 3 import-cheap, I/O-cheap helpers to `asset_gallery.py` that whimweaver will call to keep character portraits identity-consistent across infinite-memory replays.

- `get_character_portrait_history(character_id, *, reservoir_root, limit=20)` — newest-first portrait records (portrait_id, builder, seed, parent, canonical, ...). Empty list if reservoir missing.
- `build_consistent_portrait_for_character(character_id, prompt, *, reservoir_root, builder_hint=None, feature_caps=None)` — picks PuLID-Flux -> Klein img2img_ref -> Klein headswap -> Klein img2img -> SDXL img2img (capability-gated), returns `{builder, builder_args, reference_portrait_id, reference_image_path, fallback_chain}`. Does **not** submit to ComfyUI.
- `mark_canonical_portrait(character_id, portrait_id, *, reservoir_root)` — atomic JSONL rewrite (tempfile + `os.replace`), flips canonical=True on target and False everywhere else.

Whimweaver owns the on-disk reservoir layout — these helpers only read/rewrite the JSONL whimweaver points at. **No whimweaver code is touched** (audit constraint respected).

Design proposal in `_dev_docs/WHIMWEAVER_REPLAY_BRIDGE_PROPOSAL.md` covers the JSONL line schema, a concrete `character_manager.py` call sketch, the face-CLIP >0.85 follow-up test plan, and 6 open questions for the whimweaver team.

Mirrored byte-identically into `spellcaster_NSFW` (was already SHA-256-identical pre-PR).

## Test plan

- [x] 9-case local smoke suite: history sort + missing reservoir, default pulid pick against newest, caps gate skipping pulid, builder_hint honored, canonical flip + persistence + new-reference pickup, missing portrait_id => False, empty reservoir => skip identity builders -> klein_img2img.
- [x] `python -c "from spellcaster_core.asset_gallery import get_character_portrait_history, build_consistent_portrait_for_character, mark_canonical_portrait; print('OK')"` works in both SFW and NSFW trees.
- [ ] Face-CLIP >0.85 smoke across a 3-turn whimweaver convo — follow-up after whimweaver wires the helpers in (deliberately out of scope here per the audit).

Companion PR in `spellcaster_NSFW` mirrors the code-only change.

Atomic commits: 1 code, 1 doc.

Generated with Claude Code