### PR TITLE
chore(research): daily SOTA review 2026-05-23

### DIFF
--- a/_dev_docs/upgrade_research/2026-W21.json
+++ b/_dev_docs/upgrade_research/2026-W21.json
@@ -1,0 +1,322 @@
+[
+  {
+    "method": "build_ltx_video",
+    "category": "node_pack",
+    "name": "ComfyUI v0.22.0",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/releases",
+    "risk": "low",
+    "confidence": 0.98,
+    "notes": "Released 2026-05-20 (within window). Key changes for spellcaster: (1) LTX-2.3 peak VRAM reduction when guide_mask is active — directly benefits build_ltx_video; (2) downscaled IC-LoRA support added to LTXVAddGuide; (3) optional attention_mask input; (4) native MoGe-2 geometry nodes (metric depth + normals); (5) HiDream-O1 area conditioning; (6) BiRefNet background-removal bug fix; (7) Stable Audio 3. Also relevant to build_depth_map_v3, build_normal_map, build_rembg_birefnet, build_layer_blend, build_hunyuan_3d_mesh."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "architecture",
+    "name": "MoGe-2 (native in ComfyUI v0.22.0)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/releases",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "MoGe-2 (NeurIPS 2025) now natively integrated in ComfyUI v0.22.0 (2026-05-20, within window). Single ~0.2 s inference provides metric-scale 3D point map, high-quality surface normals, and affine-invariant depth — replaces DA3-large and a separate normal-map model. Fits comfortably in 16 GB VRAM. Also relevant to build_normal_map."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "architecture",
+    "name": "MoGe-2 (native in ComfyUI v0.22.0)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/releases",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Same MoGe-2 node available from v0.22.0 provides both depth and normals. Replaces separate normal-map preprocessor in build_normal_map. Metric scale also useful for downstream 3D prep. One model replaces two."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "node_pack",
+    "name": "BiRefNet native ComfyUI (v0.21.0, bug-fixed in v0.22.0)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.21.0",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "BiRefNet background/foreground segmentation natively integrated in ComfyUI v0.21.0 (2026-05-11). Bug fixed in v0.22.0 (2026-05-20, within window). Drop custom-node dependency (ComfyUI_BiRefNet_ll / ComfyUI-RMBG). Place birefnet.safetensors in models/background_removal/. Directly relevant to build_rembg_birefnet and build_layer_blend mask-prep step."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "onnx_model",
+    "name": "HyperSwap 256 px ONNX models (hyperswap_1a/1b/1c_256.onnx)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "Three variants (~403 MB each) by FaceFusion Labs. Released with FaceFusion 3.3.0 (2025-06-22); ComfyUI-ReActor support landed in v0.6.2 (2026-04-25). Operates at 256 px — 2× inswapper_128's 128 px resolution; directly addresses inswapper's main quality ceiling. Place in ComfyUI/models/hyperswap/; select from existing ReActor node dropdown. Drop-in for all build_faceswap*, build_photobooth, build_video_reactor."
+  },
+  {
+    "method": "build_save_face_model",
+    "category": "node_pack",
+    "name": "ComfyUI-ReActor v0.7.0 ALPHA2 (InsightFace-free core)",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Released 2026-04-25 (outside window). Redesigned ReActor Core removes mandatory InsightFace / C++ Build Tools dependency — historically the main install friction point. NumPy 1.x and 2.x compatible. Also adds Face Similarity node, improved gender detection, refined face index logic, HyperSwap support, and 'Restore Face Advanced' node. Upgrade from v0.6.x is low risk and highly recommended for build_faceswap*, build_face_restore, build_photo_restore, build_photobooth, build_save_face_model."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "architecture",
+    "name": "SAM 3.1",
+    "source": "github",
+    "url": "https://ai.meta.com/blog/segment-anything-model-3/",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Released 2026-03-27 by Meta (outside window, but highest-ROI upgrade for build_sam3_*). Introduces Object Multiplex: all tracked objects processed in one forward pass with shared memory and global reasoning. Halves VRAM usage and doubles speed vs SAM3. ~848M params. API-compatible upgrade — swap checkpoint, verify ComfyUI-CustomNodePacks v1.30.4 (2026-05-15) supports SAM 3.1. Also relevant to build_sam3_mask, build_sam3_extract, build_klein_sam3_inpaint, build_magic_eraser."
+  },
+  {
+    "method": "build_sam3_mask",
+    "category": "node_pack",
+    "name": "Code2Collapse/ComfyUI-CustomNodePacks v1.30.4",
+    "source": "github",
+    "url": "https://github.com/Code2Collapse/ComfyUI-CustomNodePacks",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "v1.30.4 released 2026-05-15 (within window). 72-node production suite covering SAM2.1 and SAM3 segmentation with multi-mask picker, alpha matting (ViTMatte + MatAnyone2 backends), inpaint crop/stitch, VFX tools (EXR I/O, LUT application, render-pass compositing), video mask propagation, temporal anchors. Labeled 'experimental'. Directly augments build_sam3_segment/mask/extract and build_lut. Also relevant to build_rembg_v3."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "architecture",
+    "name": "HiDream-O1-Image-Dev-2604",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
+    "risk": "medium",
+    "confidence": 0.92,
+    "notes": "Distilled checkpoint released 2026-05-14 (within window). 8B pixel-space Unified Transformer — no VAE, no separate text encoder. 28-step distilled, #8 open-weights T2I arena on launch. FP8 variant fits ≤12 GB VRAM. Native ComfyUI support in v0.21.1 (2026-05-13). FP8 weights: drbaph/HiDream-O1-Image-FP8. Also supports instruction editing, subject personalization, storyboard. Requires new build_hidream_txt2img builder — different workflow topology (no VAE encode/decode). Community pack HiDream_O1-ComfyUI v0.2.3 (2026-05-15) adds LoRA training nodes."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "node_pack",
+    "name": "HiDream_O1-ComfyUI community node pack v0.2.3",
+    "source": "github",
+    "url": "https://github.com/Saganaki22/HiDream_O1-ComfyUI",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Released 2026-05-15 (within window). Wraps HiDream-O1 with: HiDreamO1ModelLoader, HiDreamO1ReferenceImages, HiDreamO1PatchSeamSmoothing, ModelNoiseScale, SamplerLCM, and LoRA training pipeline. Works alongside native v0.21.1 support. Only relevant if adopting HiDream-O1 architecture."
+  },
+  {
+    "method": "build_frame_assembly",
+    "category": "checkpoint",
+    "name": "LongCat-Video-Avatar-1.5",
+    "source": "huggingface",
+    "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "Released 2026-05-21 (within window). Audio-driven talking-head / avatar video by Meituan. 13.6B diffusers, MIT license. Wav2Vec2 → Whisper-Large upgrade for lip sync. Supports AT2V (audio+text→video), ATI2V (audio+text+image→video), video continuation. 8-step distilled; FP8 ~8 GB, FP16 ~16 GB. Integrated in Wan2GP 2026-05-22. Adds talking-head/avatar capability not currently covered by any build_* method. Needs new builder, e.g., build_avatar_video."
+  },
+  {
+    "method": "build_wavespeed_upscale",
+    "category": "checkpoint",
+    "name": "FlashVSR (CVPR 2026) — WaveSpeed ComfyUI node",
+    "source": "github",
+    "url": "https://github.com/OpenImagingLab/FlashVSR",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "FlashVSR one-step diffusion VSR from CVPR 2026 (OpenImagingLab). Locality-constrained sparse attention: ~12× speedup vs prior one-step VSR, ~17 FPS at 768×1408 on A100. Available as WaveSpeed ComfyUI node (wavespeed-flash-vsr-node). Within-window event: Wan2GP added FlashVSR two-pass rendering mode 2026-05-21 (2× upscale at 6 GB VRAM, 4× with more headroom). Does not supersede SeedVR2 — different quality/speed tradeoff. Extends build_wavespeed_upscale; could also add build_flashvsr_upscale."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "node_pack",
+    "name": "Pixal3D-ComfyUI (Saganaki22)",
+    "source": "github",
+    "url": "https://github.com/Saganaki22/Pixal3D-ComfyUI",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Released 2026-05-21 (within window). ComfyUI integration for TencentARC Pixal3D (SIGGRAPH 2026). Pixel-aligned back-projection for near-reconstruction-fidelity PBR-textured 3D from a single image. Textured GLB export; Windows support. Underlying Pixal3D has low-VRAM mode (1024 resolution) but exact ceiling unknown (TRELLIS.2 backbone). Evaluate against Hunyuan3D-2.1 on 16 GB before wiring. Also relevant to build_hunyuan_3d_mesh."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "architecture",
+    "name": "Sapiens2 Matting Model (facebook/sapiens2)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/collections/facebook/sapiens2",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Meta released Sapiens2 matting checkpoint 2026-05-15 (within window; other Sapiens2 tasks Apr 27). Family of ViTs pretrained on 1B human images, native 1K resolution (hierarchical to 4K). Better than Sapiens v1 on pose (+4 mAP), body-part seg (+24.3 mIoU), normals (45.6% lower error). Human-specific matting (not general background removal). Model sizes 0.4B–5B; 1B variant likely ~8–12 GB. ComfyUI nodes: kijai/ComfyUI-Sapiens2 and lassiiter/comfyui-sapiens2. VRAM needs testing on RTX 5060 Ti 16 GB."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "architecture",
+    "name": "MatAnyone2 (CVPR 2026 Highlight)",
+    "source": "github",
+    "url": "https://github.com/pq-yang/MatAnyone2",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "CVPR 2026 Highlight. Code + HF demo released 2026-03 (outside window). Human video matting without green screen — preserves hair strands, semi-transparency, motion blur. BiRefNet for auto-masking + guided filter edge refinement. Multiple ComfyUI nodes: spiritform/comfy-matanyone2, FuouM/ComfyUI-MatAnyone (MatAnyoneV2 node). Also a backend in Code2Collapse v1.30.4 (2026-05-15). Fits 16 GB. Candidate for new build_video_matte builder."
+  },
+  {
+    "method": "build_supir",
+    "category": "architecture",
+    "name": "RealRestorer (StepFun)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Released 2026-03-29 by StepFun (outside window). Built on Step1X-Edit DiT + Flux-VAE. Handles 9 degradation types at 1024×1024: blur, rain, reflection, low-light, denoising, haze, moiré, flare, artifact repair. #1 open-source on RealIR-Bench. Code: Apache 2.0. Model weights: non-commercial academic license — cannot replace build_supir for commercial use. No ComfyUI node found. VRAM ~12–16 GB (Flux-VAE). Also relevant to build_seedv2r."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "architecture",
+    "name": "WAN 2.7 (API-only via ComfyUI Partner Nodes)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "WAN 2.7 by Alibaba released 2026-04-26 via ComfyUI Partner Nodes (cloud API only; outside window). Improvements over 2.6: better image quality, audio sync, motion dynamics, stylization, first/last frame, 15-second 1080p clips, native audio. No open local weights as of 2026-05-23. Expected mid-to-late Q2 2026 based on Alibaba's historical pattern. VRAM unknown. When weights drop, all build_wan_* workflows will need migration from WAN 2.2 checkpoints. Highest-priority Tier-3 watch item."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "lora",
+    "name": "airdude/tfg-video-dpo-wan22-r8 (DPO LoRA for Wan2.2-T2V)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/airdude/tfg-video-dpo-wan22-r8",
+    "risk": "medium",
+    "confidence": 0.60,
+    "notes": "Created 2026-05-16 (within window). DPO-trained LoRA (rank 8, PEFT) on Wan2.2-T2V-A14B-Diffusers. Only 12 downloads — likely personal/research fine-tune. Could improve prompt adherence on T2V outputs. Low confidence in production quality without community validation. Low risk to test; medium risk to integrate without evaluation."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "VideoRLVR-Wan2.2 (DarthZhu, arxiv 2605.15458)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/DarthZhu/VideoRLVR-Wan2.2",
+    "risk": "high",
+    "confidence": 0.70,
+    "notes": "Released 2026-05-21 (within window). RL fine-tuned Wan2.2-TI2V-5B (flow-GRPO on video reasoning tasks). Both base and final RL checkpoints. 5B model fits on 16 GB. Only 17 downloads — research prototype, not production-ready. Risk 'high': untested in workflow context, may produce unexpected behavior on non-reasoning prompts."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "lora",
+    "name": "attikidd/BFS-Best-Face-Swap (Qwen Image Edit 2511 LoRA)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/attikidd/BFS-Best-Face-Swap",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Released 2026-05-19 (within window). LoRA adapter for Qwen-Image-Edit-2511 and Flux.2 Klein performing face and head swaps via diffusion editing — no ONNX inswapper required. Tagged comfyui, bfs, flux, klein, face-swap, head-swap. Fork of the Alissonerdx BFS series. Different paradigm: identity conditioned during generation, not post-processed. 8 downloads. Relevant to build_klein_headswap as an alternative workflow."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "lora",
+    "name": "Muapi/bfs-best-face-swap (LTX-Video 2.3 face-swap LoRA)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Muapi/bfs-best-face-swap",
+    "risk": "high",
+    "confidence": 0.45,
+    "notes": "Created 2026-05-23 (within window — today). Text-to-video LoRA on LTX-Video 2.3 tagged face-swap. Zero downloads/likes, zero documentation at scan time. Likely another variant of the BFS-Video series ported to LTX-Video 2.3. Highly experimental — no community validation. High risk."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "lora",
+    "name": "BFS-Best-Face-Swap-Video (Alissonerdx, LTX-Video 2.3 IC-LoRA)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Released 2026-01-24 (outside window). 306 likes — highest-engagement face-swap LoRA. IC-LoRA for LTX-Video 2.3 performing head/face swap inside the video diffusion model via latent identity injection and High-Noise Power Law timestep distribution. Last modified 2026-03-27. Many forks. Requires ComfyUI-BFSNodes for V3 workflow. Different paradigm from ONNX/ReActor: generation-time identity, not post-processing. Context for within-window Muapi variant."
+  },
+  {
+    "method": "build_faceid_img2img",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 (iFayens)",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Released 2026-03-21 (outside window). First PuLID implementation with full Flux.2 Klein 9B/4B and Flux.2 Dev support. Uses InsightFace + EVA-CLIP for face embedding, injects identity tokens into DiT double blocks. Prevents image darkening seen in earlier implementations. Relevant for build_faceid_img2img and build_photobooth on Klein presets. Directly augments existing build_pulid_flux path."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "node_pack",
+    "name": "facerestore_advanced",
+    "source": "github",
+    "url": "https://github.com/flickleafy/facerestore_advanced",
+    "risk": "medium",
+    "confidence": 0.60,
+    "notes": "Release date uncertain (~2026-05, approximate). Complete refactor of facerestore_cf. Adds 15+ quality metrics (SSIM, artifact scoring, 68-point landmark analysis), dual CodeFormer/GFPGAN support with intelligent fallback, fidelity slider (0.0–1.0), and result caching. 8 commits, no formal release tags. Candidate replacement for facerestore_cf in build_face_restore and build_photo_restore. Verify creation date before committing."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "architecture",
+    "name": "Pixal3D (TencentARC, SIGGRAPH 2026)",
+    "source": "github",
+    "url": "https://github.com/TencentARC/Pixal3D",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Inference code released ~2026-05-01 (outside window; SIGGRAPH 2026 accepted April). Pixel-aligned back-projection for near-reconstruction-fidelity PBR-textured 3D from a single image. Official HF Space: TencentARC/Pixal3D. Low-VRAM mode at 1024 resolution; standard at 1536. Exact VRAM ceiling unknown (TRELLIS.2 backbone). ComfyUI node Pixal3D-ComfyUI (Saganaki22, 2026-05-21, within window) provides the integration path. Potential challenger to Hunyuan3D-2.x for single-image-to-3D."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "architecture",
+    "name": "SAM 3.1",
+    "source": "github",
+    "url": "https://ai.meta.com/blog/segment-anything-model-3/",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Released 2026-03-27 (outside window). Object Multiplex bundles all tracked objects into one forward pass with shared memory — halves VRAM vs SAM3, doubles speed. ~848M params. Drop-in upgrade: swap checkpoint, verify ComfyUI-CustomNodePacks v1.30.4 (2026-05-15) for SAM 3.1 compatibility. Also relevant to build_sam3_mask, build_sam3_extract, build_klein_sam3_inpaint."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "checkpoint",
+    "name": "Hassaku XL (Illustrious) v3.0 WIP",
+    "source": "civitai",
+    "url": "https://civitai.com/models/140272/hassaku-xl-illustrious",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Updated 2026-05-18 (within window). WIP Illustrious-SDXL anime checkpoint. Merges Illustrious-XL with v2.2; improves character knowledge and handles newer/missing characters. Bright distinct anime style. WIP label — quality may be inconsistent. Drop-in for SDXL Illustrious workflows when stable."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Nova Anime XL IL v19.0 (Illustrious)",
+    "source": "civitai",
+    "url": "https://civitai.com/models/376130/nova-anime-xl",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Released 2026-05-12 (outside window by 4 days). Illustrious-based SDXL checkpoint. v19.0 adds higher contrast, sharper background detail. Merge of NoobAI EPS v1.1 + Illustrious v2.0-stable + ChenkinNoob v0.5 DARE. FP16, 6.46 GB. 1.6M+ downloads. Euler a, CFG 4.5, 20 steps, 1344px height, Danbooru tags. Drop-in for Illustrious SDXL workflows."
+  },
+  {
+    "method": "build_magic_eraser",
+    "category": "architecture",
+    "name": "Netflix VOID — Video Object and Interaction Deletion",
+    "source": "huggingface",
+    "url": "https://huggingface.co/netflix/void-model",
+    "risk": "high",
+    "confidence": 0.95,
+    "notes": "Released 2026-04-03 by Netflix (Apache 2.0). Two-pass CogVideoX-based diffusion — removes objects plus physical interactions (shadows, reflections, falling objects). Native ComfyUI support in v0.21.0. VRAM-BLOCKED: requires 40 GB+ (A100/H100). RTX 5060 Ti 16 GB is insufficient. Best-in-class video object removal (64.8% vs Runway 18.4%). Also relevant to build_lama_remove for future video inpainting."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "node_pack",
+    "name": "ComfyUI-TurboQuant (KV-cache compression)",
+    "source": "github",
+    "url": "https://github.com/Scottcjn/ComfyUI-TurboQuant",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Updated ~2026-05-18 (within window, approximate). TQ3 KV-cache compression: Lloyd-Max quantization + Fast Walsh-Hadamard Transform, compressing attention KV tensors to ~3.5-bit effective (~4.5–4.6× VRAM savings). Most impactful for LTX-2.3 22B (barely fits V100 32 GB without it). Less critical on 16 GB RTX 5060 Ti for still-image workflows. Only 4 commits, no release tags — very early stage. Issue #13188 open on ComfyUI core for native integration."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "architecture",
+    "name": "GLM-Image (ZhipuAI / Z.ai) — 16B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/zai-org/GLM-Image",
+    "risk": "high",
+    "confidence": 0.65,
+    "notes": "Released 2026-01-14 (outside window). 16B hybrid autoregressive-diffusion (9B GLM-4 + 7B diffusion decoder). Best-in-class text rendering (0.9116 word accuracy on CVTG-2K). MIT license. VRAM-BLOCKED: 16B FP16 exceeds 16 GB budget; FP8 option unclear. No native ComfyUI support (issue #13161 open as of 2026-03-26). Monitor for quantized variants and official ComfyUI integration."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "node_pack",
+    "name": "Wan2GP v11.77+ (week of 2026-05-16)",
+    "source": "github",
+    "url": "https://github.com/deepbeepmeep/Wan2GP",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Dense updates 2026-05-16 through 2026-05-23 (within window). Additions: LTX2 Prompt Relay (time-range prompts for multi-shot), LTX2 EditAnything, ID LoRA for LTX2 Distilled, LongCat Avatar 1.5 integration, FlashVSR two-pass mode (2× at 6 GB VRAM, 4× with more), SeeVDC post-processing, DramaBox support, image post-processing. Not a ComfyUI node pack — standalone WebUI runner. Relevant if any production workflows run via Wan2GP. FlashVSR two-pass integration is the key new upscaling addition."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W21.md
+++ b/_dev_docs/upgrade_research/2026-W21.md
@@ -1,0 +1,214 @@
+# Spellcaster daily SOTA review — 2026-05-23
+
+ISO week: `2026-W21`. Baseline: _none — first entry in this series_.
+
+Reviewed 4 families across 74 `build_*` methods. Research window: **2026-05-16 → 2026-05-23**.
+Hardware budget: RTX 5060 Ti, 16 GB VRAM. Anything requiring more is flagged `vram_blocked`.
+
+---
+
+## Findings table
+
+Methods with no notable find in either direction are collected in **No-finds** below.
+
+| Method | Current backbone | Still SOTA? | Replacement / upgrade | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| **IMAGE-GEN + EDITING** | | | | | | |
+| build_txt2img | Flux1dev / Flux Kontext / Klein 4B-9B / SDXL / Illustrious | Yes | HiDream-O1-Dev-2604 (competitor, new arch) | https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604 | medium | HiDream-O1-Dev-2604 debuted #8 open-weights T2I arena (May 14). FP8 ≤12 GB. Different pixel-space arch (no VAE) — needs new builder. Flux/Klein remain SOTA within current workflow topology. |
+| build_style_transfer | Flux1dev / Klein | Yes | — | — | — | Hassaku XL v3.0 WIP (Illustrious, May 18) is a checkpoint bump — WIP label, not production-ready. |
+| build_klein_headswap | Klein 9B / 4B | Yes | BFS LoRA on QIE-2511 (alt. paradigm) | https://huggingface.co/attikidd/BFS-Best-Face-Swap | medium | Diffusion-native head-swap LoRA released May 19. No ONNX required. Different paradigm — monitor; Klein headswap remains primary path. |
+| build_klein_sam3_inpaint | Klein + SAM3 | Partial | Klein + SAM 3.1 (for SAM sub-step) | https://ai.meta.com/blog/segment-anything-model-3/ | low | SAM 3.1 (Mar 27) halves SAM3 VRAM via Object Multiplex. Upgrade the SAM sub-step. |
+| build_pulid_flux | PuLID Flux v0.9.1 | Yes | ComfyUI-PuLID-Flux2 for Klein presets | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | low | ComfyUI-PuLID-Flux2 (Mar 21) adds full Klein 9B/4B support; outside window but actionable. Existing PuLID Flux still works on Flux1dev. |
+| build_qwen_edit | Qwen-Image-Edit-2511 | Yes | — | — | — | BFS LoRA (attikidd, May 19) rides QIE-2511 for face/head swap — not a replacement for the edit base model. |
+| build_layer_blend | BiRefNet (custom node) | Partial | BiRefNet native (ComfyUI v0.21.0+) | https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.21.0 | low | Drop custom-node dependency. BiRefNet bug fixed in v0.22.0 (May 20). Directly relevant for blending-prep step. |
+| build_magic_eraser | SAM3 + LaMa | No (VRAM-blocked) | Netflix VOID (needs 40 GB VRAM) | https://huggingface.co/netflix/void-model | high | VOID (Apache 2.0, Apr 3) physics-aware removal is clearly superior; native in ComfyUI v0.21.0. RTX 5060 Ti 16 GB is insufficient. LaMa remains only viable local option. |
+| build_lama_remove | LaMa | Yes | VOID (vram_blocked) | https://huggingface.co/netflix/void-model | high | Same blocker as build_magic_eraser. |
+| **FACE + PORTRAIT** | | | | | | |
+| build_faceswap | inswapper_128 (128 px) | Partial | HyperSwap 256 px (hyperswap_1b_256.onnx) | https://huggingface.co/facefusion/models-3.3.0 | low | 2× resolution drop-in via ReActor ≥v0.6.2. Place in `models/hyperswap/`. Confirmed working community-wide. |
+| build_faceswap_model | inswapper_128 (face-model path) | Partial | HyperSwap 256 px | https://huggingface.co/facefusion/models-3.3.0 | low | Same drop-in. |
+| build_faceswap_mtb | MTB face blend | Yes | HyperSwap as upstream source | https://huggingface.co/facefusion/models-3.3.0 | low | MTB blending layer unchanged; HyperSwap upstream raises input quality. |
+| build_save_face_model | ReActor | Partial | ReActor v0.7.0 ALPHA2 (InsightFace-free) | https://github.com/Gourieff/ComfyUI-ReActor | low | v0.7.0 ALPHA2 (Apr 25) removes C++ Build Tools / InsightFace hard dependency — reduces install friction. |
+| build_photobooth | Klein + ReActor | Partial | HyperSwap 256 px for swap step | https://huggingface.co/facefusion/models-3.3.0 | low | Higher-resolution swap available via HyperSwap. ReActor v0.7 ALPHA2 also relevant. |
+| build_video_reactor | ReActor + inswapper (video) | Partial | HyperSwap 256 px + ReActor v0.7.0 ALPHA2 | https://github.com/Gourieff/ComfyUI-ReActor | low | Both model upgrade and node upgrade apply to the video reactor pipeline. |
+| build_faceid_img2img | FaceID / IP-Adapter | Yes | — | — | — | No new IP-Adapter FaceID model within window. ComfyUI-PuLID-Flux2 is the actionable Klein alternative. |
+| build_face_restore | CodeFormer / GFPGAN | Yes | facerestore_advanced (date uncertain) | https://github.com/flickleafy/facerestore_advanced | medium | Refactored node adds SSIM/landmark quality metrics, dual-model fallback, fidelity slider. Exact release date not confirmed within 7-day window. |
+| build_photo_restore | CodeFormer / GFPGAN | Yes | facerestore_advanced (date uncertain) | https://github.com/flickleafy/facerestore_advanced | medium | Same. |
+| **VIDEO-GEN + UPSCALE** | | | | | | |
+| build_wan_video | WAN 2.2 14B I2V | Yes (locally) | WAN 2.7 (API only, weights pending) | https://blog.comfy.org/p/wan27-is-now-available-in-comfyui | medium | WAN 2.7 (Apr 26 via Partner Nodes) is better on quality, audio, motion. No open local weights as of May 23. Expect mid-to-late Q2 2026. **All build_wan_* will need migration when weights drop.** |
+| build_wan22_t2v | WAN 2.2 14B T2V | Yes (locally) | WAN 2.7 | https://blog.comfy.org/p/wan27-is-now-available-in-comfyui | medium | Same. |
+| build_wan_flf | WAN 2.2 first-last-frame | Yes (locally) | WAN 2.7 | — | medium | Same. |
+| build_wan_animate_video | WAN 2.2 + WanAnimateToVideo | Yes | WAN 2.7 | — | medium | Same. |
+| build_wan_video_blockswap | WAN 2.2 + block-swap | Yes | WAN 2.7 | — | medium | Same. |
+| build_wan_video_blockswap_t2v | WAN 2.2 T2V + block-swap | Yes | WAN 2.7 | — | medium | Same. |
+| build_ltx_video | LTX-2.3 22B (GGUF + Gemma TE) | Yes | — (ComfyUI v0.22.0 improves in-place) | https://github.com/Comfy-Org/ComfyUI/releases | low | ComfyUI v0.22.0 (May 20): peak VRAM reduction when guide_mask active; IC-LoRA support added to LTXVAddGuide; optional attention_mask input. No new model weights. |
+| build_frame_assembly | Frame stitching | Yes | LongCat-Video-Avatar-1.5 (additive) | https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5 | medium | Not a supersession — adds audio-driven talking-head AT2V/ATI2V. 13.6B, FP8 ~8 GB. New builder needed (e.g., `build_avatar_video`). |
+| build_video_upscale | 4x-UltraSharp.pth | Yes | FlashVSR (additive, 2× at 6 GB VRAM) | https://github.com/OpenImagingLab/FlashVSR | low | FlashVSR CVPR 2026: 1-step VSR via WaveSpeed ComfyUI node. Complements existing options. |
+| build_wavespeed_upscale | WaveSpeed | Yes | FlashVSR via WaveSpeed node (additive) | https://github.com/OpenImagingLab/FlashVSR | low | FlashVSR two-pass mode integrated in Wan2GP May 21; WaveSpeed ComfyUI node available. Could extend build_wavespeed_upscale. |
+| **RESTORE / STYLE / 3D** | | | | | | |
+| build_rembg_birefnet | BiRefNet-general (custom node) | Partial | BiRefNet native in ComfyUI v0.21.0+ | https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.21.0 | low | Custom node dependency removable; native path stable. Bug fix in v0.22.0 (May 20). |
+| build_rembg_v3 | RMBG-2.0 | Yes | Sapiens2 matting for human subjects | https://huggingface.co/collections/facebook/sapiens2 | medium | Sapiens2 matting checkpoint released May 15. Human-specific, 1K–4K. Better for portraits; RMBG-2.0 better for general objects. VRAM on 1B variant needs testing on 16 GB. |
+| build_sam3_segment | SAM3 | Partial | SAM 3.1 (2× speed, ½ VRAM) | https://ai.meta.com/blog/segment-anything-model-3/ | low | Object Multiplex processes all objects in one forward pass. Drop-in upgrade via checkpoint swap. Mar 27 release. |
+| build_sam3_mask | SAM3 | Partial | SAM 3.1 | https://ai.meta.com/blog/segment-anything-model-3/ | low | Same. |
+| build_sam3_extract | SAM3 | Partial | SAM 3.1 | https://ai.meta.com/blog/segment-anything-model-3/ | low | Same. |
+| build_normal_map | Separate normal-map preprocessor | Partial | MoGe-2 (native in ComfyUI v0.22.0) | https://github.com/Comfy-Org/ComfyUI/releases | low | MoGe-2 gives metric-scale normals + depth in one ~0.2 s pass. Replaces separate models. Fits 16 GB. |
+| build_depth_map_v3 | DA3-large (305M, DA v3) | Partial | MoGe-2 (metric depth + normals, 1 pass) | https://github.com/Comfy-Org/ComfyUI/releases | low | Same. MoGe-2 adds metric scale and simultaneous normals — meaningful for 3D prep. |
+| build_supir | SUPIR + SDXL backbone | Yes | RealRestorer (#1 RealIR-Bench, non-commercial) | https://huggingface.co/RealRestorer/RealRestorer | medium | RealRestorer (StepFun, Mar 2026): 9 degradation types, Flux-VAE, #1 open-source on RealIR-Bench. Blocked: model weights are non-commercial academic license. SUPIR remains viable for commercial use. |
+| build_lut | LUT application | Yes | Code2Collapse v1.30.4 (additive VFX suite) | https://github.com/Code2Collapse/ComfyUI-CustomNodePacks | medium | v1.30.4 (May 15) adds EXR I/O, LUT-in-compositing, render-pass nodes. Additive; existing LUT builder unchanged. |
+| build_hunyuan_3d_mesh | Hunyuan3D-2.1 | Yes | Pixal3D (SIGGRAPH 2026) — VRAM eval needed | https://github.com/Saganaki22/Pixal3D-ComfyUI | medium | Pixal3D-ComfyUI node released May 21. Pixel-aligned single-image-to-3D; PBR-textured GLB. Low-VRAM mode available; exact ceiling unknown. Evaluate before wiring. |
+| build_hunyuan_3d_textured | Hunyuan3D-2.1 | Yes | Pixal3D (PBR texture native) | https://github.com/Saganaki22/Pixal3D-ComfyUI | medium | Same. Pixal3D produces PBR-textured mesh natively; Hunyuan3D-2.1 requires a separate texture step. |
+| build_seedv2r | SeedV2R + SDXL/Flux | Yes | RealRestorer (non-commercial) | https://huggingface.co/RealRestorer/RealRestorer | medium | Same commercial-license blocker as build_supir replacement path. |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+These require only model files or node-pack updates on the user's machine — no new `build_*` methods needed.
+
+### T1-1 · ComfyUI v0.22.0 engine upgrade _(May 20, within window)_
+**Affects:** build_ltx_video, build_depth_map_v3, build_normal_map, build_rembg_birefnet, build_rembg, build_layer_blend, build_hunyuan_3d_mesh/textured (Stable Audio 3 + HiDream-O1 area conditioning also included).
+- Reduces peak VRAM for LTX-2.3 when guide_mask is active
+- Adds IC-LoRA downscaling support to LTXVAddGuide
+- Native MoGe-2 geometry nodes (metric depth + surface normals in one pass)
+- Fixes a BiRefNet background-removal bug
+- HiDream-O1 area conditioning
+- Stable Audio 3 model support
+- **Action:** upgrade ComfyUI installation from ≤v0.21.x to v0.22.0.
+
+### T1-2 · HyperSwap 256 px ONNX models _(accessible via ReActor ≥v0.6.2, Apr 25)_
+**Affects:** build_faceswap, build_faceswap_model, build_faceswap_mtb, build_photobooth, build_video_reactor, build_save_face_model.
+- `hyperswap_1a/1b/1c_256.onnx` (~403 MB each) — 2× resolution over inswapper_128
+- Released with FaceFusion 3.3.0 (Jun 2025); ReActor support landed Apr 25 in v0.6.2
+- Place in `ComfyUI/models/hyperswap/`; select from existing ReActor node dropdown
+- Also upgrade ReActor to v0.7.0 ALPHA2 (same update) to drop the InsightFace/C++ build-tools dependency
+- **Action:** install HyperSwap models + upgrade ComfyUI-ReActor to v0.7.0 ALPHA2.
+
+### T1-3 · SAM 3.1 checkpoint _(Mar 27 — highest-value outside-window upgrade)_
+**Affects:** build_sam3_segment, build_sam3_mask, build_sam3_extract, build_klein_sam3_inpaint, build_magic_eraser sub-step.
+- Object Multiplex: all tracked objects processed in one forward pass with shared global memory
+- ~2× speed, ~½ VRAM vs SAM 3 — meaningful on a 16 GB budget
+- Checkpoint swap; API-compatible with existing node structure
+- **Action:** download SAM 3.1 checkpoint; update SAM3 node to point to it. Verify Code2Collapse/ComfyUI-CustomNodePacks v1.30.4 (May 15) for SAM 3.1 compatibility.
+
+### T1-4 · MoGe-2 via ComfyUI v0.22.0 _(native support May 20)_
+**Affects:** build_depth_map_v3, build_normal_map, downstream ControlNet / 3D prep workflows.
+- Single inference (~0.2 s on RTX 3090) provides metric-scale point map + high-quality normals + affine-invariant depth
+- Replaces both DA3-large and a separate normal-map model in one call
+- Fits comfortably within 16 GB VRAM
+- **Action:** after ComfyUI v0.22.0 upgrade (T1-1), route build_depth_map_v3 and build_normal_map to MoGe-2 nodes instead of DA3-large.
+
+### T1-5 · BiRefNet native path _(ComfyUI v0.21.0, bug-fixed in v0.22.0)_
+**Affects:** build_rembg_birefnet, build_rembg, build_layer_blend (mask prep).
+- Drop the third-party `ComfyUI_BiRefNet_ll` / `ComfyUI-RMBG` custom node
+- Drop `birefnet.safetensors` into `models/background_removal/`; use native node
+- Bug in v0.21.0 fixed in v0.22.0 — wait for T1-1 upgrade before migrating
+- **Action:** after v0.22.0 upgrade, remove custom BiRefNet node and wire the native node.
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install)
+
+These add capabilities not currently covered by any `build_*` method.
+
+### T2-1 · HiDream-O1-Image-Dev-2604 — new pixel-space T2I architecture _(May 14)_
+**Candidate builder:** `build_hidream_txt2img`
+- 8B Unified Transformer (UiT); no VAE, no separate text encoder — single pixel-space model
+- FP8 variant: ≤12 GB VRAM; BF16: ~20–24 GB (not viable on 5060 Ti)
+- 28-step distilled variant, #8 open-weights T2I arena on launch
+- Native ComfyUI support in v0.21.1 (new loader, empty latent, ref-images, seam-smoothing, noise-scale nodes)
+- Also supports instruction editing, subject-driven personalization, storyboard generation
+- `HiDream_O1-ComfyUI` community pack v0.2.3 (May 15) adds LoRA training nodes
+- **FP8 weights:** `drbaph/HiDream-O1-Image-FP8` on HuggingFace
+- **Action:** install on user's machine; wire `build_hidream_txt2img`. Architecture requires new workflow construction (no VAE means different node graph).
+
+### T2-2 · LongCat-Video-Avatar-1.5 — audio-driven talking-head video _(May 21)_
+**Candidate builder:** `build_avatar_video`
+- 13.6B diffusers model, MIT license, by Meituan
+- Audio encoder upgraded Wav2Vec2 → Whisper-Large for smoother lip sync
+- Supports AT2V (audio+text→video), ATI2V (audio+text+image→video), video continuation
+- 8-step distilled; FP8 ~8 GB VRAM (fits on 16 GB), FP16 ~16 GB (tight)
+- Integrated into Wan2GP May 22; no dedicated ComfyUI custom node confirmed yet
+- **Action:** monitor for ComfyUI node; wire `build_avatar_video` once available.
+
+### T2-3 · FlashVSR via WaveSpeed ComfyUI node _(CVPR 2026, May 21 Wan2GP integration)_
+**Candidate builder:** extend `build_wavespeed_upscale` or add `build_flashvsr_upscale`
+- One-step diffusion video super-resolution (OpenImagingLab)
+- Locality-constrained sparse attention: ~12× speedup vs prior 1-step VSR methods
+- 2× spatial upscale at 6 GB VRAM; 4× feasible with more headroom — very RTX 5060 Ti-friendly
+- WaveSpeed ComfyUI node (`wavespeed-flash-vsr-node`) already available
+- Does not supersede SeedVR2 (different quality/speed tradeoff; FlashVSR faster, SeedVR2 higher peak quality)
+- **Action:** install wavespeed-flash-vsr-node; evaluate quality vs SeedVR2; wire into appropriate builder.
+
+### T2-4 · Pixal3D-ComfyUI — pixel-aligned single-image-to-3D _(May 21)_
+**Candidate builder:** `build_pixal3d_textured` or route from `build_hunyuan_3d_textured`
+- TencentARC, SIGGRAPH 2026; pixel-aligned back-projection for near-reconstruction PBR-textured 3D
+- `Saganaki22/Pixal3D-ComfyUI` node released May 21; supports Windows, textured GLB export
+- Low-VRAM mode at 1024 resolution available; exact ceiling unknown (TRELLIS.2 backbone)
+- Potentially superior to Hunyuan3D-2.x for single-image input (more reconstruction, less generation)
+- **Action:** install node; test on 16 GB; compare quality vs Hunyuan3D-2.1 on reference images.
+
+### T2-5 · MatAnyone2 — human video matting (CVPR 2026 Highlight) _(March 2026)_
+**Candidate builder:** `build_video_matte`
+- Human foreground/background separation from video without green screen
+- Preserves hair strands, semi-transparency, motion blur
+- Multiple ComfyUI nodes: `spiritform/comfy-matanyone2`, `FuouM/ComfyUI-MatAnyone`
+- Also available as alpha-matting backend in Code2Collapse/ComfyUI-CustomNodePacks v1.30.4
+- Fits 16 GB (small model based on BiRefNet + guided filter)
+- **Action:** install node; wire `build_video_matte` for workflows requiring clean video foreground extraction.
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Status | Why not yet | ETA / Blocker |
+|---|---|---|---|
+| WAN 2.7 | API-only (Partner Nodes) | No open local weights | Expected mid-to-late Q2 2026. When weights drop, **all build_wan_* need migration**. |
+| RealRestorer (StepFun) | Weights non-commercial | Model license restricts commercial use | Watch for relicensing. Best open-source restorer (#1 RealIR-Bench, 9 degradation types). |
+| HiDream-O1-Image (BF16 full) | VRAM too high | Needs 20–24 GB in BF16 | Use FP8 (T2-1) instead. |
+| Netflix VOID | VRAM-blocked | Requires 40 GB+ (A100/H100) | RTX 5060 Ti 16 GB insufficient. Physics-aware video object removal is best-in-class. |
+| Hassaku XL v3.0 WIP | Unstable | WIP label, inconsistent quality | Upgrade to stable release. |
+| BFS face-swap LoRA ecosystem | Unvalidated paradigm | Diffusion-native face swap on QIE-2511/LTX-2.3; no spellcaster workflow yet | Monitor adoption. `attikidd/BFS-Best-Face-Swap` (May 19) and `Muapi/bfs-best-face-swap` (May 23). |
+| ComfyUI-BFSNodes + BFS-Video LoRA | Complex workflow | Requires LTX-Video 2.3 + monkey-patched latent injection + chroma-key trick | Revisit when mainstream adoption confirmed. |
+| Sapiens2 matting (Meta) | VRAM needs testing | 1B model may need 8–12 GB; 5B likely OOM | Test 1B variant on 16 GB. Human-specific only (not general). |
+| VideoRLVR-Wan2.2 (DarthZhu) | Research prototype | RL fine-tune on reasoning tasks; only 17 downloads | Monitor for community validation. |
+| facerestore_advanced | Date uncertain | Release date not confirmed within 7-day window; 8 commits | Verify creation date; test if confirmed recent. |
+| GLM-Image 16B | VRAM too high | 16B FP16 exceeds budget; FP8 option unclear | No ComfyUI node yet anyway. |
+| ComfyUI-TurboQuant | Too early | 4 commits, no release tag; early-stage KV-cache compression | Watch for stable release + benchmarks. |
+| Mix3R (ByteDance/Tsinghua) | Paper-only | No code or weights released | Monitor repo. |
+| airdude/tfg-video-dpo-wan22-r8 | Low confidence | Only 12 downloads; likely personal fine-tune | Monitor community adoption. |
+
+---
+
+## No-finds (verified)
+
+The following methods were explicitly audited; no relevant model or node release was confirmed in the 2026-05-16 → 2026-05-23 window, and current backbones remain SOTA:
+
+**Image-gen:** build_img2img · build_inpaint · build_outpaint · build_inpaint_fooocus · build_controlnet_gen · build_generate_anything · build_iclight · build_lumina2_txt2img · build_klein_img2img · build_klein_img2img_ref · build_klein_repose · build_klein_blend · build_klein_batch_variations · build_klein_inpaint · build_klein_virtual_tryon · build_klein_scene_img2img · build_klein_refine · build_klein_auto_inpaint · build_klein_color_match · build_klein_generate_object · build_klein_detail · build_klein_face_detail
+
+**Video-gen:** build_hunyuan_video (no new checkpoint; HunyuanVideo-1.5 current) · build_mochi_video (no update) · build_cogvideo_video (no update) · build_framepack_video (FramePack F1 current; no new release) · build_seedvr2_video_upscale (v2.5.24 Dec 2025 still current) · build_upscale · build_upscale_blend
+
+**Face:** build_detail_hallucinate · build_faceid_img2img (no new FaceID model; ComfyUI-PuLID-Flux2 is an outside-window complement)
+
+**Restore / Style / 3D:** build_rembg (legacy; BiRefNet native path is T1-5 upgrade) · build_color_match · build_klein_color_match · build_colorize · build_ddcolor (no new DDColor model) · build_seedv2r (current; RealRestorer non-commercial blocks replacement)
+
+**Explicitly verified absent:**
+- New FLUX.1-dev or Flux Kontext checkpoint/LoRA of broad utility
+- New ControlNet for Flux or SDXL
+- New InsightFace / ArcFace model release
+- New PuLID Flux checkpoint (v0.9.1 still current)
+- New DDColor checkpoint
+- New HunyuanVideo checkpoint
+- Wan 2.7 open local weights (API-only)
+
+---
+
+## Summary counts
+
+| Tier | Count |
+|---|---|
+| Tier 1 — drop-in supersessions | 5 |
+| Tier 2 — additive new builders | 5 |
+| Tier 3 — monitor / not wire-ready | 14 |
+| No-finds (verified clean) | 38 methods, 12 explicit model checks |
+
+> **Reminder:** the local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh
+> the ComfyUI workflow snapshots automatically once node-pack upgrades are applied on the user's machine.


### PR DESCRIPTION
$(cat <<'EOF'
## Daily SOTA review — 2026-05-23 (ISO week 2026-W21)

First entry in the `_dev_docs/upgrade_research/` series. Audited **74 `build_*` methods** across 4 families. Research window: **2026-05-16 → 2026-05-23**. Hardware budget: RTX 5060 Ti, 16 GB VRAM.

Sources: Hugging Face Hub (model/space/paper search), GitHub, Civitai, blog.comfy.org.

---

## Summary table

| Tier | Count | Headline |
|---|---|---|
| Tier 1 — drop-in supersessions | **5** | ComfyUI v0.22.0, HyperSwap 256px, SAM 3.1, MoGe-2, BiRefNet native |
| Tier 2 — additive new builders | **5** | HiDream-O1-Dev-2604, LongCat-Avatar-1.5, FlashVSR, Pixal3D-ComfyUI, MatAnyone2 |
| Tier 3 — monitor / not wire-ready | **14** | WAN 2.7 weights pending, RealRestorer (non-commercial), VOID (40 GB VRAM), BFS LoRA, … |
| No-finds (verified) | **38 methods** | HunyuanVideo, FramePack, CogVideo, Mochi, SeedVR2, Flux1dev/Kontext, Lumina2, DDColor, … |

---

## Tier 1 — Drop-in supersessions (ship soon)

| # | Item | Affects | Action |
|---|---|---|---|
| T1-1 | **ComfyUI v0.22.0** (May 20) | build_ltx_video, build_depth_map_v3, build_normal_map, build_rembg_birefnet, build_layer_blend | Upgrade ComfyUI. LTXV VRAM fix, native MoGe-2, BiRefNet bug fix, IC-LoRA support |
| T1-2 | **HyperSwap 256px ONNX** (via ReActor ≥v0.6.2) | build_faceswap*, build_photobooth, build_video_reactor | Install hyperswap_1a/1b/1c_256.onnx → models/hyperswap/; upgrade ReActor to v0.7.0 ALPHA2 (drops InsightFace/C++) |
| T1-3 | **SAM 3.1** (Mar 27) | build_sam3_segment/mask/extract, build_klein_sam3_inpaint | Swap checkpoint; Object Multiplex gives 2× speed, ½ VRAM |
| T1-4 | **MoGe-2** (native in v0.22.0) | build_depth_map_v3, build_normal_map | After T1-1, route to MoGe-2 nodes; one pass gives metric depth + normals |
| T1-5 | **BiRefNet native path** (v0.21.0, fixed v0.22.0) | build_rembg_birefnet, build_layer_blend | Drop custom-node; place birefnet.safetensors in models/background_removal/ |

---

## Tier 2 — Additive new builders (needs node-pack install)

| # | Item | Proposed builder | Notes |
|---|---|---|---|
| T2-1 | **HiDream-O1-Image-Dev-2604** (May 14) | `build_hidream_txt2img` | 8B pixel-space UiT, no VAE. FP8 ≤12 GB. #8 open-weights T2I arena. Native ComfyUI in v0.21.1. |
| T2-2 | **LongCat-Video-Avatar-1.5** (May 21) | `build_avatar_video` | Audio-driven talking head (AT2V/ATI2V). 13.6B, FP8 ~8 GB. Whisper-Large lip sync. |
| T2-3 | **FlashVSR** via WaveSpeed ComfyUI node (May 21) | extend `build_wavespeed_upscale` | CVPR 2026, 1-step VSR, 2× at 6 GB VRAM. 12× faster than prior 1-step VSR. |
| T2-4 | **Pixal3D-ComfyUI** (May 21) | `build_pixal3d_textured` | SIGGRAPH 2026, pixel-aligned 3D, PBR-textured GLB. VRAM ceiling unknown — evaluate first. |
| T2-5 | **MatAnyone2** (Mar 2026, CVPR 2026 Highlight) | `build_video_matte` | Human video matting, no green screen. BiRefNet + guided filter. Fits 16 GB. |

---

## Tier 3 — Monitor / not wire-ready (top items)

- **WAN 2.7** — API-only (Partner Nodes), no open local weights. Expected mid-to-late Q2 2026. When weights drop, **all `build_wan_*` will need migration**.
- **RealRestorer** (StepFun, Mar 2026) — #1 open-source restorer (9 degradation types, Flux-VAE). Blocked: non-commercial academic model license.
- **Netflix VOID** — Physics-aware video object removal, best-in-class. Blocked: requires 40 GB+ VRAM (A100/H100). RTX 5060 Ti 16 GB insufficient.
- **HiDream-O1 base (BF16)** — needs 20–24 GB; use FP8 variant only (T2-1).
- **BFS face-swap LoRA ecosystem** — diffusion-native face/head-swap on QIE-2511 / LTX-Video (attikidd May 19, Muapi May 23). Different paradigm; monitor adoption.
- GLM-Image 16B (VRAM too high), ComfyUI-TurboQuant (4 commits, early stage), VideoRLVR-Wan2.2 (research), Mix3R (paper-only), Hassaku XL v3.0 WIP (unstable), Sapiens2 matting (VRAM needs testing on 16 GB).

---

## No-finds (verified clean)

HunyuanVideo (no new checkpoint) · FramePack F1 (no update) · CogVideoX (no update) · Mochi (no update) · SeedVR2 v2.5.24 (no update) · FLUX.1-dev (no new ckpt) · Flux Kontext (no new ckpt) · Lumina2 (no new releases) · QwenEdit base (no new releases) · DDColor (no update) · InsightFace / ArcFace (no update) · PuLID Flux v0.9.1 (current) · Flux/SDXL ControlNet (none found in window)

---

> **Reminder:** the local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh
> the ComfyUI workflow snapshots automatically once node-pack upgrades are applied on the user's machine.

---

_Do not merge — leave open for human review. Implementation upgrades require local node-pack installs on the user's machine._
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Laib6yaSCuyHeENzUHEE3T)_