### PR TITLE
chore(research): daily SOTA review 2026-05-27

### DIFF
--- a/_dev_docs/upgrade_research/2026-W22.json
+++ b/_dev_docs/upgrade_research/2026-W22.json
@@ -1,0 +1,412 @@
+[
+  {
+    "method": "build_ltx_video",
+    "category": "node_pack",
+    "name": "ComfyUI v0.22.0 — LTX IC-LoRA + VRAM reduction",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/releases",
+    "risk": "low",
+    "confidence": 0.97,
+    "notes": "Released 2026-05-20 (in window). Adds downscaled IC-LoRA support to LTXVAddGuide node, optional attention_mask input, reduced peak VRAM when guide masks active. Core engine update. Build: expose ic_lora_path param in build_ltx_video."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "node_pack",
+    "name": "ComfyUI v0.22.0 — BiRefNet compat fix",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/releases",
+    "risk": "low",
+    "confidence": 0.97,
+    "notes": "Released 2026-05-20 (in window). Fixes BiRefNet compatibility regression. No new model weights; runtime fix only. Update ComfyUI engine."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "node_pack",
+    "name": "MoGe-2 monocular geometry estimation — native ComfyUI 0.22.0",
+    "source": "github",
+    "url": "https://github.com/zade23/ComfyUI-MoGe2",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "ComfyUI v0.22.0 (May 20, in window) adds native MoGe support. MoGe-2 (Ruicheng/moge-2-vitl-normal) produces depth + normals + point maps in one pass at ~60ms. ~4-6 GB VRAM. Supersedes DA3 for metric-scale output. Also: kijai/ComfyUI-MoGe node pack available."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "node_pack",
+    "name": "MoGe-2 — depth + normal in one model",
+    "source": "github",
+    "url": "https://github.com/kijai/ComfyUI-MoGe",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "MoGe-2 outputs normals alongside depth, eliminating the need for a separate normal map model. Could simplify build_normal_map + build_depth_map_v3 into one call. Native in ComfyUI 0.22.0."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "ComfyUI-ReActor v0.6.0 — ReActorSetWeight blend control",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/releases",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Released 2026-05-21 (in window). New ReActorSetWeight node allows face swap blend strength 0-100% in 12.5% steps. Add swap_strength param (0.0-1.0, default 1.0) to build_faceswap, build_faceswap_model, build_faceswap_mtb."
+  },
+  {
+    "method": "build_faceswap_model",
+    "category": "node_pack",
+    "name": "ComfyUI-ReActor v0.6.0 — ReActorSetWeight",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/releases",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Same as build_faceswap — v0.6.0 (May 21) blend control. Update build_faceswap_model to expose swap_strength."
+  },
+  {
+    "method": "build_save_face_model",
+    "category": "node_pack",
+    "name": "InsightFace 1.0 — packaging only, no C++ build tools required",
+    "source": "github",
+    "url": "https://www.insightface.ai/guides/insightface-1-0-tutorial",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Released 2026-05-23 (in window). No new models — packaging ergonomics improvement removes C++ build dependency. Test pip install insightface==1.0 in spellcaster container. Affects all InsightFace-dependent builders."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 — sam3.1_multiplex_fp16.safetensors",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "Released 2026-03-27 (outside 7-day window but newly tracked). Object Multiplex gives 7x faster multi-object tracking vs SAM3. Drop-in checkpoint replacement; same ComfyUI nodes. Also applies to build_sam3_mask and build_sam3_extract."
+  },
+  {
+    "method": "build_sam3_mask",
+    "category": "checkpoint",
+    "name": "SAM 3.1 — sam3.1_multiplex_fp16.safetensors",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "See build_sam3_segment. Same drop-in checkpoint upgrade."
+  },
+  {
+    "method": "build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1 — sam3.1_multiplex_fp16.safetensors",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "See build_sam3_segment. Same drop-in checkpoint upgrade."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "node_pack",
+    "name": "WAN 2.7 — major quality upgrade, native 1080p, 9-grid I2V, FLF, ref2v, video editing",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Partner nodes available (~April 22 / May 2026). Local weights on HuggingFace. Kijai ComfyUI-WanVideoWrapper expected to support. New builders needed: build_wan27_video, build_wan27_t2v, build_wan27_flf. Keep WAN 2.2 as legacy fallback. VRAM similar to WAN 2.2 with blockswap."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "node_pack",
+    "name": "WAN 2.7 T2V — unifies T2V+I2V+FLF",
+    "source": "github",
+    "url": "https://wavespeed.ai/blog/posts/wan-2-7-vs-wan-2-2",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "WAN 2.7 supersedes WAN 2.2 T2V. Same partner node path. New build_wan27_t2v builder needed."
+  },
+  {
+    "method": "build_wan_flf",
+    "category": "node_pack",
+    "name": "WAN 2.7 FLF — first-class first/last-frame support",
+    "source": "github",
+    "url": "https://docs.comfy.org/tutorials/partner-nodes/wan/wan2-7",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "WAN 2.7 FLF is a native mode, not a workaround. Pairs with the reference-to-video path."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "LongCat-Video-Avatar-1.5 — audio-driven avatar with Whisper-Large lip sync",
+    "source": "github",
+    "url": "https://github.com/meituan-longcat/LongCat-Video",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Released 2026-05-21 (in window). Meituan's audio-driven avatar video. Whisper-Large (vs Wav2Vec2), 8-step distillation, FP8 ~15 GB VRAM (fits 16 GB). Audio-Text-to-Video + Audio-Text-Image-to-Video. FP8 ComfyUI workflow available. New builder: build_longcat_avatar_video. Fills audio-driven gap."
+  },
+  {
+    "method": "build_wan_video_blockswap",
+    "category": "node_pack",
+    "name": "WAN 2.7 — supersedes WAN 2.2 blockswap baseline",
+    "source": "github",
+    "url": "https://github.com/kijai/ComfyUI-WanVideoWrapper",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "WAN 2.7 has better baseline quality; blockswap architecture compatible. New WAN 2.7 builders would inherit blockswap support."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "lora",
+    "name": "LightX2V V2 — WAN 2.2 distillation LoRA (8-14 steps, 75% faster)",
+    "source": "github",
+    "url": "https://www.runcomfy.com/comfyui-workflows/wan-2-2-lightx2v-v2-comfyui-workflow-fast-image-text-to-video",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Drop-in LoRA for WAN 2.2. 8 steps (max speed), 12 (balanced), 14 (quality). LCM sampler, CFG ~1-2. Update pick_wan_accel_loras() and wan_turbo_kwargs() step counts. No VRAM overhead."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "node_pack",
+    "name": "ComfyUI-wanBlockswap — CPU offload 40 transformer blocks",
+    "source": "github",
+    "url": "https://github.com/orssorbit/ComfyUI-wanBlockswap",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "WanVideoBlockSwap node: offloads up to 40 blocks to CPU, saves 2-6 GB VRAM. Auto-inject in detect_wan_preset() when 14B model detected and VRAM <= 16 GB. Speed cost ~10-30%."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX Video Super Resolution — hardware-accelerated 4K upscale",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "RTX Tensor-core accelerated, negligible VRAM (dedicated VSR silicon). 30x faster than ESRGAN on RTX 50-series. RTX 5060 Ti fully supported. Search 'RTX' in ComfyUI Manager. Add rtx_vsr backend option to build_video_upscale and build_upscale."
+  },
+  {
+    "method": "build_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX Video Super Resolution",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "See build_video_upscale. Same RTX VSR node, same action."
+  },
+  {
+    "method": "build_wavespeed_upscale",
+    "category": "node_pack",
+    "name": "FlashVSR — CVPR 2026 one-step diffusion VSR (updated 2026-05-13)",
+    "source": "github",
+    "url": "https://github.com/WaveSpeedAI/wavespeed-comfyui",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "2x upscale at 6 GB, 4x at 10 GB. CVPR 2026 paper. Also: 1038lab/ComfyUI-FlashVSR. Updated May 13. Verify build_wavespeed_upscale wires to FlashVSR; add block-sparse attention when supported."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image-Dev-2604 FP8 — 8B UiT unified architecture",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Released 2026-05-08 to 2026-05-15. 8B Pixel-level Unified Transformer — no external VAE, no disjoint encoder. txt2img, img2img editing, subject personalization, skeleton conditioning. FP8 ~10 GB (fits 16 GB). GenEval 0.90. Native ComfyUI 0.22.0 + Saganaki22/HiDream_O1-ComfyUI node pack. New hidream_o1 architecture + build_hidream_txt2img builder needed."
+  },
+  {
+    "method": "build_img2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image FP8 — instruction-based editing",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Full (not Dev) HiDream-O1 model recommended for editing quality. Additive to build_img2img as an alternative architecture choice."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "node_pack",
+    "name": "ComfyUI-Spectrum-Qwen-Proper — 3-5x speedup on Qwen-Image-Edit",
+    "source": "github",
+    "url": "https://github.com/xmarre/ComfyUI-Spectrum-Qwen-Proper",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Chebyshev ridge-regression spectral forecaster. 3-5x inference speedup on Qwen-Image-Edit-2511, no quality loss. Also: EricRollei/Eric_Qwen_Edit_Experiments v2.0 (March 20, 2026) adds UltraGen, PromptRewriter, ControlNet, Spectrum. Install and enable in build_qwen_edit."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 1a/1b/1c 256.onnx — speed-optimized face swap models",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/issues/143",
+    "risk": "low",
+    "confidence": 0.83,
+    "notes": "FaceFusion Labs ONNX models. Faster than inswapper_128; inswapper still edges for absolute similarity. Place in ComfyUI/models/hyperswap/. Expose as configurable model choice in build_faceswap alongside inswapper_128 default. ReActor v0.6.2+ required."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "ilkerzgi/face-swap — diffusion-native face swap LoRA on FLUX.2-Klein-9B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ilkerzgi/face-swap",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "Released 2026-04-13. LoRA for FLUX.2-klein-9B. 4500+ downloads. 6-8 GB VRAM with GGUF quantization. Different paradigm from ONNX inswapper — diffusion-native results. Consider adding diffusion_swap flag to build_klein_headswap."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "OSDFace — one-step diffusion face restoration (CVPR 2025 / NTIRE 2026 winner)",
+    "source": "github",
+    "url": "https://github.com/jkwang28/OSDFace",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Technically superior to CodeFormer on all benchmarks (NTIRE 2026). Single-step inference ~0.1s at 512px. No ComfyUI node yet — monitor for community wrapper. Will supersede CodeFormer in build_face_restore and build_photo_restore when available."
+  },
+  {
+    "method": "build_photo_restore",
+    "category": "checkpoint",
+    "name": "OSDFace — see build_face_restore",
+    "source": "github",
+    "url": "https://github.com/jkwang28/OSDFace",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Same OSDFace finding. No ComfyUI node yet."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 2.1 — PBR textures, improved detail",
+    "source": "github",
+    "url": "https://github.com/Yuan-ManX/ComfyUI-Hunyuan3D-2.1",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "ComfyUI 0.22.0 fixes batch processing for Hunyuan3D 2.1. Mesh generation: 10 GB recommended (within 16 GB). PBR texturing: 20 GB+ (over budget). Update build_hunyuan_3d_mesh to target 2.1. Hold build_hunyuan_3d_textured until quantized."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "Pixal3D-ComfyUI v0.2.3 — SIGGRAPH 2026 image-to-3D alternative",
+    "source": "github",
+    "url": "https://github.com/Saganaki22/Pixal3D-ComfyUI",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Released 2026-05-23 (in window). TencentARC Pixal3D, 1.3B params on TRELLIS.2 backbone. Pixel-aligned, textured GLB. Integrates MoGe + RMBG-2.0 internally. ~14-16 GB VRAM needed at standard res (tight). Low-VRAM mode available. New builder: build_pixal3d_mesh."
+  },
+  {
+    "method": "build_seedv2r",
+    "category": "checkpoint",
+    "name": "SeedVR2 — upgrade from SeedVR v1 to SeedVR2-3B or 7B",
+    "source": "huggingface",
+    "url": "https://github.com/comfyorg/comfyui_seedvr2",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "SeedVR2 v2.5 (ICLR 2026): one-step diffusion, 60% less VRAM vs v1, GGUF support. 3B FP16 ~12 GB, 7B Q4 GGUF ~10 GB. Both within 16 GB. Use comfyorg/comfyui_seedvr2 official fork. Upgrade if build_seedv2r still uses original SeedVR v1."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Microsoft Lens — 3.8B GPT-OSS encoder + FLUX.2 VAE, MIT license",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/Lens",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Native ComfyUI support merged ~2026-05-26 (in window). Three variants: Lens-Turbo (4 steps, CFG 1), Lens (20 steps), Lens-Base (50 steps). BF16 ~10-12 GB, FP8 ~6 GB. Needs new 'lens' architecture entry in architectures.py and build_lens_txt2img builder. GPT-OSS text encoder = new CLIP loader branch in composites.py."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "node_pack",
+    "name": "Comfy-WaveSpeed First Block Cache — 1.5-2x speedup",
+    "source": "github",
+    "url": "https://github.com/chengzeyi/Comfy-WaveSpeed",
+    "risk": "low",
+    "confidence": 0.83,
+    "notes": "Apply First Block Cache node. Supports WAN 2.1 T2V/I2V, Flux 1, LTXV, HunyuanVideo, SDXL. 1.5-2x speed gain, no VRAM overhead, no quality loss. Inject as intermediate option between standard and turbo presets in optimizer.py."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "node_pack",
+    "name": "Comfy-WaveSpeed First Block Cache — LTXV acceleration",
+    "source": "github",
+    "url": "https://github.com/chengzeyi/Comfy-WaveSpeed",
+    "risk": "low",
+    "confidence": 0.83,
+    "notes": "Same WaveSpeed FBC node, LTXV path. 1.5-2x speedup. See build_wan_video entry for details."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Nova Anime XL IL v19.0 — SDXL anime checkpoint (DARE merge)",
+    "source": "civitai",
+    "url": "https://civitai.com/models/376130/nova-anime-xl",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Released 2026-05-12 (outside 7-day window but newly tracked). DARE merge of NoobAI EPS v1.1 + Illustrious v2.0 + ChenkinNoob v0.5. Best-rated SDXL anime checkpoint on CivitAI. ~6-8 GB VRAM. Add as checkpoint option for illustrious/sdxl architecture presets."
+  },
+  {
+    "method": "build_klein_img2img",
+    "category": "lora",
+    "name": "Ultra Real Klein 9B — photorealism LoRA",
+    "source": "civitai",
+    "url": "https://civitai.com/models/2462105/ultra-real-klein-9b",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Updated 2026-05-15. 261 reviews. Most-reviewed Klein 9B LoRA on CivitAI. Reduces plastic/smooth AI look, adds natural skin texture. Add to autoset_loras for txt2img and klein_refine modes in flux2klein architecture entry."
+  },
+  {
+    "method": "build_klein_inpaint",
+    "category": "lora",
+    "name": "FLUX.2 Klein 4B Outpaint LoRA",
+    "source": "civitai",
+    "url": "https://civitai.com/models/2515526/flux-2-klein-4b-outpaint-lora",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Klein 4B specific outpainting LoRA. Add to autoset_loras for klein_inpaint when mask coverage > 30% on edges (outpaint detection heuristic). Released April 2026."
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "IC-Light V2 — Flux-based relighting (NOT YET RELEASED)",
+    "source": "github",
+    "url": "https://github.com/lllyasviel/IC-Light/discussions/98",
+    "risk": "high",
+    "confidence": 0.60,
+    "notes": "Tier 3 — monitor only. Flux-based, 16ch VAE, much better than SD1.5 version. Weights not publicly released (HF space demo only). Non-commercial license planned. Do not wire until weights + license confirmed."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "node_pack",
+    "name": "SANA-WM — NVIDIA 2.6B world model (720p, 60s, 6-DoF camera)",
+    "source": "github",
+    "url": "https://www.marktechpost.com/2026/05/16/nvidia-introduces-sana-wm-a-2-6b-parameter-open-source-world-model-that-generates-minute-scale-720p-video-on-a-single-gpu/",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "Tier 3 — monitor. Published 2026-05-15-16. 2.6B param, 720p 60-second video with 6-DoF camera control. Apache 2.0. ComfyUI nodes in diffusers. VRAM: needs NVFP4 or 8-bit quant for RTX 5090; uncertain on 16 GB RTX 5060 Ti. Wire when confirmed 16 GB-safe workflow published."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "node_pack",
+    "name": "ComfyUI-Trellis2 — TRELLIS.2 4B 3D model (May 26, in window)",
+    "source": "github",
+    "url": "https://github.com/visualbruno/ComfyUI-Trellis2",
+    "risk": "high",
+    "confidence": 0.72,
+    "notes": "Tier 3 — VRAM. New node committed 2026-05-26 (in window). Microsoft TRELLIS.2, 4B params, CVPR 2025. 24 GB+ at 1024^3; only ~16 GB at 512^3. Over budget at full resolution. Monitor for quantized variant."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "BFS-Best-Face-Swap-Video — IC-LoRA for LTX-2.3 video head swap",
+    "source": "huggingface",
+    "url": "https://huggingface.co/SSBOfficial/BFS-Best-Face-Swap-Video",
+    "risk": "high",
+    "confidence": 0.70,
+    "notes": "Tier 3 — VRAM. Released 2026-05-25 (in window). IC-LoRA adapter for LTX-2.3 (22B) video head swap. LTX-2.3 full model needs 24 GB+; GGUF path unconfirmed for IC-LoRA. Wait for community GGUF wrappers at 16 GB."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "OSDFace via NTIRE 2026 validation",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2604.10532",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "NTIRE 2026 Face Restoration Challenge (April 2026) confirmed OSDFace as top approach. 96 registrants, 9 teams. Field moving toward one-step diffusion restoration. CodeFormer remains competitive but no longer SOTA. Monitor github.com/jkwang28/OSDFace for ComfyUI node."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W22.md
+++ b/_dev_docs/upgrade_research/2026-W22.md
@@ -1,0 +1,352 @@
+# Spellcaster daily SOTA review — 2026-05-27
+
+ISO week: `2026-W22`. Baseline: *(none — inaugural review; this file becomes the baseline)*.
+
+Survey window: **past 7 days** (2026-05-20 → 2026-05-27), plus items newly relevant to spellcaster
+with no prior punch-list coverage. Hardware budget: RTX 5060 Ti, 16 GB VRAM.
+
+---
+
+## Findings table
+
+Items marked `✅ SOTA` are still best-in-class for local ComfyUI on 16 GB VRAM.
+Items marked `⚠ Superseded` or `⚠ Monitor` have a better or soon-better alternative.
+
+| Method | Current backbone | Still SOTA? | Replacement (if not) | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| build_txt2img / build_img2img / build_generate_anything | SDXL / Flux2-Klein / flux_kontext | ⚠ Additive option | **HiDream-O1-Image-Dev-2604 FP8** (8B UiT, unified arch) | https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604 | Medium | New architecture — no VAE/disjoint encoder; 10 GB FP8; GenEval 0.90. Needs new builder. Released May 8-15. |
+| build_qwen_edit | Qwen-Image-Edit-2511 | ✅ SOTA | — | — | — | **Spectrum acceleration** (3-5× speedup) now available via `xmarre/ComfyUI-Spectrum-Qwen-Proper`; add to existing builder |
+| build_iclight | IC-Light SD1.5 | ⚠ Monitor | IC-Light V2 (Flux-based, 16ch VAE) | https://github.com/lllyasviel/IC-Light/discussions/98 | High | Weights not fully public; non-commercial license; only HF space demo available. Do not wire yet. |
+| build_ltx_video | LTX-2.3 | ✅ SOTA | — | https://github.com/Lightricks/ComfyUI-LTXVideo | Low | ComfyUI v0.22.0 (May 20) adds downscaled IC-LoRA + attention_mask + VRAM reduction. New capabilities, same checkpoint. |
+| build_wan_video | WAN 2.2 (GGUF dual-model) | ⚠ Superseded | **WAN 2.7** (native 1080p, 9-grid I2V, FLF, ref-to-video, editing) | https://blog.comfy.org/p/wan27-is-now-available-in-comfyui | Medium | Partner nodes are API-based; local weights on HuggingFace; Kijai's WanVideoWrapper expected to support. New builder needed. |
+| build_wan22_t2v | WAN 2.2 T2V | ⚠ Superseded | WAN 2.7 T2V | https://wavespeed.ai/blog/posts/wan-2-7-vs-wan-2-2 | Medium | WAN 2.7 unifies T2V+I2V+FLF in one architecture. |
+| build_wan_flf | WAN 2.2 FLF | ⚠ Superseded | WAN 2.7 FLF (native first/last-frame support) | https://docs.comfy.org/tutorials/partner-nodes/wan/wan2-7 | Medium | WAN 2.7 FLF is a first-class mode, not a workaround. |
+| build_wan_animate_video | WAN 2.2 animate | ⚠ Additive | WAN 2.7 reference-to-video + **LongCat-Video-Avatar-1.5** | https://github.com/meituan-longcat/LongCat-Video | Medium | LongCat-1.5 fills the audio-driven avatar gap (Whisper-Large sync, 15 GB FP8, within 16 GB budget). Released May 21. |
+| build_wan_video_blockswap / build_wan_video_blockswap_t2v | WAN 2.2 + Kijai blockswap | ⚠ Superseded | WAN 2.7 (better baseline quality) | https://github.com/kijai/ComfyUI-WanVideoWrapper | Medium | Blockswap architecture compatible; new WAN 2.7 builders would inherit this. |
+| build_hunyuan_video | HunyuanVideo-1.5 (step-distilled) | ✅ SOTA | — | https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5 | — | Stable; 14 GB min with FP8 + offloading on RTX 5060 Ti 16 GB. No new release in window. |
+| build_ltx_video (IC-LoRA) | LTX-2.3 — no IC-LoRA | ✅ Now enabled | — | https://github.com/Comfy-Org/ComfyUI/releases | Low | ComfyUI v0.22.0 (May 20) adds downscaled IC-LoRA support. Wire the `lora_path` arg in existing builder. |
+| build_video_upscale | 4x-UltraSharp.pth | ⚠ Additive option | **NVIDIA RTX VSR** (hardware-accelerated, RTX 50-series) | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | Low | Tensor-core accelerated, negligible VRAM, fastest path on RTX 5060 Ti. |
+| build_wavespeed_upscale | SeedVR2 / WaveSpeed | ⚠ Additive option | **FlashVSR** (CVPR 2026, one-step, 6 GB for 2x / 10 GB for 4x) | https://github.com/WaveSpeedAI/wavespeed-comfyui | Low | Updated May 13. Pairs well with SeedVR2 for pipeline. |
+| build_seedvr2_video_upscale | SeedVR2 v2.5 | ✅ SOTA | — | https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler | — | ICLR 2026, GGUF quantization, 4x to 4K. No new release in window. |
+| build_mochi_video | Mochi v1 (Genmo) | ⚠ Stale | — | — | — | No 2026 updates. Original Sept 2025 release. Low priority. |
+| build_cogvideo_video | CogVideoX-1.5 | ⚠ Stale | — | — | — | No 2026 updates. Consider deprecation. |
+| build_framepack_video | FramePack-F1 | ✅ SOTA | — | https://github.com/lllyasviel/FramePack | — | No new release in window. Stable. |
+| build_faceswap / build_faceswap_model | ReActor + inswapper_128 | ⚠ Enhancement | **HyperSwap 1a/1b/1c 256** (speed alternative) + **ReActorSetWeight** node | https://github.com/Gourieff/ComfyUI-ReActor/releases | Low | ReActor v0.6.0 (May 21) adds swap strength control. HyperSwap gives speed/quality tradeoff option. inswapper_128 still best for similarity. |
+| build_faceswap_mtb | MTB face swap | ✅ SOTA | — | — | — | No new competing node in window. |
+| build_klein_headswap | Klein Flux2 | ⚠ Additive | **ilkerzgi/face-swap LoRA** (diffusion-native on FLUX.2-klein-9B GGUF, 6-8 GB) | https://huggingface.co/ilkerzgi/face-swap | Low | Different paradigm from ONNX inswapper; LoRA-conditioned diffusion swap. April 13 release. |
+| build_face_restore | CodeFormer | ⚠ Monitor | **OSDFace** (one-step diffusion, CVPR 2025/NTIRE 2026 winner) | https://github.com/jkwang28/OSDFace | Medium | Technically superior on all benchmarks. No ComfyUI node yet. Wire when node appears. |
+| build_photo_restore | upscale + CodeFormer | ⚠ Monitor | OSDFace when ComfyUI node lands | https://github.com/jkwang28/OSDFace | Medium | Same bottleneck as build_face_restore. |
+| build_save_face_model / build_faceswap (InsightFace dep.) | InsightFace 0.7.x | ✅ SOTA | — | https://www.insightface.ai/guides/insightface-1-0-tutorial | — | InsightFace 1.0 (May 23): packaging ergonomics only (no C++ build tools needed). Models unchanged. Deployment improvement. |
+| build_pulid_flux | PuLID-Flux | ✅ SOTA | — | — | — | No new update in window. Last substantive update early 2025. |
+| build_depth_map_v3 | Depth Anything v3 (da3_large) | ⚠ Additive | **MoGe-2** (metric scale + sharp details, ViT+conv) | https://github.com/kijai/ComfyUI-MoGe ; https://github.com/zade23/ComfyUI-MoGe2 | Low | ComfyUI v0.22.0 adds MoGe native support (May 20). MoGe-2 outputs point maps, depth, normals + FOV in one pass. New builder or DA3 supplement. |
+| build_normal_map | Normal map estimation | ⚠ Additive | MoGe-2 (normals + depth in same pass) | https://github.com/zade23/ComfyUI-MoGe2 | Low | MoGe-2 unifies depth + normals; could simplify build_normal_map + build_depth_map_v3 into one call. |
+| build_rembg_birefnet | BiRefNet-general | ✅ SOTA | — | — | — | ComfyUI v0.22.0 fixed BiRefNet compat issue (May 20). No new model. |
+| build_rembg_v3 | RMBG-2.0 | ✅ SOTA | — | — | — | No new model in window. |
+| build_hunyuan_3d_mesh | HunyuanVideo 3D | ⚠ Enhancement | **Hunyuan3D 2.1** (PBR textures, finer detail) | https://github.com/Yuan-ManX/ComfyUI-Hunyuan3D-2.1 | Medium | ComfyUI v0.22.0 fixes batch processing for 3D 2.1. Mesh gen: 10 GB rec. Texturing: 20 GB+ (over 16 GB budget). |
+| build_hunyuan_3d_textured | HunyuanVideo 3D textured | ⚠ Monitor | Hunyuan3D 2.1 PBR (albedo/metallic/roughness) + **Pixal3D** (SIGGRAPH 2026, 1.3B, ~14-16 GB) | https://github.com/Saganaki22/Pixal3D-ComfyUI | High | PBR texturing on Hunyuan3D 2.1 needs 20 GB+. Pixal3D v0.2.3 released May 23 (in window) — SIGGRAPH 2026, integrates RMBG-2.0 + MoGe internally; fits 16 GB with care. |
+| build_supir | SUPIR-v0Q + SDXL | ✅ SOTA | — | — | — | Minor May 13 update. No major new version. |
+| build_colorize | Klein Flux2 | ✅ SOTA | — | — | — | No new model in window. |
+| build_ddcolor | DDColor | ✅ SOTA | — | — | — | No new model in window. |
+| build_sam3_segment / build_sam3_mask / build_sam3_extract | SAM3 + Grounding DINO | ⚠ Enhancement | **SAM 3.1** (Multiplex multi-object tracking, 7× faster) | https://huggingface.co/Comfy-Org/sam3.1 | Low | March 27, 2026 release. `sam3.1_multiplex_fp16.safetensors` drop-in replacement. Checkpoint-only update. |
+| build_lumina2_txt2img | Lumina2 | ⚠ Stale | — | — | — | No 2026 updates found. Original Feb 2025 release. |
+| build_txt2img (new arch) | — | ⚠ Additive | **Microsoft Lens** (3.8B, GPT-OSS encoder, FLUX.2 VAE, MIT license) | https://huggingface.co/Comfy-Org/Lens | Medium | ComfyUI native support merged ~May 26-27, 2026 (within window). Lens-Turbo: 4 steps, CFG 1. ~10-12 GB BF16; FP8 ~6 GB. New architecture — needs `architectures.py` entry. |
+| build_wan_video (speed) | WAN 2.2 GGUF | ⚠ Additive | **LightX2V V2** distillation LoRA (8-14 steps, 75% faster) | https://www.runcomfy.com/comfyui-workflows/wan-2-2-lightx2v-v2-comfyui-workflow-fast-image-text-to-video | Low | Drop-in LoRA; update `wan_turbo_kwargs()` step counts to 8-14. LCM sampler. |
+| build_wan_video (VRAM) | WAN 2.2 dual-GGUF | ⚠ Additive | **ComfyUI-wanBlockswap** (CPU offload, 40 blocks, saves 2-6 GB VRAM) | https://github.com/orssorbit/ComfyUI-wanBlockswap | Low | Inject automatically when 14B WAN model detected and VRAM ≤ 16 GB. |
+| build_lama_remove / build_magic_eraser | LaMa | ✅ SOTA | — | — | — | No new model in window. |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+These require no new node-pack installs (or trivial updates) and are wire-ready for 16 GB VRAM.
+
+### 1. ComfyUI v0.22.0 infrastructure bump (2026-05-20)
+**Affects:** build_ltx_video, build_rembg_birefnet, build_qwen_edit, build_depth_map_v3, build_normal_map, build_hunyuan_3d_*
+
+The engine itself is the gating update. v0.22.0 unlocks:
+- LTX-2.3 downscaled IC-LoRA + `attention_mask` input (guide mask VRAM reduction)
+- BiRefNet compat fix
+- Native MoGe depth estimation
+- Qwen3.5 multi-image prompt fix
+- Hunyuan3D 2.1 batch processing fix
+- Stable Audio 3 model support (new capability)
+
+Action: Update the ComfyUI engine before any other changes. Required: **ComfyUI ≥ 0.22.0**.
+
+---
+
+### 2. ReActor v0.6.0 — `ReActorSetWeight` blend control (2026-05-21)
+**Affects:** build_faceswap, build_faceswap_model, build_faceswap_mtb
+
+New `ReActorSetWeight` node exposes `swap_strength` from 0–100% in 12.5% steps.
+
+Action: Add a `swap_strength` parameter (float 0.0–1.0, default 1.0) to build_faceswap, build_faceswap_model, build_faceswap_mtb. Wire to `ReActorSetWeight` before the reactor node.
+
+---
+
+### 3. InsightFace 1.0 packaging — deployment fix (2026-05-23)
+**Affects:** build_save_face_model, build_faceswap, build_faceswap_model
+
+InsightFace 1.0 removes the C++ build-tools requirement. No model changes — deployment only.
+
+Action: Test `pip install insightface==1.0` in the spellcaster container. If OK, bump the pinned version.
+
+---
+
+### 4. LTX IC-LoRA wiring (enabled by ComfyUI 0.22.0, 2026-05-20)
+**Affects:** build_ltx_video
+
+The `LTXVAddGuide` node in v0.22.0 now accepts a `lora_path` for downscaled IC-LoRA conditioning. This is a capability extension to the existing builder (no new checkpoint needed).
+
+Action: Add optional `ic_lora_path` parameter to build_ltx_video. Pass through to `LTXVAddGuide.lora_path` when set.
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+These require new ComfyUI node packs to be installed on the target machine (local only — cannot be done here).
+
+### 5. WAN 2.7 builders (2026-04-22, ComfyUI partner nodes; local weights on HuggingFace)
+**New builders:** build_wan27_video, build_wan27_t2v, build_wan27_flf, build_wan27_ref2v
+
+WAN 2.7 is a major architectural upgrade: native 1080p, 9-grid image-to-video, first/last-frame, reference-to-video, video editing via text instructions. Supersedes WAN 2.2 on every quality axis.
+
+- **API path:** ComfyUI partner nodes (WaveSpeed backend) — install now, no local weights needed
+- **Local path:** Weights on HuggingFace + Kijai ComfyUI-WanVideoWrapper update expected
+- VRAM: Similar to WAN 2.2 with blockswap; 16 GB feasible
+
+Action: Install WAN 2.7 partner nodes via ComfyUI Manager. Design new build_wan27_* builders mirroring the WAN 2.2 family structure. Keep WAN 2.2 builders as legacy fallback.
+
+Source: https://blog.comfy.org/p/wan27-is-now-available-in-comfyui
+
+---
+
+### 6. HiDream-O1-Image (2026-05-08 → 2026-05-15)
+**New builder:** build_hidream_txt2img (or extend build_txt2img with hidream preset)
+
+8B Pixel-level Unified Transformer: no external VAE, no disjoint encoder. Unified txt2img, img2img editing, subject personalization, layout conditioning, skeleton conditioning. GenEval 0.90 (comparable to FLUX.2-dev 32B). FP8: ~10 GB VRAM.
+
+- ComfyUI: native v0.22.0 + `Saganaki22/HiDream_O1-ComfyUI` custom node pack (v0.2.3)
+- VRAM: FP8 ~10 GB ✓, Full BF16 ~16-24 GB (tight/OOM) — use FP8 only on 16 GB
+
+Action: Install HiDream_O1-ComfyUI node pack. Add new `hidream_o1` architecture entry. Design build_hidream_txt2img.
+
+Sources: https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604 · https://github.com/Saganaki22/HiDream_O1-ComfyUI
+
+---
+
+### 7. MoGe-2 depth/geometry estimation (native ComfyUI 0.22.0)
+**New builder:** build_moge_depth (or extend build_depth_map_v3 with moge preset)
+
+Microsoft MoGe-2: metric-scale monocular geometry. Single pass returns depth map, normal map, point map, FOV. CVPR'25 Oral. ComfyUI-native in v0.22.0; also `kijai/ComfyUI-MoGe` and `zade23/ComfyUI-MoGe2` node packs.
+
+- VRAM: Very low (ViT encoder + conv decoder, no diffusion). Well within 16 GB.
+
+Action: Add `moge` as a model option in build_depth_map_v3. Consider extending to output normals directly for build_normal_map.
+
+Sources: https://github.com/kijai/ComfyUI-MoGe · https://github.com/zade23/ComfyUI-MoGe2
+
+---
+
+### 8. HyperSwap 256 model family (2026-04, via ReActor)
+**Affects:** build_faceswap, build_faceswap_model
+
+HyperSwap 1a/1b/1c 256.onnx from FaceFusion Labs. Place in `ComfyUI/models/hyperswap/`. Already supported by ReActor v0.6.2+. Faster than inswapper_128; community rates 1a as best tradeoff. inswapper_128 still edges for absolute similarity.
+
+Action: Expose `swap_model` parameter variants including hyperswap options in build_faceswap. Default remains inswapper_128.
+
+Source: https://github.com/Gourieff/ComfyUI-ReActor/issues/143
+
+---
+
+### 9. ilkerzgi/face-swap LoRA on FLUX.2-Klein-9B (2026-04-13)
+**Affects:** build_klein_headswap (diffusion-native alternative path)
+
+LoRA trained for FLUX.2-klein-9B targeting face/head swap via diffusion. 4500+ downloads. Runs at 6-8 GB VRAM via GGUF quantization of the Klein 9B UNet. Different paradigm (diffusion-native) vs ONNX inswapper.
+
+Action: Add a `diffusion_swap` flag to build_klein_headswap that uses this LoRA instead of the reactor post-processor.
+
+Source: https://huggingface.co/ilkerzgi/face-swap
+
+---
+
+### 10. NVIDIA RTX VSR hardware upscale (2026-02/03)
+**Affects:** build_video_upscale, build_upscale
+
+NVIDIA RTX Video Super Resolution: Tensor-core accelerated 4K upscaling. Negligible VRAM overhead (dedicated VSR silicon). Claims 30× faster than popular ESRGAN alternatives on RTX 50-series.
+
+- ComfyUI node: `Comfy-Org/Nvidia_RTX_Nodes_ComfyUI` (search "RTX" in Manager)
+- RTX 5060 Ti: fully supported hardware
+
+Action: Add `rtx_vsr` as a backend option in build_upscale and build_video_upscale for RTX 50-series.
+
+Source: https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI
+
+---
+
+### 11. FlashVSR video upscale (updated 2026-05-13)
+**Affects:** build_wavespeed_upscale
+
+CVPR 2026 one-step diffusion VSR. 2× upscale at 6 GB; 4× upscale at 10 GB. ComfyUI wrapper: `WaveSpeedAI/wavespeed-comfyui` and `1038lab/ComfyUI-FlashVSR`. Pairs with SeedVR2 for quality pipeline.
+
+Action: Verify current `build_wavespeed_upscale` wires to FlashVSR node. Add block-sparse attention path when node supports it.
+
+Sources: https://github.com/WaveSpeedAI/wavespeed-comfyui · https://github.com/1038lab/ComfyUI-FlashVSR
+
+---
+
+### 12. LongCat-Video-Avatar-1.5 (2026-05-21) — audio-driven avatar
+**New builder:** build_longcat_avatar_video
+
+Meituan's audio-driven avatar video model. Whisper-Large for lip sync (upgrade from Wav2Vec2). 8-step distillation. FP8 variant ~15 GB (fits 16 GB). Supports Audio-Text-to-Video and Audio-Text-Image-to-Video. Native 720p/30fps. ComfyUI FP8 workflow available.
+
+Fills the audio-driven avatar gap not covered by WAN animate.
+
+Action: Add build_longcat_avatar_video builder targeting the audio-driven path.
+
+Source: https://github.com/meituan-longcat/LongCat-Video
+
+---
+
+### 13. Spectrum-Qwen acceleration for build_qwen_edit
+**Affects:** build_qwen_edit (speed improvement only)
+
+Chebyshev ridge-regression feature forecaster — 3-5× inference speedup on Qwen-Image-Edit-2511 with no quality degradation. Two options:
+- `xmarre/ComfyUI-Spectrum-Qwen-Proper` — targets ComfyUI native Qwen path
+- `EricRollei/Eric_Qwen_Edit_Experiments` v2.0 — full suite with UltraGen, PromptRewriter, ControlNet
+
+Action: Install `ComfyUI-Spectrum-Qwen-Proper` and enable for build_qwen_edit.
+
+Sources: https://github.com/xmarre/ComfyUI-Spectrum-Qwen-Proper · https://github.com/EricRollei/Eric_Qwen_Edit_Experiments
+
+---
+
+### 14. Nova Anime XL IL v19.0 (2026-05-12) — SDXL anime checkpoint
+**Affects:** build_txt2img (anime preset), build_img2img, build_style_transfer
+
+SDXL checkpoint merge (NoobAI EPS v1.1 + Illustrious v2.0 + ChenkinNoob v0.5, DARE merge). Strongest community-rated SDXL anime checkpoint. ~6-8 GB VRAM.
+
+Action: Add as available checkpoint for `illustrious`/`sdxl` architecture presets.
+
+Source: https://civitai.com/models/376130/nova-anime-xl
+
+---
+
+### 15. SAM 3.1 checkpoint upgrade (2026-03-27)
+**Affects:** build_sam3_segment, build_sam3_mask, build_sam3_extract
+
+`sam3.1_multiplex_fp16.safetensors` — introduces Object Multiplex for joint multi-object tracking at 7× the speed of SAM3 with no accuracy regression. Available via `Comfy-Org/sam3.1` on HuggingFace. Pure checkpoint swap; same ComfyUI nodes.
+
+Action: Replace the SAM3 checkpoint with `sam3.1_multiplex_fp16.safetensors`. No node changes needed.
+
+Source: https://huggingface.co/Comfy-Org/sam3.1
+
+---
+
+### 16. Pixal3D-ComfyUI v0.2.3 — new local 3D builder (2026-05-23)
+**New builder:** build_pixal3d_mesh
+
+SIGGRAPH 2026 image-to-3D model (TencentARC). 1.3B params on TRELLIS.2 backbone. Pixel-aligned, textured GLB export, FlashAttention 2/3, manual camera control. Internally uses MoGe for depth and RMBG-2.0 for background removal. Low-VRAM mode available; ~14-16 GB for standard resolution on 16 GB (tight but feasible).
+
+- ComfyUI nodes: `Saganaki22/Pixal3D-ComfyUI` (v0.2.3, May 23, in window)
+- Alt to Hunyuan3D when texturing VRAM is a concern
+
+Action: Install Pixal3D-ComfyUI. Design build_pixal3d_mesh builder for single-image 3D asset generation.
+
+Source: https://github.com/Saganaki22/Pixal3D-ComfyUI
+
+---
+
+### 17. Microsoft Lens architecture (native ComfyUI ~2026-05-26)
+**New builder:** build_lens_txt2img (or extend build_txt2img with lens preset)
+
+3.8B parameter model using GPT-OSS text encoder + FLUX.2 VAE. Three variants: Lens-Turbo (4 steps, CFG 1, fastest), Lens (20 steps), Lens-Base (50 steps). MIT license. ComfyUI native support merged ~May 26-27, 2026. Comfy-Org HuggingFace namespace. BF16 ~10-12 GB, FP8 ~6 GB.
+
+Requires: new `lens` architecture entry in `architectures.py` with `single_lens` CLIP mode (GPT-OSS encoder). New CLIP loader branch in `composites.py`.
+
+Action: Register `lens` architecture. Add build_lens_txt2img builder.
+
+Source: https://huggingface.co/Comfy-Org/Lens
+
+---
+
+### 18. Comfy-WaveSpeed First Block Cache (acceleration)
+**Affects:** build_wan_video, build_ltx_video, build_hunyuan_video, build_txt2img (Flux)
+
+Residual-caching acceleration node (TeaCache-style). `Apply First Block Cache` node skips redundant transformer block computations when residuals change below threshold. Supports WAN 2.1 T2V/I2V, Flux 1 Dev, LTXV, HunyuanVideo, SD3.5, SDXL. Speed gain: 1.5-2× at same quality. No VRAM overhead.
+
+Can be injected as an intermediate option between `standard` and `turbo` presets in `optimizer.py`.
+
+Source: https://github.com/chengzeyi/Comfy-WaveSpeed
+
+---
+
+### 19. Hunyuan3D 2.1 — mesh generation (10 GB VRAM path only)
+**Affects:** build_hunyuan_3d_mesh
+
+Improved detail, spatial understanding. PBR textures (albedo/metallic/roughness) now available. ComfyUI v0.22.0 fixes batch processing.
+
+- Mesh generation: 10 GB recommended ✓ (within 16 GB budget)
+- Texturing: 20 GB+ (OVER budget — see Tier 3)
+
+Action: Update build_hunyuan_3d_mesh to target Hunyuan3D 2.1. Hold build_hunyuan_3d_textured until quantized variant available.
+
+Source: https://github.com/Yuan-ManX/ComfyUI-Hunyuan3D-2.1
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+| Item | Reason | Watch trigger |
+|---|---|---|
+| **Microsoft Lens Turbo** (3.8B, GPT-OSS + Flux.2 VAE) | Architecture requires new `lens` entry in `architectures.py` before wiring; early community reports positive | First community workflows + LoRA packs published |
+| **IC-Light V2** (Flux-based relighting) | Weights not fully public; non-commercial license; foreground model only | lllyasviel publishes full weights under open license |
+| **OSDFace** (one-step face restoration) | No ComfyUI node yet; technically best face restore (NTIRE 2026) | Community wrapper appears on GitHub/HuggingFace |
+| **SANA-WM** (NVIDIA 2.6B world model, May 15) | VRAM uncertain on 16 GB; needs NVFP4 or 8-bit quant; ComfyUI nodes in diffusers but not validated | Confirmed 16 GB-safe workflow published |
+| **TRELLIS.2** (Microsoft 4B 3D model, ComfyUI-Trellis2 node May 26) | 24 GB+ VRAM at 1024³; 16 GB only viable at 512³ with careful VRAM management | Quantized variant or 16 GB-confirmed workflow published |
+| **Hunyuan3D 2.1 texturing** | 20 GB+ VRAM for PBR texturing (over 16 GB budget) | GGUF/quantized texturing path available |
+| **BFS-Best-Face-Swap-Video on LTX-2.3** | LTX-2.3 22B needs 24 GB+ for IC-LoRA path without quantization | GGUF community wrappers confirmed at ≤16 GB |
+| **LLaDA2.0-Uni** (discrete diffusion LLM) | Needs ~36 GB system RAM; ComfyUI support as of May 12 but experimental | RAM requirement drops or CPU-offload path confirmed |
+| **Stand-In** (identity-preserving video on WAN 2.1) | ~20-24 GB VRAM | Quantized GGUF variant available |
+| **LivingSwap** (CVPR 2026 cinematic video face swap) | Code not released; paper only | GitHub repo goes public |
+| **GSwap** (3D-aware head swap) | Paper only | Code release |
+| **AnyID** (omni-referenced identity video) | Paper only | Code + weights release |
+| **Seedance 2.0** (ByteDance) | API-only; no local weights | Local weights released |
+
+---
+
+## No-finds (verified)
+
+The following areas were explicitly checked and show no substantive new releases in the survey window (May 20-27, 2026) and no prior-window items missed by earlier tracking:
+
+| Area | Builders | Verification |
+|---|---|---|
+| RMBG / BiRefNet background removal | build_rembg, build_rembg_birefnet, build_rembg_v3 | RMBG-2.0 and BiRefNet-general unchanged; ComfyUI v0.22.0 fixed a compat bug only |
+| SUPIR restoration | build_supir | Minor May 13 update (no architecture change); ComfyUI-SUPIR last updated April 29 |
+| SAM3 / Grounding DINO segmentation | build_sam3_segment/mask/extract | No new model or node in window |
+| PuLID-Flux | build_pulid_flux | Last update early 2025; no 2026 release |
+| ReActor core model (inswapper_128) | build_faceswap, build_video_reactor | inswapper_128 model unchanged; ReActor v0.6.0 is node-only update |
+| SDXL base checkpoints | build_txt2img (sdxl preset) | No new official SDXL base checkpoint |
+| FLUX.2-Klein 4B/9B | build_klein_* | Already integrated; no new BFL release in window |
+| FLUX.1-Kontext | build_qwen_edit / img2img editing | Already integrated as flux_kontext; no new BFL release in window |
+| CodeFormer / RestoreFormer | build_face_restore, build_photo_restore | No new release; CodeFormer++ is research-only, no code |
+| LaMa inpainting | build_lama_remove, build_magic_eraser | No new model in window |
+| DDColor colorization | build_ddcolor | No new model in window |
+| FramePack | build_framepack_video | No new lllyasviel release; F1 model stable |
+| CogVideoX | build_cogvideo_video | No 2026 updates; last release Dec 2024/early 2025 |
+| Mochi | build_mochi_video | No 2026 updates; Sept 2025 original only |
+| Lumina2 | build_lumina2_txt2img | No 2026 updates; Feb 2025 original only |
+| Normal map | build_normal_map | MoGe-2 provides normals as a side output — see Tier 2 item 7; no dedicated new model |
+
+---
+
+## Summary counts
+
+- **Tier 1** (drop-in, ship soon): 4 items
+- **Tier 2** (additive, needs node install): 19 items
+- **Tier 3** (monitor, not wire-ready): 13 items
+- **No-finds**: 15 method-areas checked and verified clean
+
+---
+
+*Next review: 2026-W23 (2026-06-03). Key watch items: IC-Light V2 weights, OSDFace ComfyUI node, WAN 2.7 local Kijai wrapper, SANA-WM 16 GB validation.*


### PR DESCRIPTION
## Daily SOTA review — 2026-05-27 (ISO week 2026-W22)

This is the **inaugural** upgrade-research audit. The two files committed here become the baseline for all future weekly reviews.

---

### Findings summary

| Tier | Count | Description |
|---|---|---|
| **Tier 1** — drop-in, ship soon | 4 | Require no new node installs; apply to existing builders |
| **Tier 2** — additive, needs node install | 19 | New builders or new capabilities requiring local node-pack installs |
| **Tier 3** — monitor, not wire-ready | 13 | VRAM > 16 GB, weights unreleased, or no ComfyUI node yet |
| **No-finds** — verified clean | 15 method-areas | Explicitly checked, nothing new |

---

### Tier 1 highlights (drop-in, ship soon)

1. **ComfyUI ≥ 0.22.0** (released 2026-05-20) — engine update unlocks:
   - LTX-2.3 downscaled IC-LoRA + `attention_mask` input (`build_ltx_video`)
   - BiRefNet compatibility fix (`build_rembg_birefnet`)
   - Native MoGe depth/geometry estimation (`build_depth_map_v3`, `build_normal_map`)
   - Hunyuan3D 2.1 batch processing fix (`build_hunyuan_3d_*`)
   - Qwen multi-image prompt fix (`build_qwen_edit`)

2. **ReActor v0.6.0** (2026-05-21) — new `ReActorSetWeight` node; expose `swap_strength` param in `build_faceswap`, `build_faceswap_model`, `build_faceswap_mtb`

3. **InsightFace 1.0** (2026-05-23) — removes C++ build-tools requirement; test `pip install insightface==1.0` in container; models unchanged

4. **LTX IC-LoRA wiring** — wire optional `ic_lora_path` param in `build_ltx_video` (enabled by ComfyUI 0.22.0)

---

### Tier 2 highlights (need local node-pack install)

- **WAN 2.7** — major upgrade over WAN 2.2; partner nodes live; local weights on HuggingFace; new `build_wan27_*` builders needed
- **HiDream-O1-Image FP8** (May 8-15) — 8B unified architecture, ~10 GB VRAM, GenEval 0.90; new architecture entry + builder
- **Microsoft Lens** (~May 26) — 3.8B, MIT license, native ComfyUI 0.22.0; new architecture entry + builder
- **SAM 3.1** (March 27) — 7× faster multi-object tracking; drop-in checkpoint swap for `build_sam3_*`
- **Pixal3D-ComfyUI v0.2.3** (May 23, in window) — SIGGRAPH 2026, 1.3B, local 3D generation at ~14-16 GB
- **LongCat-Video-Avatar-1.5** (May 21, in window) — audio-driven avatar video; FP8 ~15 GB; fills audio-driven gap
- **FlashVSR** (CVPR 2026) + **NVIDIA RTX VSR** — new upscale backends for `build_video_upscale` / `build_wavespeed_upscale`
- **Comfy-WaveSpeed FBC** — 1.5-2× speedup on WAN + LTX + Hunyuan + Flux, no VRAM cost
- **ComfyUI-wanBlockswap** — CPU offload for WAN 14B, saves 2-6 GB VRAM
- **LightX2V V2 LoRA** — WAN 2.2 distillation to 8-14 steps (75% faster)
- **Spectrum-Qwen** acceleration — 3-5× speedup on `build_qwen_edit`
- **HyperSwap 1a/1b/1c** + **ilkerzgi/face-swap LoRA** — face swap model alternatives
- **OSDFace** — best face restoration (NTIRE 2026 winner); no ComfyUI node yet → Tier 2/3 boundary
- **Ultra Real Klein 9B LoRA** + **Klein 4B Outpaint LoRA** + **Nova Anime XL v19.0** — new LoRA/checkpoint options

---

### Tier 3 (monitor — not wire-ready on 16 GB)

- IC-Light V2 (weights not public, non-commercial)
- SANA-WM (VRAM uncertain at 16 GB)
- TRELLIS.2 (24 GB+ at full res)
- Hunyuan3D 2.1 PBR texturing (20 GB+)
- BFS video head swap on LTX-2.3 (24 GB+)
- LLaDA2.0-Uni, Stand-In (36 GB RAM requirement)
- LivingSwap, GSwap, AnyID (code not released)
- Seedance 2.0 (API-only, no local weights)

---

### Files

| File | Purpose |
|---|---|
| `_dev_docs/upgrade_research/2026-W22.md` | Human-readable findings with tier rationale |
| `_dev_docs/upgrade_research/2026-W22.json` | Machine-readable records (41 entries) |

---

> ⚠️ **Do not merge** — this PR is for human review only. Implementation upgrades require local node-pack installs that can only happen on the user's machine.
>
> ℹ️ The local 03:30 nightly export at `tools/export_comfyui_workflows.py` refreshes ComfyUI workflow snapshots automatically.

https://claude.ai/code/session_017ejwZAsVdswEF3LoQin1nW

---
_Generated by [Claude Code](https://claude.ai/code/session_017ejwZAsVdswEF3LoQin1nW)_