### PR TITLE
chore(research): daily SOTA review 2026-05-21

### DIFF
--- a/_dev_docs/upgrade_research/2026-W21.json
+++ b/_dev_docs/upgrade_research/2026-W21.json
@@ -1,0 +1,242 @@
+[
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 Multiplex (sam3.1_multiplex_fp16.safetensors)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Applies equally to build_sam3_mask and build_sam3_extract. Native ComfyUI core support via PR #13408 (kijai, May 2026). 2x throughput via multiplexed 16-object/pass tracking. Drop-in replacement for SAM 3.0 checkpoint. Checkpoint dest: ComfyUI/models/sams/."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "node_pack",
+    "name": "ComfyUI Native BiRefNet Core Node",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/new-open-source-models-now-in-comfyui",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Applies equally to build_rembg_v3. Announced May 14, 2026 in official ComfyUI blog. Same RMBG-2.0 weights; removes dependency on third-party wrapper node packs. Available after ComfyUI v0.21.1+ upgrade."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 1c_256.onnx (quality variant)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "Applies equally to build_faceswap_model. Ships with ReActor v0.6.2 (released April 25, 2026; hotfix May 12). 256px face crop vs 128px for inswapper_128. Three variants: 1a (speed), 1b (balanced), 1c (quality). The swap_model param already accepts arbitrary .onnx filenames — zero Spellcaster code change needed. Dest: ComfyUI/models/hyperswap/."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "ComfyUI-ReActor v0.6.2 — Restore Face Advanced + ReActorSetWeight",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/releases",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "New Restore Face Advanced node applies CodeFormer/GFPGAN only to the swapped face region (not full image). ReActorSetWeight adds 0-100% blend strength. Additive to existing build_faceswap workflow; no breaking changes."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "GonzaLomo XL v7.0 DMD (Photo XL)",
+    "source": "civitai",
+    "url": "https://civitai.com/models/1513492/gonzalomo-xlfluxpony",
+    "risk": "low",
+    "confidence": 0.83,
+    "notes": "Applies equally to build_img2img (SDXL path). Updated May 18, 2026. DMD2-distilled SDXL; 4-step inference. Best current free photorealism SDXL checkpoint. ~8 GB VRAM. Recommend as default SDXL preset checkpoint."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "node_pack",
+    "name": "MoGe Depth Estimator (native ComfyUI v0.22.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/MoGe",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Microsoft MoGe; CVPR 2025 Oral. 314M params; 60 ms/image; 2 GB VRAM. Outperforms DepthAnything/DA3 on geometry-heavy scenes. Available as native node in ComfyUI v0.22.0 (May 20, 2026). Upgrade depth preprocessor path in build_controlnet_gen after engine update."
+  },
+  {
+    "method": "build_klein_img2img",
+    "category": "lora",
+    "name": "Ultra Real Klein 9B v4 LoRA",
+    "source": "civitai",
+    "url": "https://civitai.com/models/2462105/ultra-real-klein-9b",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Released May 15, 2026. Applies to all 15 build_klein_* methods in photorealism contexts. 158 MB safetensors. Reduces synthetic skin texture. Trigger: 'High-quality photograph of a'. ~13 GB total with Klein 9B FP8."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "lora",
+    "name": "MJ Style Distilled 206 LoRA (Klein 9B)",
+    "source": "civitai",
+    "url": "https://civitai.com/models/2592307/mj-style-distilled-206",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "~late April/early May 2026. Also applicable to build_klein_* style-mode workflows. 206-style distillation for artistic diversity. ~13 GB total with Klein 9B FP8."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "BFS LoRA v3 (Best Face Swap, Klein 9B)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Also applicable to build_klein_face_detail. Video variant at Alissonerdx/BFS-Best-Face-Swap-Video. Diffusion-based face/head swap via Klein reference conditioning; v3 adds persistent-template conditioning for video consistency. Complements (does not replace) ONNX ReActor path. ~12-14 GB with Klein 9B FP8."
+  },
+  {
+    "method": "build_wavespeed_upscale",
+    "category": "node_pack",
+    "name": "WaveSpeed FlashVSR (CVPR 2026)",
+    "source": "github",
+    "url": "https://github.com/OpenImagingLab/FlashVSR",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "ComfyUI node updated May 13, 2026 (one day before window). One-step diffusion VSR; 12x speedup vs prior one-step models; locality-constrained sparse attention. Supports 2x/4x to 720p/1080p/2K/4K. WaveSpeed cloud API fallback available. 16 GB OK for 1080p local inference."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "WAN 2.7",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/wan27-is-now-available-in-comfyui",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Released April 3, 2026 (pre-window context). Applies equally to build_wan22_t2v, build_wan_flf, build_wan_animate_video. Supersedes WAN 2.1/2.2. Better motion quality, style consistency, up to 5 reference persons, audio, video continuation. 5B fits 12 GB; 14B needs 16 GB + blockswap. Verify build_wan_video_blockswap and build_wan_video_blockswap_t2v checkpoint format compat before wiring."
+  },
+  {
+    "method": "build_lumina2_txt2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image-Dev-2604 (8B UiT)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Released May 14, 2026. Pixel-level Unified Transformer — no external VAE or CLIP. Beats FLUX.2 32B on GenEval/DPG-Bench at 8B params. Dev variant ~10 GB VRAM; full BF16 ~20 GB (skip full). ComfyUI node: Saganaki22/HiDream_O1-ComfyUI v0.2.3 (May 15). Cannot retrofit into Flux/SDXL loader chain — needs a new build_hidream_txt2img builder. Also relevant to build_qwen_edit as instruction-editing architecture."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 (22B joint audio-video)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "Released March 2026 (pre-window). 22B parameters; rebuilt VAE; 4x larger text connector; native portrait generation; joint audio-video output. VRAM needs local test before wiring — 22B may exceed 16 GB. Supersedes LTX-Video 0.9.x if VRAM permits."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "node_pack",
+    "name": "NormalCrafter ComfyUI Wrapper",
+    "source": "github",
+    "url": "https://github.com/AIWarper/ComfyUI-NormalCrafterWrapper",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "SVD-adapted for temporally consistent per-frame normal maps. 1.6 degree MAE improvement and +3.1% pixel accuracy over DSINE on Sintel. Sliding-window inference for arbitrary-length video. ~8-12 GB VRAM (SVD-based). Significant quality gain for video workflows; single-node install, auto-downloads weights."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "HY-World 2.0 / HY-Pano 2.0 (Tencent)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tencent/HY-World-2.0",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Applies equally to build_hunyuan_3d_textured. HY-Pano 2.0 open-sourced May 11, 2026. Adds scene-level 3D world generation (navigable scenes, Gaussian Splattings, game-engine export) on top of object-level 3D. ComfyUI wrapper: AHEKOT/ComfyUI_HYWorld2 (community, immature). Full pipeline VRAM unclear — may exceed 16 GB. Monitor wrapper maturity before wiring."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "checkpoint",
+    "name": "PuLID-Flux2 v0.6.2 native Klein weights",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "Klein v1 and v2 native PuLID weights separate from Flux.1 weights. Improved face recognition quality and reduced artifacts. Total budget ~14-16 GB with Klein 9B FP8 — borderline at 16 GB. Confirm VRAM headroom in a local test before updating defaults."
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "IC-Light V2-Vary (stronger effect variant)",
+    "source": "github",
+    "url": "https://github.com/lllyasviel/IC-Light/discussions/109",
+    "risk": "low",
+    "confidence": 0.55,
+    "notes": "Demo-only via HF Space; weights not yet released. Stronger illumination variation vs IC-Light V2 FC. Flux-based relighting; est. 12-16 GB VRAM. Watch lllyasviel Discussion #109 for weight drop."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "api_node",
+    "name": "Topaz Astra 2 (creative video upscaling)",
+    "source": "github",
+    "url": "https://docs.comfy.org/tutorials/partner-nodes/topaz/astra-2",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Released April 28, 2026. Prompt-guided creative diffusion upscaling; Creativity/Sharpness sliders; up to 450 frames with prompt, 9000 without; FullHD or 4K output. Cloud API only (Topaz subscription). Zero local VRAM. Relevant for quality-over-speed video upscaling workflows."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "api_node",
+    "name": "HappyHorse 1.0 (Alibaba Future Life Lab)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/happyhorse-10-is-now-available",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "Applies equally to build_wan22_t2v and similar T2V/I2V builders as a quality alternative. Topped Artificial Analysis T2V and I2V leaderboard at launch (April 7, 2026). Supports T2V, I2V, Subject-to-Video up to 1080p/15s with co-generated audio. API only (muapi.ai). Zero local VRAM. No open-source weights."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "api_node",
+    "name": "Seedance 2.0 (ByteDance)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/seedance-20-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Public April 15, 2026; ComfyUI integration active late April 2026. Generates 2K video with native audio; multi-modal input (9 images, 3 video clips, 3 audio); T2V, Reference-to-Video, First/Last-Frame-to-Video. API only. Could complement build_seedvr2_video_upscale in a generation+upscale pipeline."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Nucleus-Image (17B MoE diffusion transformer)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
+    "risk": "high",
+    "confidence": 0.82,
+    "notes": "Released April 14, 2026; ComfyUI native support (CORE-185) in v0.21-v0.22 window. 17B total params, ~2B active via sparse MoE. Matches top-tier models on GenEval/DPG-Bench. VRAM: FP8 needs 24 GB (RTX 4090); exceeds 16 GB even at FP8. Hold until confirmed 16 GB-compatible GGUF quant. Apache 2.0 license."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "node_pack",
+    "name": "Code2Collapse/ComfyUI-CustomNodePacks (SAM3 + LUT + ViTMatte)",
+    "source": "github",
+    "url": "https://github.com/Code2Collapse/ComfyUI-CustomNodePacks",
+    "risk": "medium",
+    "confidence": 0.68,
+    "notes": "Also relevant to build_lut (EXR I/O + render passes) and build_rembg (ViTMatte alpha matting). Updated May 21, 2026. 72 nodes covering SAM2.1/SAM3 segmentation, ViTMatte, inpaint crop/stitch, VFX tools, video mask propagation. Self-labelled experimental; 44 stars. Worth evaluating for LUT and matting nodes once stability is confirmed."
+  },
+  {
+    "method": "build_photo_restore",
+    "category": "checkpoint",
+    "name": "RealRestorer (StepFun, Step1X-Edit DiT)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "high",
+    "confidence": 0.65,
+    "notes": "Released March 26, 2026. Also relevant to build_face_restore and build_detail_hallucinate. Supports 9 degradation types: blur, rain, reflection, low-light, denoising, haze, moire, flare, artifact repair. 1024x1024 native. Step1X-Edit DiT backbone; FP16 ~16-20 GB (borderline to exceeds 16 GB). No confirmed FP8 variant. Hold until FP8/GGUF available."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "CodeFormer++ (DAM + TGRN)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2510.04410",
+    "risk": "low",
+    "confidence": 0.60,
+    "notes": "Also applicable to build_faceswap (post-processing step). Paper October 2025. Adds Deformable Alignment Module and Texture-prior Guided Restoration Network on top of CodeFormer. Higher fidelity texture. No public weights yet. When checkpoint drops, it should be a direct codeformer-v0.1.0.pth replacement."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W21.md
+++ b/_dev_docs/upgrade_research/2026-W21.md
@@ -1,0 +1,238 @@
+# Spellcaster daily SOTA review — 2026-05-21
+
+ISO week: `2026-W21`. Baseline: none (inaugural report — `_dev_docs/upgrade_research/` directory created this run).
+
+Research window: **2026-05-14 → 2026-05-21**.
+Hardware budget: RTX 5060 Ti, 16 GB VRAM.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / Upgrade | Source URL | Risk | Notes |
+|--------|-----------------|-------------|----------------------|------------|------|-------|
+| build_sam3_segment / build_sam3_mask / build_sam3_extract | SAM 3.0 | **No** | SAM 3.1 Multiplex (`sam3.1_multiplex_fp16.safetensors`) | https://huggingface.co/Comfy-Org/sam3.1 | Low | Native ComfyUI PR #13408 (kijai); 2× throughput; 16-object/pass multiplex; same VRAM |
+| build_rembg_birefnet / build_rembg_v3 | BiRefNet / RMBG-2.0 (custom nodes) | Yes (same model) | Native ComfyUI BiRefNet core node | https://blog.comfy.org/p/new-open-source-models-now-in-comfyui | Low | Announced May 14; same RMBG-2.0 weights; can drop custom wrapper dependency |
+| build_faceswap / build_faceswap_model | `inswapper_128.onnx` | **No** | `hyperswap_1c_256.onnx` (ReActor v0.6.2) | https://huggingface.co/facefusion/models-3.3.0 | Low | 256px face crop vs 128px; `swap_model` param already accepts arbitrary `.onnx`; +Restore Face Advanced node |
+| build_txt2img / build_img2img (SDXL) | SDXL checkpoint | Partially | GonzaLomo XL v7.0 DMD | https://civitai.com/models/1513492/gonzalomo-xlfluxpony | Low | DMD2 distilled; 4-step inference; 8 GB VRAM; updated May 18 |
+| build_controlnet_gen (depth path) | DepthAnything / DA3 | **No** | MoGe (native in ComfyUI v0.22.0) | https://huggingface.co/Comfy-Org/MoGe | Low | 314M params; 60 ms/img; 2 GB VRAM; CVPR'25 Oral |
+| build_klein_* (15 methods) | Klein 9B/4B + Qwen3 CLIP | Yes (backbone) | — | — | Low | Additive LoRAs in Tier 2; LLAMA CLIP normalization fix in v0.21.1 improves all 15 |
+| build_wavespeed_upscale | WaveSpeed / SeedVR2 | **No** | WaveSpeed FlashVSR (CVPR 2026) | https://github.com/OpenImagingLab/FlashVSR | Low | 12× speedup vs prior one-step VSR; node updated May 13; 16 GB OK local + cloud API |
+| build_wan_video / build_wan22_t2v / build_wan_flf / build_wan_animate_video | WAN 2.1/2.2 | **No** | WAN 2.7 (ComfyUI partner nodes) | https://blog.comfy.org/p/wan27-is-now-available-in-comfyui | Low | Released Apr 3 (pre-window context); verify blockswap builder compat with new checkpoint |
+| build_ltx_video | LTX-Video 0.9.x | **No** | LTX-2.3 (22B, rebuilt VAE) | https://huggingface.co/Lightricks/LTX-2.3 | Medium | 22B; VRAM needs local test; joint audio-video; released Mar 2026 (pre-window) |
+| build_lumina2_txt2img | Lumina-Image 2.0 | **No** | HiDream-O1-Image-Dev-2604 (8B UiT) | https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604 | Medium | Released May 14; ~10 GB Dev VRAM; beats FLUX.2 32B on benchmarks; new loader needed |
+| build_normal_map | DSINE / StableNormal | Partially | NormalCrafter (SVD-based temporal) | https://github.com/AIWarper/ComfyUI-NormalCrafterWrapper | Low-Medium | 8–12 GB; 1.6° MAE improvement; temporal consistency for video normal maps |
+| build_iclight | IC-Light V2 | Yes | IC-Light V2-Vary (stronger effect variant) | https://github.com/lllyasviel/IC-Light/discussions/109 | N/A | No weights released yet; monitor discussion |
+| build_hunyuan_3d_mesh / build_hunyuan_3d_textured | HunyuanVideo 3D 2.x | Partially | HY-World 2.0 (scene-level 3D) | https://github.com/AHEKOT/ComfyUI_HYWorld2 | Medium | HY-Pano 2.0 open-sourced May 11; full pipeline VRAM unclear; wrapper immature |
+| build_pulid_flux | PuLID Flux.1 v0.9.1 | Partially | PuLID-Flux2 v0.6.2 (native Klein weights) | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Low-Medium | Native Klein v1/v2 weights; total budget ~14–16 GB with Klein 9B (borderline) |
+| build_video_upscale | RealESRGAN / 4x-UltraSharp | Partially | Topaz Astra 2 (cloud, prompt-guided) | https://docs.comfy.org/tutorials/partner-nodes/topaz/astra-2 | Medium | API-only; creative diffusion upscaling; Apr 28 release |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+All items here fit 16 GB VRAM, have native ComfyUI support or a trivial file-swap path, and require no Spellcaster workflow code changes.
+
+### 1. SAM 3.1 Multiplex — `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract`
+
+- **Checkpoint:** `sam3.1_multiplex_fp16.safetensors` → `ComfyUI/models/sams/`
+- **Nodes:** `SAM3_Detect`, `SAM3_VideoTrack`, `SAM3_TrackToMask`, `SAM3_TrackPreview` — merged into ComfyUI core (PR #13408, kijai)
+- **Improvement:** Multiplexed multi-object tracking, 16 objects per forward pass, ~2× throughput vs SAM 3.0; text-conditioned detection of occluded objects
+- **VRAM:** ~6–8 GB (unchanged)
+- **Action:** Download checkpoint from `Comfy-Org/sam3.1` on HF; update local ComfyUI to v0.21.1+
+
+### 2. Native BiRefNet core node — `build_rembg_birefnet` / `build_rembg_v3`
+
+- **Announced:** May 14, 2026 — https://blog.comfy.org/p/new-open-source-models-now-in-comfyui
+- **Improvement:** Same RMBG-2.0 weights now served via a first-class ComfyUI core node; removes dependency on community wrapper packs
+- **VRAM:** ~2–4 GB (unchanged)
+- **Action:** Update ComfyUI to v0.21.1+; rewire builders to native BiRefNet node if desired
+
+### 3. HyperSwap 1c_256.onnx — `build_faceswap` / `build_faceswap_model`
+
+- **Model:** `hyperswap_1c_256.onnx` (quality), `hyperswap_1b_256.onnx` (balanced), `hyperswap_1a_256.onnx` (speed) → `ComfyUI/models/hyperswap/`
+- **Source:** `facefusion/models-3.3.0` on HF — https://huggingface.co/facefusion/models-3.3.0
+- **Improvement:** 256px face crop vs 128px for `inswapper_128`; 2× face detail fidelity; ReActor v0.6.2 also adds Restore Face Advanced node (surgical per-face-region restoration) and ReActorSetWeight (0–100% blend)
+- **VRAM:** ~200 MB ONNX, negligible CUDA overhead
+- **Action:** Install ReActor v0.6.2; download HyperSwap models; update `swap_model` default or add quality-preset option in `build_faceswap`
+
+### 4. GonzaLomo XL v7.0 DMD — `build_txt2img` / `build_img2img` (SDXL path)
+
+- **Checkpoint:** CivitAI model 1513492, updated May 18, 2026
+- **Improvement:** DMD2-distilled SDXL; 4-step inference at SDXL quality; best current free photorealism checkpoint for tight framing
+- **VRAM:** ~8 GB (standard SDXL)
+- **Action:** Download checkpoint; consider as default SDXL checkpoint in preset configs
+
+### 5. MoGe depth preprocessor — `build_controlnet_gen` (depth path)
+
+- **Available:** Native node in ComfyUI v0.22.0 (released May 20, 2026)
+- **Source:** `Comfy-Org/MoGe` on HF — https://huggingface.co/Comfy-Org/MoGe
+- **Improvement:** 314M params; 60 ms/image; 2 GB VRAM; CVPR'25 Oral; outperforms DA3 on geometry-heavy scenes
+- **Action:** After ComfyUI v0.22.0 upgrade, switch depth preprocessor in `build_controlnet_gen` from DA3 to MoGe for sharper depth maps
+
+### 6. ComfyUI v0.22.0 engine upgrade — all Klein / Flux builders
+
+- **Key fixes:**
+  - v0.21.1 (May 13): LLAMA text encoder final-normalization disabled — directly improves CLIP text encoding quality for all Flux/Klein builders
+  - v0.22.0 (May 20): dynamic CLIP save fix (relevant to Klein builders that serialize partial models at runtime)
+  - v0.22.0: HiDream-O1 area conditioning + Nucleus Image native support
+- **Action:** Update ComfyUI on the local instance; no Spellcaster workflow code changes required
+
+---
+
+## Tier 2 — Additive new builders / node-pack installs
+
+These require installing new node packs or checkpoints on the user's machine. Some require new builder methods.
+
+### 7. WAN 2.7 — `build_wan_video` / `build_wan22_t2v` / `build_wan_flf` / `build_wan_animate_video`
+
+- **Released:** April 3, 2026 (pre-window; listed as important context)
+- **Source:** https://blog.comfy.org/p/wan27-is-now-available-in-comfyui | https://docs.comfy.org/tutorials/partner-nodes/wan/wan2-7
+- **Improvement:** Better motion quality, style consistency, up to 5 reference persons, vocal timbre reference, 3×3 grid generation, video continuation mode
+- **VRAM:** 5B variant ≈12 GB; 14B variant ≈16 GB with blockswap
+- **Action:** Install ComfyUI WAN 2.7 partner node; verify `build_wan_video_blockswap` and `build_wan_video_blockswap_t2v` work with new checkpoint format before wiring
+
+### 8. WaveSpeed FlashVSR — `build_wavespeed_upscale`
+
+- **Node updated:** May 13, 2026 (one day before window; immediately relevant)
+- **Source:** https://github.com/OpenImagingLab/FlashVSR | https://wavespeed.ai/models/wavespeed-ai/flashvsr
+- **Improvement:** CVPR 2026; one-step diffusion VSR with locality-constrained sparse attention; 12× speedup; 2× and 4× upscaling to 4K; better temporal coherence than SeedVR2 for streaming
+- **VRAM:** 16 GB OK for 1080p local; cloud API fallback available
+- **Action:** Install `wavespeed-flash-vsr-node`; update `build_wavespeed_upscale` to reference it
+
+### 9. Ultra Real Klein 9B v4 LoRA — `build_klein_*` (all photorealism contexts)
+
+- **Released:** May 15, 2026
+- **Source:** https://civitai.com/models/2462105/ultra-real-klein-9b
+- **Improvement:** Reduces "plastic AI skin" look; best for close-up and medium portrait shots; 158 MB safetensors
+- **VRAM:** ~13 GB total with Klein 9B FP8
+- **Action:** Download LoRA; add as optional `lora` entry in Klein photorealism preset configs
+
+### 10. MJ Style Distilled 206 LoRA — `build_style_transfer` / `build_klein_*`
+
+- **Source:** https://civitai.com/models/2592307/mj-style-distilled-206
+- **Improvement:** 206-style distillation LoRA for Klein 9B; wide range of artistic/stylized looks; no additional infrastructure
+- **VRAM:** ~13 GB total with Klein 9B FP8
+- **Action:** Download LoRA; add as style-mode option in `build_style_transfer` Klein path
+
+### 11. BFS LoRA v3 (Best Face Swap) — `build_klein_headswap` / `build_klein_face_detail`
+
+- **Source:** https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap (video variant: `BFS-Best-Face-Swap-Video`)
+- **Improvement:** Diffusion-based face/head swap via Klein img2img reference conditioning; v3 adds persistent-template conditioning for video consistency; complements (does not replace) ONNX ReActor path
+- **VRAM:** ~12–14 GB with Klein 9B FP8
+- **Action:** Download LoRA; add as optional mode in `build_klein_headswap`
+
+### 12. HiDream-O1-Image-Dev-2604 — new builder candidate (`build_hidream_txt2img`)
+
+- **Released:** May 14, 2026 — https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604
+- **Architecture:** Pixel-level Unified Transformer (UiT); no VAE, no separate CLIP — all modalities share one token space
+- **Quality:** Beats FLUX.2 [dev] 32B on GenEval/DPG-Bench at 8B params; supports instruction-based editing and multi-reference personalization
+- **VRAM:** Dev variant ~10 GB; full BF16 model ~20 GB (skip full)
+- **ComfyUI nodes:** `Saganaki22/HiDream_O1-ComfyUI` v0.2.3 (released May 15)
+- **Action:** This cannot be retrofitted into existing Flux/SDXL loader chains. Evaluate as a new `build_hidream_txt2img` builder once the ComfyUI node reference-image path stabilises
+
+### 13. NormalCrafter wrapper — `build_normal_map` (video workflows)
+
+- **Source:** https://github.com/AIWarper/ComfyUI-NormalCrafterWrapper
+- **Improvement:** SVD-adapted model for temporally consistent normal maps; 1.6° mean angular error improvement over DSINE; +3.1% pixel accuracy; sliding-window for arbitrary-length video
+- **VRAM:** ~8–12 GB (SVD-based)
+- **Action:** Install node pack; evaluate as replacement for static per-frame DSINE in video pipelines
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Blocker | Watch trigger |
+|------|---------|---------------|
+| Netflix VOID (video object removal) | ~40 GB VRAM (A100); exceeds 16 GB hard limit | Quantized GGUF variant confirmed at ≤16 GB |
+| LTX-2.3 (22B joint audio-video) | VRAM unconfirmed locally | Local 16 GB VRAM test report |
+| Nucleus-Image (17B MoE diffusion) | >16 GB even at FP8 on 24 GB hardware | Confirmed ≤16 GB GGUF quant |
+| HY-World 2.0 / HY-Pano 2.0 (scene 3D) | Pipeline VRAM unclear; wrapper (`AHEKOT/ComfyUI_HYWorld2`) immature | Stable wrapper + VRAM profiling |
+| IC-Light V2-Vary (stronger relighting) | No weights released yet | lllyasviel Discussion #109 weight drop |
+| Hunyuan 3D 3.1 | API-only; no local open weights | Open-source weights on `Tencent-Hunyuan` GitHub |
+| Topaz Astra 2 (creative video upscale) | Proprietary API / subscription | Open-weight creative upscaling alternative |
+| Seedance 2.0 (ByteDance) | Proprietary API | Open-weight release |
+| HappyHorse 1.0 (Alibaba/Taotian) | Proprietary API | Open-weight release |
+| PuLID-Flux2 v0.6.2 Klein weights | Total budget ~14–16 GB with Klein 9B (borderline) | VRAM headroom test on Klein 9B FP8 |
+| HiDream-O1 FP8 (reference-image) | Reference-image conditioning unstable in current node pack | v0.3+ of `HiDream_O1-ComfyUI` |
+| Code2Collapse CustomNodePacks v0521 | Self-labelled experimental; 44 stars | Stability / maintained-status check |
+| RealRestorer (Step1X-Edit DiT) | FP16 ~16–20 GB; no confirmed FP8 | Confirmed FP8/GGUF variant at ≤16 GB |
+| CodeFormer++ (DAM + TGRN) | No public weights yet | Checkpoint drop on HuggingFace |
+| facerestore_advanced | No official tagged release | First tagged release |
+
+---
+
+## No-finds (verified)
+
+The following builders were surveyed; no new models, node-packs, or supersessions were found in the May 14–21, 2026 window.
+
+| Builder | Verified finding |
+|---------|-----------------|
+| build_inpaint / build_outpaint | No LaMa / MAT update; `comfyui-inpaint-nodes` (Acly) unchanged |
+| build_inpaint_fooocus | No Fooocus update |
+| build_generate_anything | No backbone update |
+| build_style_transfer (backbone) | Backbone unchanged; additive LoRAs in Tier 2 |
+| build_hunyuan_video | HunyuanVideo-1.5 (8.3B) remains current; no new checkpoint |
+| build_mochi_video | Mochi 1 (Genmo AI) remains current; no Mochi 2 |
+| build_cogvideo_video | CogVideoX 1.5 remains current; no 2.0 |
+| build_framepack_video | No new FramePack checkpoint (SD.Next wrapper update is not a model change) |
+| build_seedvr2_video_upscale | SeedVR2 ICLR-2026 remains current; no SeedVR3 |
+| build_upscale / build_upscale_blend | No new ESRGAN or comparable open-weight upscaler |
+| build_video_reactor | No video-specific ReActor update (image ReActor upgrade is Tier 1) |
+| build_faceswap_mtb | No MTB face swap update |
+| build_face_restore (CodeFormer) | CodeFormer v0.1.0 still current; CodeFormer++ weights not yet public |
+| build_photo_restore | No direct update |
+| build_detail_hallucinate | No update |
+| build_photobooth | No direct update (HiDream-O1 reference-image path in Tier 3) |
+| build_save_face_model | No update |
+| build_faceid_img2img | No new face ID embedding model |
+| build_supir | No SUPIR update; UniRes paper (arXiv 2506.05599) outperforms SUPIR but has no ComfyUI nodes |
+| build_color_match / build_klein_color_match | No update |
+| build_colorize / build_ddcolor | No DDColor successor with ComfyUI support |
+| build_lut | No new LUT-specific model |
+| build_rembg (base RMBG) | No RMBG-3.0 or BiRefNet successor found |
+| build_depth_map_v3 (DA3) | No DA4; DA3 (`da3_large.safetensors`) remains SOTA |
+| build_seedv2r | No SeedVR2 checkpoint update |
+| build_qwen_edit | Last major release Feb 2026 (Qwen-Image 2.0); no new variant |
+| build_wan_video_blockswap / _t2v | No dedicated blockswap update; WAN 2.7 compat needs verification (Tier 2) |
+| build_wan_animate_video (backbone) | Backbone covered by WAN 2.7 (Tier 2) |
+
+---
+
+## Sources
+
+- https://blog.comfy.org/p/new-open-source-models-now-in-comfyui (ComfyUI: VOID, BiRefNet, Gemma 4 — May 14, 2026)
+- https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.22.0
+- https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.21.1
+- https://huggingface.co/Comfy-Org/sam3.1
+- https://ai.meta.com/blog/segment-anything-model-3/
+- https://github.com/Comfy-Org/ComfyUI/pull/13408
+- https://huggingface.co/facefusion/models-3.3.0 (HyperSwap models)
+- https://github.com/Gourieff/ComfyUI-ReActor/releases (v0.6.2)
+- https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604
+- https://arxiv.org/abs/2605.11061 (HiDream-O1 paper)
+- https://github.com/Saganaki22/HiDream_O1-ComfyUI (v0.2.3, May 15)
+- https://huggingface.co/Comfy-Org/MoGe
+- https://github.com/microsoft/MoGe
+- https://civitai.com/models/2462105/ultra-real-klein-9b (Ultra Real Klein 9B v4)
+- https://civitai.com/models/2592307/mj-style-distilled-206
+- https://civitai.com/models/1513492/gonzalomo-xlfluxpony (GonzaLomo XL v7.0 DMD)
+- https://github.com/OpenImagingLab/FlashVSR (WaveSpeed FlashVSR, CVPR 2026)
+- https://wavespeed.ai/models/wavespeed-ai/flashvsr
+- https://blog.comfy.org/p/wan27-is-now-available-in-comfyui
+- https://huggingface.co/Lightricks/LTX-2.3
+- https://github.com/netflix/void-model
+- https://huggingface.co/netflix/void-model
+- https://huggingface.co/NucleusAI/Nucleus-Image
+- https://arxiv.org/abs/2604.12163 (Nucleus-Image paper)
+- https://github.com/lllyasviel/IC-Light/discussions/109
+- https://github.com/iFayens/ComfyUI-PuLID-Flux2 (v0.6.2)
+- https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap
+- https://github.com/AHEKOT/ComfyUI_HYWorld2
+- https://huggingface.co/tencent/HY-World-2.0
+- https://github.com/AIWarper/ComfyUI-NormalCrafterWrapper
+- https://docs.comfy.org/tutorials/partner-nodes/topaz/astra-2
+- https://blog.comfy.org/p/happyhorse-10-is-now-available
+- https://blog.comfy.org/p/seedance-20-is-now-available-in-comfyui
+- https://arxiv.org/abs/2506.05599 (UniRes, SUPIR successor paper)
+- https://arxiv.org/abs/2510.04410 (CodeFormer++ paper)


### PR DESCRIPTION
$(cat <<'EOF'
## Daily SOTA review — 2026-05-21 (ISO week 2026-W21)

Inaugural `_dev_docs/upgrade_research/` report. Surveyed all ~74 `build_*` builders across four families over the May 14–21 window. Hardware budget: RTX 5060 Ti, 16 GB VRAM.

---

## Summary

| Tier | Count | Description |
|------|-------|-------------|
| **Tier 1** — Drop-in supersessions | 6 | Swap a file or update ComfyUI; no workflow code changes needed |
| **Tier 2** — Additive / new builders | 7 | Needs node-pack install or new checkpoint on local machine |
| **Tier 3** — Monitor / not wire-ready | 14 | Blocked by VRAM, missing weights, or API-only |
| **No-finds** | 29 builders | Verified unchanged this week |

---

## Tier 1 highlights (ship soon — local machine actions)

| # | Item | Affected builder(s) | Action |
|---|------|---------------------|--------|
| 1 | **SAM 3.1 Multiplex** (`sam3.1_multiplex_fp16.safetensors`) | `build_sam3_*` | Download from `Comfy-Org/sam3.1` → `models/sams/`; native core node |
| 2 | **Native BiRefNet core node** (May 14 ComfyUI announcement) | `build_rembg_birefnet`, `build_rembg_v3` | Update ComfyUI to v0.21.1+; drop custom wrapper |
| 3 | **HyperSwap 1c_256.onnx** (ReActor v0.6.2) | `build_faceswap`, `build_faceswap_model` | Download to `models/hyperswap/`; set as default `swap_model` |
| 4 | **GonzaLomo XL v7.0 DMD** (May 18, CivitAI) | `build_txt2img`, `build_img2img` (SDXL) | Set as default SDXL photorealism checkpoint |
| 5 | **MoGe depth node** (native in ComfyUI v0.22.0) | `build_controlnet_gen` (depth path) | Switch preprocessor after engine upgrade |
| 6 | **ComfyUI v0.22.0** (LLAMA fix + dynamic CLIP + MoGe) | All Klein / Flux builders | Engine update on local instance |

## Tier 2 highlights (additive — node-pack installs)

| # | Item | Affected builder(s) |
|---|------|---------------------|
| 7 | **WAN 2.7** (partner node, Apr 3) | `build_wan_video`, `build_wan22_t2v`, `build_wan_flf`, `build_wan_animate_video` |
| 8 | **WaveSpeed FlashVSR** (CVPR 2026, May 13 node update) | `build_wavespeed_upscale` |
| 9 | **Ultra Real Klein 9B v4 LoRA** (May 15, CivitAI) | all `build_klein_*` |
| 10 | **MJ Style Distilled 206 LoRA** (CivitAI) | `build_style_transfer`, `build_klein_*` |
| 11 | **BFS LoRA v3** (Klein headswap, HuggingFace) | `build_klein_headswap`, `build_klein_face_detail` |
| 12 | **HiDream-O1-Image-Dev-2604** (May 14, new arch) | New `build_hidream_txt2img` builder candidate |
| 13 | **NormalCrafter** (SVD-based temporal normals) | `build_normal_map` |

## Notable Tier 3 items

- **Netflix VOID** (video object + physics deletion): ~40 GB VRAM — hard no on 16 GB. Watch for quantized variant.
- **Nucleus-Image** (17B MoE diffusion): >16 GB even at FP8. Watch for GGUF quant.
- **IC-Light V2-Vary**: No weights yet — watch `lllyasviel/IC-Light` Discussion #109.
- **LTX-2.3** (22B joint audio-video): VRAM needs local verification.

---

## Files

- `_dev_docs/upgrade_research/2026-W21.md` — full findings table, tier write-ups, no-finds, all sources
- `_dev_docs/upgrade_research/2026-W21.json` — 25 machine-readable candidate records (one per model/node)

---

> **Reminder:** The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically. No action needed here for that.

**Do not merge** — leave open for human review and local testing before any node-pack installs.
EOF

---
_Generated by [Claude Code](https://claude.ai/code/session_015cxxzr6WnHPbbnxGqesGzY)_