### PR TITLE
feat(workflows): NSFW source-of-truth annotations (audit #4)

### DIFF
--- a/comfyui-spellcaster/spellcaster_core/builders_manifest.json
+++ b/comfyui-spellcaster/spellcaster_core/builders_manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "generator": "spellcaster/tools/build_builders_manifest.py",
   "source": "comfyui-spellcaster/spellcaster_core/workflows.py",
   "method_count": 73,
@@ -704,6 +704,7 @@
       "kind": "image",
       "model_family": "detect",
       "target_class": "ReActorFaceSwapOpt",
+      "nsfw": true,
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -779,6 +780,7 @@
       "kind": "image",
       "model_family": "detect",
       "target_class": "ReActorFaceSwapOpt",
+      "nsfw": true,
       "input_slots": [
         "target_filename"
       ],
@@ -852,6 +854,7 @@
       "kind": "image",
       "model_family": "detect",
       "target_class": "Face Swap (mtb)",
+      "nsfw": true,
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -1945,6 +1948,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "VAEEncodeForInpaint",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2026,6 +2030,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "Flux2KleinEnhancer",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2097,6 +2102,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "AILab_ImageCombiner",
+      "nsfw": true,
       "input_slots": [],
       "params": [
         {
@@ -2190,6 +2196,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "ColorMatchV2",
+      "nsfw": true,
       "input_slots": [
         "target_filename",
         "reference_filename"
@@ -2225,6 +2232,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "FaceDetailer",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2316,6 +2324,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "FaceDetailer",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2403,6 +2412,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "BiRefNetRMBG",
+      "nsfw": true,
       "input_slots": [],
       "params": [
         {
@@ -2482,6 +2492,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "IdentityFeatureTransfer",
+      "nsfw": true,
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -2593,6 +2604,7 @@
       "label": "Image-to-image with Flux 2 Klein (distilled fast model)",
       "kind": "image",
       "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2698,6 +2710,7 @@
       "label": "Klein img2img with separate reference image",
       "kind": "image",
       "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename",
         "ref_filename"
@@ -2819,6 +2832,7 @@
       "label": "Klein Inpaint: regenerate masked area using FluxGuidance + SetLatentNoiseMask",
       "kind": "image",
       "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename",
         "mask_filename"
@@ -2969,6 +2983,7 @@
       "label": "Klein Multi-Reference Refiner — enhance detail using structural references",
       "kind": "image",
       "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -3040,6 +3055,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "IdentityFeatureTransfer",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -3126,6 +3142,7 @@
       "kind": "detect",
       "model_family": "flux2klein",
       "target_class": "SAM3Segment",
+      "nsfw": true,
       "input_slots": [
         "image_filename",
         "ref_filename"
@@ -3218,6 +3235,7 @@
       "label": "Klein scene img2img: harmonize a composited scene",
       "kind": "image",
       "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -3285,6 +3303,7 @@
       "kind": "image",
       "model_family": "flux2klein",
       "target_class": "ReferenceLatent",
+      "nsfw": true,
       "input_slots": [
         "face_filename"
       ],

--- a/comfyui-spellcaster/spellcaster_core/workflows.py
+++ b/comfyui-spellcaster/spellcaster_core/workflows.py
@@ -209,6 +209,68 @@ except ImportError:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+#  NSFW source-of-truth — annotate methods at the source they live in
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# This module-level frozenset is the AUTHORITATIVE classification of which
+# ``build_*`` methods operate on NSFW content (explicit nudity, sexual
+# contexts, identity manipulation that the Voodoomaster ⇄ Voodoomancer
+# 2026-05-14 mandate categorises as NSFW-licensed).
+#
+# Why this lives in workflows.py and not in the manifest builder:
+# the builder code is the canonical home for the methods themselves, so
+# the NSFW label belongs next to the implementation it labels. Earlier
+# the classification lived as ``_NSFW_BUILDERS`` inside
+# ``tools/build_builders_manifest.py``; that table now defers to this
+# set (and falls back to its own local copy when this constant is
+# absent, so old SFW trees that haven't been mirrored still work).
+#
+# Mirror invariant: this constant MUST be byte-identical between the
+# spellcaster (SFW) and spellcaster_NSFW trees. The two workflows.py
+# files are mirrored by ``tests/mirror_drift.py`` within each repo and
+# by ``tests/cross_repo_drift.py`` across repos.
+#
+# Conservative policy: false-negatives leak NSFW methods through the
+# SFW channel — strictly worse than false-positives. When in doubt
+# about a new builder, tag it NSFW. The consumer-side heuristic in
+# ``voodoomaster/capabilities/builders_manifest.py:is_nsfw_method``
+# also acts as a SUPERSET safety net (Klein family + faceswap +
+# headswap), so a missed tag here is caught there.
+#
+# The 19 method ids below are the exact set surfaced by the live
+# ``/v1/capabilities`` gate (Voodoomaster on Theo, 2026-05-14), verified
+# against both the consumer heuristic and the producer's prior
+# ``_NSFW_BUILDERS`` table.
+
+NSFW_METHODS: frozenset[str] = frozenset({
+    # ── Klein family (Flux2 photoreal identity-preserving) ──────────────
+    # All klein_* builders are NSFW-licensed by design.
+    "build_klein_img2img",
+    "build_klein_img2img_ref",
+    "build_klein_inpaint",
+    "build_klein_refine",
+    "build_klein_scene_img2img",
+    "build_klein_color_match",
+    "build_klein_blend",
+    "build_klein_detail",
+    "build_klein_face_detail",
+    "build_klein_repose",
+    "build_klein_headswap",
+    "build_klein_virtual_tryon",
+    "build_klein_generate_object",
+    "build_klein_batch_variations",
+    "build_klein_auto_inpaint",
+    "build_klein_sam3_inpaint",
+    # ── Face / head identity manipulation ───────────────────────────────
+    # ReActor-family face swap + MTB faceswap. Any builder whose canonical
+    # job is replacing a face/head in a target image is NSFW-licensed.
+    "build_faceswap",
+    "build_faceswap_model",
+    "build_faceswap_mtb",
+})
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 #  SHARED CONSTANTS — Single source of truth for Klein / Flux2 / Studio
 # ═══════════════════════════════════════════════════════════════════════════
 

--- a/plugins/gimp/comfyui-connector/spellcaster_core/builders_manifest.json
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/builders_manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "generator": "spellcaster/tools/build_builders_manifest.py",
   "source": "comfyui-spellcaster/spellcaster_core/workflows.py",
   "method_count": 73,
@@ -704,6 +704,7 @@
       "kind": "image",
       "model_family": "detect",
       "target_class": "ReActorFaceSwapOpt",
+      "nsfw": true,
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -779,6 +780,7 @@
       "kind": "image",
       "model_family": "detect",
       "target_class": "ReActorFaceSwapOpt",
+      "nsfw": true,
       "input_slots": [
         "target_filename"
       ],
@@ -852,6 +854,7 @@
       "kind": "image",
       "model_family": "detect",
       "target_class": "Face Swap (mtb)",
+      "nsfw": true,
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -1943,8 +1946,9 @@
       "builder": "build_klein_auto_inpaint",
       "label": "Klein Auto-Inpaint — describe what to mask, then inpaint it",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "VAEEncodeForInpaint",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2024,8 +2028,9 @@
       "builder": "build_klein_batch_variations",
       "label": "Klein batch variations — N Klein renders from one reference in a single pass",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "Flux2KleinEnhancer",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2095,8 +2100,9 @@
       "builder": "build_klein_blend",
       "label": "Klein Blend: composite foreground onto background, then harmonize with Klein",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "AILab_ImageCombiner",
+      "nsfw": true,
       "input_slots": [],
       "params": [
         {
@@ -2188,8 +2194,9 @@
       "builder": "build_klein_color_match",
       "label": "Color-match a generated image to a reference photo",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "ColorMatchV2",
+      "nsfw": true,
       "input_slots": [
         "target_filename",
         "reference_filename"
@@ -2223,8 +2230,9 @@
       "builder": "build_klein_detail",
       "label": "Klein Detail Enhancer — detect ANY region and re-generate at high detail",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "FaceDetailer",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2314,8 +2322,9 @@
       "builder": "build_klein_face_detail",
       "label": "Klein Face Detailer — detect faces and re-generate them at high detail",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "FaceDetailer",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2401,8 +2410,9 @@
       "builder": "build_klein_generate_object",
       "label": "Klein Object Generator — generate any object/person as a transparent layer",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "BiRefNetRMBG",
+      "nsfw": true,
       "input_slots": [],
       "params": [
         {
@@ -2480,8 +2490,9 @@
       "builder": "build_klein_headswap",
       "label": "Head swap with Klein Flux2 refinement",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "IdentityFeatureTransfer",
+      "nsfw": true,
       "input_slots": [
         "target_filename",
         "source_filename"
@@ -2592,7 +2603,8 @@
       "builder": "build_klein_img2img",
       "label": "Image-to-image with Flux 2 Klein (distilled fast model)",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -2697,7 +2709,8 @@
       "builder": "build_klein_img2img_ref",
       "label": "Klein img2img with separate reference image",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename",
         "ref_filename"
@@ -2818,7 +2831,8 @@
       "builder": "build_klein_inpaint",
       "label": "Klein Inpaint: regenerate masked area using FluxGuidance + SetLatentNoiseMask",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename",
         "mask_filename"
@@ -2968,7 +2982,8 @@
       "builder": "build_klein_refine",
       "label": "Klein Multi-Reference Refiner — enhance detail using structural references",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -3038,8 +3053,9 @@
       "builder": "build_klein_repose",
       "label": "Klein Re-poser: change character pose using ReferenceLatent + BasicScheduler",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "IdentityFeatureTransfer",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -3124,8 +3140,9 @@
       "builder": "build_klein_sam3_inpaint",
       "label": "Klein SAM3 Inpaint — detect a region by text and inpaint it",
       "kind": "detect",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "SAM3Segment",
+      "nsfw": true,
       "input_slots": [
         "image_filename",
         "ref_filename"
@@ -3217,7 +3234,8 @@
       "builder": "build_klein_scene_img2img",
       "label": "Klein scene img2img: harmonize a composited scene",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
+      "nsfw": true,
       "input_slots": [
         "image_filename"
       ],
@@ -3283,8 +3301,9 @@
       "builder": "build_klein_virtual_tryon",
       "label": "Klein Virtual Try-On — 4-reference photoshoot composition",
       "kind": "image",
-      "model_family": "klein",
+      "model_family": "flux2klein",
       "target_class": "ReferenceLatent",
+      "nsfw": true,
       "input_slots": [
         "face_filename"
       ],
@@ -4232,7 +4251,7 @@
       "builder": "build_pulid_flux",
       "label": "PuLID Flux — auto-detects Flux1 vs Flux2 (Klein). Drop-in for _build_pulid_flux()",
       "kind": "other",
-      "model_family": "flux",
+      "model_family": "flux1dev",
       "input_slots": [
         "target_filename",
         "face_ref_filename"
@@ -4318,7 +4337,7 @@
       "builder": "build_qwen_edit",
       "label": "Qwen Image Edit 2509 — instruction-driven edits via TextEncodeQwenImageEditPlus",
       "kind": "other",
-      "model_family": "flux",
+      "model_family": "flux1dev",
       "target_class": "TextEncodeQwenImageEditPlus",
       "input_slots": [
         "image_filename",

--- a/plugins/gimp/comfyui-connector/spellcaster_core/workflows.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/workflows.py
@@ -209,6 +209,68 @@ except ImportError:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+#  NSFW source-of-truth — annotate methods at the source they live in
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# This module-level frozenset is the AUTHORITATIVE classification of which
+# ``build_*`` methods operate on NSFW content (explicit nudity, sexual
+# contexts, identity manipulation that the Voodoomaster ⇄ Voodoomancer
+# 2026-05-14 mandate categorises as NSFW-licensed).
+#
+# Why this lives in workflows.py and not in the manifest builder:
+# the builder code is the canonical home for the methods themselves, so
+# the NSFW label belongs next to the implementation it labels. Earlier
+# the classification lived as ``_NSFW_BUILDERS`` inside
+# ``tools/build_builders_manifest.py``; that table now defers to this
+# set (and falls back to its own local copy when this constant is
+# absent, so old SFW trees that haven't been mirrored still work).
+#
+# Mirror invariant: this constant MUST be byte-identical between the
+# spellcaster (SFW) and spellcaster_NSFW trees. The two workflows.py
+# files are mirrored by ``tests/mirror_drift.py`` within each repo and
+# by ``tests/cross_repo_drift.py`` across repos.
+#
+# Conservative policy: false-negatives leak NSFW methods through the
+# SFW channel — strictly worse than false-positives. When in doubt
+# about a new builder, tag it NSFW. The consumer-side heuristic in
+# ``voodoomaster/capabilities/builders_manifest.py:is_nsfw_method``
+# also acts as a SUPERSET safety net (Klein family + faceswap +
+# headswap), so a missed tag here is caught there.
+#
+# The 19 method ids below are the exact set surfaced by the live
+# ``/v1/capabilities`` gate (Voodoomaster on Theo, 2026-05-14), verified
+# against both the consumer heuristic and the producer's prior
+# ``_NSFW_BUILDERS`` table.
+
+NSFW_METHODS: frozenset[str] = frozenset({
+    # ── Klein family (Flux2 photoreal identity-preserving) ──────────────
+    # All klein_* builders are NSFW-licensed by design.
+    "build_klein_img2img",
+    "build_klein_img2img_ref",
+    "build_klein_inpaint",
+    "build_klein_refine",
+    "build_klein_scene_img2img",
+    "build_klein_color_match",
+    "build_klein_blend",
+    "build_klein_detail",
+    "build_klein_face_detail",
+    "build_klein_repose",
+    "build_klein_headswap",
+    "build_klein_virtual_tryon",
+    "build_klein_generate_object",
+    "build_klein_batch_variations",
+    "build_klein_auto_inpaint",
+    "build_klein_sam3_inpaint",
+    # ── Face / head identity manipulation ───────────────────────────────
+    # ReActor-family face swap + MTB faceswap. Any builder whose canonical
+    # job is replacing a face/head in a target image is NSFW-licensed.
+    "build_faceswap",
+    "build_faceswap_model",
+    "build_faceswap_mtb",
+})
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 #  SHARED CONSTANTS — Single source of truth for Klein / Flux2 / Studio
 # ═══════════════════════════════════════════════════════════════════════════
 

--- a/tools/build_builders_manifest.py
+++ b/tools/build_builders_manifest.py
@@ -260,6 +260,79 @@ def _bucket_for(name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# NSFW classification (schema v3) — sourced from workflows.NSFW_METHODS
+# ---------------------------------------------------------------------------
+#
+# Source-of-truth migration (2026-05-15, audit item #4): the NSFW
+# classification lives next to the builder methods themselves in
+# ``spellcaster_core.workflows.NSFW_METHODS``. This module simply
+# consults that constant. The local fallback table below is retained
+# as a SAFETY NET — it activates only when the workflows module is
+# missing the constant (old mirror, partial rebase, etc.) so a
+# producer running against a stale tree still emits a correct manifest.
+#
+# This is the SFW tree's mirror of the NSFW-tree producer logic. The
+# SFW manifest gains the ``nsfw: true`` tags for the 19 NSFW-licensed
+# builders so cross-repo consumers see a consistent wire shape
+# regardless of which channel served the manifest. The consumer-side
+# gate decides whether to honour the tag (block / allow) per channel.
+#
+# Conservative policy: false-negatives leak NSFW methods through the
+# SFW channel — strictly worse than false-positives. When in doubt
+# about a new builder, tag it NSFW upstream in workflows.NSFW_METHODS.
+
+# Fallback used only when ``workflows.NSFW_METHODS`` is absent (old tree).
+# Mirrors the canonical set in workflows.py — keep them in lock-step.
+_NSFW_BUILDERS_FALLBACK: frozenset[str] = frozenset({
+    # ── Klein family (Flux2 photoreal identity-preserving) ──────────────
+    "build_klein_img2img",
+    "build_klein_img2img_ref",
+    "build_klein_inpaint",
+    "build_klein_refine",
+    "build_klein_scene_img2img",
+    "build_klein_color_match",
+    "build_klein_blend",
+    "build_klein_detail",
+    "build_klein_face_detail",
+    "build_klein_repose",
+    "build_klein_headswap",
+    "build_klein_virtual_tryon",
+    "build_klein_generate_object",
+    "build_klein_batch_variations",
+    "build_klein_auto_inpaint",
+    "build_klein_sam3_inpaint",
+    # ── Face / head identity manipulation ───────────────────────────────
+    "build_faceswap",
+    "build_faceswap_model",
+    "build_faceswap_mtb",
+})
+
+
+def _resolve_nsfw_set() -> tuple[frozenset[str], str]:
+    """Return ``(set, source_tag)`` where source_tag is one of
+    ``"workflows.NSFW_METHODS"`` (authoritative) or ``"fallback"``
+    (the local table). The source_tag is exposed so callers (tests,
+    diagnostic CLI) can verify the import path landed."""
+    try:
+        wf = importlib.import_module("spellcaster_core.workflows")
+        nsfw_set = getattr(wf, "NSFW_METHODS", None)
+        if isinstance(nsfw_set, (frozenset, set)) and nsfw_set:
+            return frozenset(nsfw_set), "workflows.NSFW_METHODS"
+    except Exception:  # noqa: BLE001
+        pass
+    return _NSFW_BUILDERS_FALLBACK, "fallback"
+
+
+_NSFW_BUILDERS, _NSFW_SOURCE = _resolve_nsfw_set()
+
+
+def _is_nsfw_builder(builder_name: str) -> bool:
+    """Return True iff this builder is NSFW-licensed per the
+    authoritative ``workflows.NSFW_METHODS`` set (with local fallback)."""
+    return builder_name in _NSFW_BUILDERS
+
+
+# ---------------------------------------------------------------------------
 # target_class — terminal ComfyUI class_type the builder lands on
 # ---------------------------------------------------------------------------
 #
@@ -559,41 +632,43 @@ def enumerate_manifest() -> list[dict[str, Any]]:
         family = _model_family_for(name)
         kind = _bucket_for(name)
         input_slots = [p["name"] for p in params if "slot" in p]
+        target_class = _target_class_for(name, fn)
+        nsfw_flag = _is_nsfw_builder(name)
+
+        # Build entry with deterministic key ordering so PR diffs remain
+        # readable. Optional keys (``target_class``, ``nsfw``) are inserted
+        # in stable slots between the structural fields; absent when not
+        # applicable so the manifest stays compact for SFW-only methods.
         entry: dict[str, Any] = {
             "id":           bare_id,
             "builder":      name,
             "label":        _label_for(name, short_doc),
             "kind":         kind,
             "model_family": family,
-            "input_slots":  input_slots,
-            "params":       params,
-            "short_doc":    short_doc,
         }
-        target_class = _target_class_for(name, fn)
         if target_class:
-            # Insert just after model_family so dispatcher-relevant
-            # fields cluster together in the rendered JSON.
-            entry = {
-                "id":           entry["id"],
-                "builder":      entry["builder"],
-                "label":        entry["label"],
-                "kind":         entry["kind"],
-                "model_family": entry["model_family"],
-                "target_class": target_class,
-                "input_slots":  entry["input_slots"],
-                "params":       entry["params"],
-                "short_doc":    entry["short_doc"],
-            }
+            entry["target_class"] = target_class
+        if nsfw_flag:
+            entry["nsfw"] = True
+        entry["input_slots"] = input_slots
+        entry["params"] = params
+        entry["short_doc"] = short_doc
         entries.append(entry)
     return entries
 
 
-# schema_version bumped 1 -> 2 with the addition of the optional
-# ``target_class`` field per method. Field is omitted when neither the
-# override table nor the AST heuristic can resolve a class; consumers
-# that parse this manifest are required to tolerate the field's
-# absence (fall back to their own static table).
-SCHEMA_VERSION = 2
+# schema_version bumped:
+#   1 -> 2: optional ``target_class`` field per method.
+#   2 -> 3: optional ``nsfw`` field per method (producer-side SSoT for
+#           NSFW classification; sourced from workflows.NSFW_METHODS,
+#           with local fallback for stale trees). Mirrors the bump that
+#           landed in spellcaster_NSFW; the SFW manifest gains the
+#           ``nsfw: true`` tags so cross-repo consumers see a consistent
+#           wire shape regardless of which channel served the manifest.
+# Consumers that parse this manifest are required to tolerate the
+# optional fields' absence (fall back to their own static tables and/or
+# heuristics).
+SCHEMA_VERSION = 3
 GENERATOR_TAG = "spellcaster/tools/build_builders_manifest.py"
 
 


### PR DESCRIPTION
## Summary

Audit item #4 (2026-05-15): mirror the `NSFW_METHODS` SSoT constant
from spellcaster_NSFW so both trees carry the canonical NSFW
classification next to the methods themselves. Also bumps this tree's
manifest schema 2 -> 3 to match the NSFW tree — the SFW manifest now
emits `nsfw: true` tags on the 19 NSFW-licensed builders so cross-repo
consumers see a consistent wire shape regardless of channel.

The consumer-side voodoomaster gate decides whether to honour the
tag (block on SFW channel, surface on NSFW channel).

## What changed

- `comfyui-spellcaster/spellcaster_core/workflows.py` — add 19-entry
  `NSFW_METHODS` frozenset (mirrors NSFW tree).
- `plugins/gimp/comfyui-connector/spellcaster_core/workflows.py` —
  mirror surface 1.
- `tools/build_builders_manifest.py` — import `workflows.NSFW_METHODS`
  via `_resolve_nsfw_set()`; emit `nsfw: true` per method; schema 2 -> 3.
  Local `_NSFW_BUILDERS_FALLBACK` retained as safety net.
- `comfyui-spellcaster/spellcaster_core/builders_manifest.json` —
  auto-regenerated: +19 nsfw=true tags, schema 2 -> 3.
- `plugins/gimp/comfyui-connector/spellcaster_core/builders_manifest.json` —
  mirror surface 1.

## Hash-stability

- caps `methods_hash` invariant (computed over routes | archs-keys |
  flags-keys | node_count) — NOT affected; per-method nsfw flag is
  not in the hash inputs.
- The 19 nsfw=true tags are net-new in the SFW manifest, but the
  consumer-side heuristic (`is_nsfw_method` in voodoomaster) already
  classified these as NSFW via the Klein/faceswap/headswap superset.
  The producer tag is just now explicit.

## Test plan

- [x] `python tools/build_builders_manifest.py --check` — manifest fresh
- [x] Producer `_NSFW_SOURCE` reports `workflows.NSFW_METHODS`
- [x] `python tests/mirror_drift.py` — workflows.py + builders_manifest.json
      surfaces are in sync (the pre-existing asset_gallery.py drift is
      out of scope and untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)