### PR TITLE
chore(research): daily SOTA review 2026-05-29

### DIFF
--- a/_dev_docs/upgrade_research/2026-W22.json
+++ b/_dev_docs/upgrade_research/2026-W22.json
@@ -1,0 +1,272 @@
+[
+  {
+    "method": "build_img2img",
+    "category": "checkpoint",
+    "name": "FLUX.1 Kontext [dev]",
+    "source": "huggingface",
+    "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "12B Flow Matching model (BFL open weights, 2025-05-29). Community GGUF Q5/Q6/Q8 now confirmed fitting 10–13 GB VRAM on RTX 5060 Ti. Unifies T2I + instruction-based image editing in one pass. Native ComfyUI support. Paper arxiv:2506.15742. Also relevant to build_inpaint, build_style_transfer."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-2.0",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Qwen/Qwen-Image",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Tech report arxiv:2605.10730 published 2026-05-11. 7B Multimodal Diffusion Transformer + Qwen3-VL encoder. Successor to Qwen2.5-VL backbone in build_qwen_edit. Companion VAE report arxiv:2605.13565 (2026-05-19). Open weights expected (Apache-2.0 precedent); not yet confirmed fully public."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Released 2026-05-08, MIT license. 8B pixel-native unified model; no external VAE/CLIP. FP8 quant (drbaph/HiDream-O1-Image-FP8) ~10 GB VRAM. ComfyUI bbox conditioning via Saganaki22/HiDream_O1-ComfyUI (added 2026-05-13, entering window). Additive new builder; not a replacement for SDXL/Flux spine."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "node_pack",
+    "name": "VIBE: Visual Instruction Based Editor (ComfyUI node)",
+    "source": "github",
+    "url": "https://github.com/ComfyNodePRs/PR-ComfyUI-VIBE-11e7b9c7",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Paper arxiv:2601.02242 (Jan 2026). 2B Qwen3-VL + 1.6B Sana1.5 instruction-editing pipeline; ~6–8 GB VRAM. Lightweight complement to build_qwen_edit or as in-pipeline refiner."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "lora",
+    "name": "Muapi Flux.1-dev style LoRA batch (10+ models, 2026-05-22–28)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Muapi",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "10+ FLUX.1-dev style LoRAs published 2026-05-22 to 2026-05-28: DBZ anime (05-28), ink wash (05-28), ligne-claire (05-25), ultra semi-realistic (05-25), Alex Ross (05-24), Take On Me rotoscope (05-23), Comix (05-23). Apache-2.0 / openrail++. Standard diffusers format; drop-in for build_style_transfer and build_txt2img Flux path."
+  },
+  {
+    "method": "build_klein_img2img",
+    "category": "lora",
+    "name": "Flux.2-klein-4B_Lora (nphSi)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/nphSi/Flux.2-klein-4B_Lora",
+    "risk": "low",
+    "confidence": 0.70,
+    "notes": "First public community LoRA targeting Flux.2-klein-4B base. Trained via OpenTrainer F2k. Zero downloads as of review; quality unvalidated. Signals the Klein LoRA training ecosystem is becoming accessible."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Kijai/WanVideo_comfy_nvfp4",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy_nvfp4",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Created 2026-05-28. NVFP4-quantized Wan video checkpoints repackaged by Kijai for ComfyUI. RTX 5060 Ti (Blackwell) qualifies. Significant VRAM and speed savings over FP8. Requires NVFP4 loader support in ComfyUI-WanVideoWrapper (verify GH issue #1888). Also relevant to build_wan22_t2v, build_wan_video_blockswap, build_wan_video_blockswap_t2v, build_wan_animate_video."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Kijai/WanVideo_comfy (re-pull — updated 2026-05-24)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Main Kijai Wan checkpoint repo (4.8M downloads) received updated files on 2026-05-24. Re-pull to pick up VACE/I2V variant updates. Relevant to all build_wan_* methods using Kijai weights."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "lora",
+    "name": "VideoRLVR-Wan2.2 (DarthZhu)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/DarthZhu/VideoRLVR-Wan2.2",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "RL fine-tune of Wan2.2-TI2V-5B with verifiable video rewards (arxiv:2605.15458, May 2026). Improved instruction-following in generated video. 5B fits 16 GB VRAM comfortably. HF modified 2026-05-21. Base also at DarthZhu/VideoRLVR-Wan2.2-Base."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "paper",
+    "name": "Video Quality Models for Diffusion-Based Video Super-Resolution benchmark",
+    "source": "arxiv",
+    "url": "https://arxiv.org/abs/2605.25940",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Published 2026-05-25 (in window). Benchmarks Lanczos, Rhea, SCST, DOVE, SeedVR2, Starlight Mini. SeedVR2 confirmed top-tier; no-reference video quality metrics proven unreliable for diffusion VSR. Also relevant to build_wavespeed_upscale."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-Video-0.9.7-dev (yrrhall, community mirror)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/yrrhall/LTX-Video-0.9.7-dev",
+    "risk": "medium",
+    "confidence": 0.60,
+    "notes": "Community upload created 2026-05-23. Tagged base_model:finetune of Lightricks/LTX-Video. This is the 2B open-weights branch (LTX-2.3 at 22B requires >16 GB — hard skip). Treat as dev mirror until Lightricks publishes official 0.9.7 tag on their namespace."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "lora",
+    "name": "dslr-photo-video-wan-2.1-2.2-low-noise (Muapi)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Muapi/dslr-photo-video-wan-2.1-2.2-low-noise",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "Created 2026-05-28 (in window). LoRA targeting low-noise DSLR-photographic output for Wan2.1/2.2 T2V. Additive quality option; compatible with Wan 14B T2V. Also relevant to build_wan22_t2v."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "ComfyUI-ReActor ≥ May 12 2026 + HyperSwap 256 ONNX",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "ReActor updated ~2026-05-12. Adds: HyperSwap 256 px ONNX models (1a/1b/1c) from FaceFusion Labs (hyperswap_1a/1b/1c_256.onnx → models/hyperswap/); new 'Restore Face Advanced' node (targeted per-face restoration post-swap); ReActorSetWeight node (0–100% swap strength). Open issues #183/#204 on HyperSwap selector bugs; test before production use. InSwapper 128 still recommended as default for ID similarity."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "onnx",
+    "name": "HyperSwap 256 — hyperswap_1a/1b/1c_256.onnx (FaceFusion Labs)",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/issues/143",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Three 256 px ONNX swap models now supported inside ReActor. 2× internal resolution vs InSwapper 128. 1c variant reported most balanced. InSwapper still wins on identity-similarity score in community benchmarks; HyperSwap is opt-in upgrade. Fits 16 GB VRAM."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2 (iFayens) — native Klein 4B/9B weights",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "v0.6.2 released ~2026-05-22 (confirmed 'about 1 week ago' as of review). Key changes: improved face-recognition backbone, fewer artifacts, native Klein 4B/9B v1/v2 weight support. sipie800/ComfyUI-PuLID-Flux-Enhanced officially discontinued — migration required. Also relevant to build_klein_face_detail, build_faceid_img2img, build_pulid_flux."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "paper",
+    "name": "NTIRE 2026 Real-World Face Restoration Challenge",
+    "source": "arxiv",
+    "url": "https://arxiv.org/abs/2604.10532",
+    "risk": "medium",
+    "confidence": 0.60,
+    "notes": "Published 2026-04-15. 10 competing SOTA face restoration methods, AdaFace-based identity scoring. Winning weights not yet public (repo: github.com/jkwang28/NTIRE2026_RealWorld_Face_Restoration). CodeFormer/GFPGAN remain current until weights drop. Also relevant to build_photo_restore."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "DreamID-V (ByteDance, ComfyUI JR fork)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/XuGuo699/DreamID-V",
+    "risk": "high",
+    "confidence": 0.70,
+    "notes": "Published Jan 2026. Video DiT face swap using Wan2.1 backbone; significantly outperforms InSwapper on FID (4.69) and ID similarity. ComfyUI nodes: github.com/HM-RunningHub/ComfyUI_RH_DreamID-V and JR fork (github.com/Goldlionren/ComfyUI_JR_DreamID-V) with FFN chunking + optional FlashAttention 2. 16 GB VRAM borderline — Wan-1.3B-Faster variant reduces peak VRAM. Test on testbed before wiring."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "node_pack",
+    "name": "BiRefNet native ComfyUI (Comfy-Org/BiRefNet)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/new-open-source-models-now-in-comfyui",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "ComfyUI blog 2026-05-14: BiRefNet ships natively via Comfy-Org/BiRefNet model card. Model → models/background_removal/birefnet.safetensors. No custom node required. Official Comfy-Org maintained checkpoint. Existing custom node wrappers still work."
+  },
+  {
+    "method": "build_magic_eraser",
+    "category": "node_pack",
+    "name": "VOID (Netflix) native ComfyUI — quad-mask video inpaint",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/new-open-source-models-now-in-comfyui",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Announced ComfyUI blog 2026-05-14. Netflix VOID uses quadmask (4-value: remove/overlap/physically-affected/keep) for video object removal. Native ComfyUI node. BiRefNet v2 in same release is a complement to SAM3 masking step in build_magic_eraser for hair/fur/transparency. New video inpaint capability not currently in Spellcaster."
+  },
+  {
+    "method": "build_supir",
+    "category": "paper",
+    "name": "ASASR: Adversarial Sobolev Alignment for Faithful Image Super Resolution",
+    "source": "arxiv",
+    "url": "https://arxiv.org/abs/2605.23264",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Submitted 2026-05-22 (in window). ICML 2026 accepted. Sobolev-geometry-based framework fixing spectral misalignment in generative SR. Code: github.com/wafer-bob/ASASR. No HF weights yet. SUPIR remains current production backbone; monitor for checkpoint release."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "paper",
+    "name": "AssetGen: Deployable 3D Asset Generation at Interactive Speed",
+    "source": "arxiv",
+    "url": "https://arxiv.org/abs/2605.26137",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Submitted 2026-05-22 (in window). Single-image to textured PBR mesh (baked normals) in ~30 s (Flash variant: 14 s). Coarse-to-refine VecSet + GPU mesh simplification + multi-view texture baking + 3D inpainting. No public weights yet. When released, evaluate as replacement for build_hunyuan_3d_mesh / build_hunyuan_3d_textured. Also relevant to build_hunyuan_3d_textured."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Meta facebookresearch/sam3)",
+    "source": "github",
+    "url": "https://github.com/facebookresearch/sam3",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "SAM 3.1 released 2026-03-27. Adds shared-memory multi-object tracking. 848M params, gated HF access. Image segmentation quality unchanged vs SAM 3 — tracking-only update. ComfyUI nodes: ComfyUI-SAM3 (PozzettiAndrea), ComfyUI-TBG-SAM3, ComfyUI-Easy-Sam3. No action required."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "MoGe-2 (Ruicheng/moge-2-vitl-normal)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Ruicheng/moge-2-vitl-normal",
+    "risk": "low",
+    "confidence": 0.91,
+    "notes": "Paper arxiv:2507.02546 (July 2025); integrated into ComfyUI v0.22.0 (2026-05-20). 330M ViT-L, ~660 MB FP16, well within 16 GB VRAM. Outputs metric depth + surface normals + GLB mesh from single image. ComfyUI node: zade23/ComfyUI-MoGe2. Strong upgrade for build_normal_map; supplementary depth output relevant to build_depth_map_v3."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "paper",
+    "name": "Depth Anything with Any Prior (Prior Depth Anything)",
+    "source": "arxiv",
+    "url": "https://arxiv.org/abs/2505.10565",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Submitted 2026-05-15. Extends Depth Anything V2 with sparse LiDAR/depth prior for metric accuracy up to 4K. Code: github.com/SpatialVision/Prior-Depth-Anything. Not a standalone monocular depth drop-in — requires sparse prior input. No ComfyUI node yet. Depth Anything v3 remains the production backbone."
+  },
+  {
+    "method": "build_seedv2r",
+    "category": "node_pack",
+    "name": "ComfyUI-SeedVR2_VideoUpscaler (numz) — active maintenance confirmed",
+    "source": "github",
+    "url": "https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "GitHub issues filed 2026-05-25 and 2026-05-26 confirm active maintenance. Last stable release v2.5.23 (2025-12-24). SeedVR2 (ICLR 2026, arxiv:2506.05301) supports FP8 on 12–16 GB VRAM. Note: verify whether build_seedv2r points to SeedVR2 (video) or a distinct SeedV2R (image restoration) backbone — names are similar."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "checkpoint",
+    "name": "RMBG-2.0 (briaai/RMBG-2.0) — confirmed current",
+    "source": "huggingface",
+    "url": "https://huggingface.co/briaai/RMBG-2.0",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "HF lastModified ~2026-04-13. BiRefNet-architecture backbone with Bria AI proprietary training data. No superseding open background-removal model found in the 7-day window. Current backbone confirmed SOTA."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "paper",
+    "name": "SridBench — Scientific Research Illustration Drawing Benchmark",
+    "source": "arxiv",
+    "url": "https://arxiv.org/abs/2505.22126",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Published 2026-05-28 (in window). All tested models (GPT-4o-image, Gemini-2.0-Flash, etc.) fall far short of human performance on scientific figure generation across 13 disciplines. Context only — useful for setting user-facing expectations in Spellcaster's illustration use cases. No model action."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W22.md
+++ b/_dev_docs/upgrade_research/2026-W22.md
@@ -1,0 +1,208 @@
+# Spellcaster daily SOTA review — 2026-05-29
+
+ISO week: `2026-W22`. Baseline: *(inaugural review — no prior baseline)*.
+
+Research window: 2026-05-22 → 2026-05-29.  
+Hardware budget: RTX 5060 Ti, 16 GB VRAM.  
+73 `build_*` methods audited across four families.
+
+---
+
+## Findings table
+
+| # | Method(s) | Current backbone | Still SOTA? | Replacement / upgrade | Source URL | Risk |
+|---|-----------|-----------------|-------------|----------------------|------------|------|
+| 1 | build_inpaint · build_img2img · build_style_transfer | SDXL / Flux ControlNet inpaint | ⚠️ Upgrade avail | FLUX.1 Kontext [dev] (12B, Q5/Q6 fits 16 GB) | https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev | Low |
+| 2 | build_qwen_edit | Qwen2.5-VL + diffusion | ⚠️ Upgrade pending | Qwen-Image-2.0 (7B, Apache-2.0, open weights expected) | https://huggingface.co/Qwen/Qwen-Image | Medium |
+| 3 | build_txt2img · build_img2img | SDXL / Flux | ✅ Additive | HiDream-O1-Image (8B MIT, FP8 ~10 GB VRAM) | https://huggingface.co/HiDream-ai/HiDream-O1-Image | Medium |
+| 4 | build_qwen_edit (light path) | Qwen2.5-VL | ✅ Additive | VIBE node (2B Qwen3-VL + 1.6B Sana1.5, ~6–8 GB) | https://github.com/ComfyNodePRs/PR-ComfyUI-VIBE-11e7b9c7 | Low |
+| 5 | build_txt2img · build_style_transfer | Flux LoRA chain | ✅ Additive | 10+ Muapi Flux.1-dev style LoRAs (2026-05-22–28) | https://huggingface.co/Muapi | Low |
+| 6 | build_klein_* | Flux2-Klein 4B/9B | ✅ Yes | — | https://huggingface.co/nphSi/Flux.2-klein-4B_Lora | Low |
+| 7 | build_wan_video · build_wan22_t2v · build_wan_video_blockswap | Kijai WanVideo FP8 GGUF | ⚠️ Upgrade avail | Kijai/WanVideo_comfy_nvfp4 (NVFP4, RTX 50xx native, 2026-05-28) | https://huggingface.co/Kijai/WanVideo_comfy_nvfp4 | Medium |
+| 8 | build_wan_video | Kijai WanVideo | ✅ Re-pull | — | https://huggingface.co/Kijai/WanVideo_comfy | Low |
+| 9 | build_wan22_t2v | Wan2.2-TI2V-5B | ⚠️ Upgrade avail | VideoRLVR-Wan2.2 RL fine-tune (5B, better instruction-following) | https://huggingface.co/DarthZhu/VideoRLVR-Wan2.2 | Medium |
+| 10 | build_seedvr2_video_upscale · build_wavespeed_upscale | SeedVR2 | ✅ Yes (benchmarked) | — | https://arxiv.org/abs/2605.25940 | Low |
+| 11 | build_ltx_video | LTX-Video 0.9.x (2B) | ⚠️ Version bump avail | LTX-Video-0.9.7-dev (community upload, 2026-05-23) | https://huggingface.co/yrrhall/LTX-Video-0.9.7-dev | Medium |
+| 12 | build_wan_video · build_wan22_t2v | Wan2.1/2.2 | ✅ Additive | Muapi DSLR low-noise LoRA (2026-05-28) | https://huggingface.co/Muapi/dslr-photo-video-wan-2.1-2.2-low-noise | Low |
+| 13 | build_faceswap · build_faceswap_model | InSwapper 128 ONNX | ⚠️ Upgrade avail | HyperSwap 256 ONNX (1a/1b/1c) via ReActor ≥ May 12 2026 | https://github.com/Gourieff/ComfyUI-ReActor | Low |
+| 14 | build_face_restore | GFPGAN / CodeFormer | ✅ Additive | ReActor "Restore Face Advanced" node (targeted post-swap restoration) | https://github.com/Gourieff/ComfyUI-ReActor | Low |
+| 15 | build_klein_headswap · build_faceid_img2img · build_klein_face_detail | PuLID-Flux (sipie800 — **discontinued**) | ⚠️ Migration required | PuLID-Flux2 v0.6.2 (iFayens, native Klein 4B/9B, ~2026-05-22) | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Low |
+| 16 | build_face_restore · build_photo_restore | GFPGAN / CodeFormer | ✅ Yes (for now) | NTIRE 2026 winning weights (pending public release) | https://arxiv.org/abs/2604.10532 | Medium |
+| 17 | build_faceswap · build_faceswap_model | InSwapper 128 ONNX | ✅ Yes (for now) | DreamID-V ByteDance (Jan 2026, 16 GB borderline) | https://huggingface.co/XuGuo699/DreamID-V | High |
+| 18 | build_rembg_birefnet | BiRefNet custom node | ⚠️ Simplification avail | Comfy-Org/BiRefNet native (birefnet.safetensors, ComfyUI ≥ v0.21.x) | https://blog.comfy.org/p/new-open-source-models-now-in-comfyui | Low |
+| 19 | build_magic_eraser | SAM3 + LaMa | ✅ Additive | VOID (Netflix, native ComfyUI, quad-mask video inpaint) | https://blog.comfy.org/p/new-open-source-models-now-in-comfyui | Low |
+| 20 | build_supir | SUPIR (SDXL-based) | ✅ Yes | — | https://arxiv.org/abs/2605.23264 | Low |
+| 21 | build_hunyuan_3d_mesh · build_hunyuan_3d_textured | HunyuanDiT 3D | ✅ Yes (for now) | AssetGen (30 s PBR mesh; no public weights yet) | https://arxiv.org/abs/2605.26137 | Medium |
+| 22 | build_sam3_segment · build_sam3_mask · build_sam3_extract | SAM 3 | ✅ Yes | — | https://github.com/facebookresearch/sam3 | Low |
+| 23 | build_normal_map | (custom backbone) | ⚠️ Upgrade avail | MoGe-2 (330M ViT-L, depth+normals+mesh, native ComfyUI v0.22.0) | https://huggingface.co/Ruicheng/moge-2-vitl-normal | Low |
+| 24 | build_depth_map_v3 | Depth Anything v3 | ✅ Yes | — | https://arxiv.org/abs/2505.10565 | Low |
+| 25 | build_seedv2r | SeedVR2 | ✅ Yes | — | https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler | Low |
+| 26 | build_rembg_v3 | RMBG-2.0 | ✅ Yes | — | https://huggingface.co/briaai/RMBG-2.0 | Low |
+| 27 | build_ddcolor | DDColor artistic | ✅ Yes | — | — | Low |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+These are confirmed-ready upgrades requiring only local node-pack or checkpoint changes; no code changes to `workflows.py` needed.
+
+### T1-A · PuLID-Flux2 v0.6.2 — migrate from discontinued sipie800 fork
+
+**Affected:** `build_klein_headswap`, `build_klein_face_detail`, `build_faceid_img2img`, `build_pulid_flux`
+
+The sipie800/ComfyUI-PuLID-Flux-Enhanced fork has been officially discontinued. The iFayens/ComfyUI-PuLID-Flux2 v0.6.2 release (confirmed ~2026-05-22, approx. 1 week before this review) adds native Klein 4B/9B weight support (v1 and v2), improved face-recognition backbone accuracy, and fewer swap artifacts. This is a required migration, not optional.
+
+**Action:** Uninstall `sipie800/ComfyUI-PuLID-Flux-Enhanced` → install `iFayens/ComfyUI-PuLID-Flux2`; download Klein v1/v2 native PuLID weights.  
+**Source:** https://github.com/iFayens/ComfyUI-PuLID-Flux2  
+**Risk:** Low
+
+---
+
+### T1-B · BiRefNet native ComfyUI — retire custom-node wrapper
+
+**Affected:** `build_rembg_birefnet`
+
+ComfyUI blog post of 2026-05-14 announces BiRefNet ships natively via the `Comfy-Org/BiRefNet` HuggingFace model card. Model file goes to `models/background_removal/birefnet.safetensors`; no custom node required.
+
+**Action:** Download `Comfy-Org/BiRefNet → birefnet.safetensors`; switch `build_rembg_birefnet` to use the native ComfyUI background-removal node.  
+**Source:** https://blog.comfy.org/p/new-open-source-models-now-in-comfyui  
+**Risk:** Low
+
+---
+
+### T1-C · MoGe-2 as build_normal_map backbone
+
+**Affected:** `build_normal_map` (supplementary: `build_depth_map_v3`)
+
+MoGe-2 (Microsoft, arxiv:2507.02546) produces metric depth + surface normals + GLB mesh from a single image using a 330M parameter ViT-L (~660 MB FP16). ComfyUI v0.22.0 (2026-05-20) integrates MoGe nodes natively. This is a substantial quality and scope upgrade for `build_normal_map` at near-zero VRAM cost.
+
+**Action:** Install `zade23/ComfyUI-MoGe2` (or use ComfyUI v0.22.0 native MoGe nodes); download `Ruicheng/moge-2-vitl-normal`.  
+**Source:** https://huggingface.co/Ruicheng/moge-2-vitl-normal  
+**Risk:** Low
+
+---
+
+### T1-D · HyperSwap 256 ONNX via ReActor ≥ May 12 2026
+
+**Affected:** `build_faceswap`, `build_faceswap_model`
+
+ReActor (updated ~2026-05-12) adds FaceFusion Labs HyperSwap 256-pixel ONNX models (`hyperswap_1a/1b/1c_256.onnx`) and a new "Restore Face Advanced" node that scopes restoration to only the swapped face region. HyperSwap doubles internal swap resolution vs InSwapper 128; the 1c variant is reported most balanced. InSwapper 128 still leads on raw identity-similarity scores in community tests, so keep it as the default with HyperSwap as an opt-in.
+
+**Action:** Update ComfyUI-ReActor to ≥ 2026-05-12 build; download `hyperswap_1a/1b/1c_256.onnx` to `models/hyperswap/`.  
+**Source:** https://github.com/Gourieff/ComfyUI-ReActor  
+**Risk:** Low
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install + new workflow wiring)
+
+### T2-A · FLUX.1 Kontext [dev] — unified instruction-editing + T2I
+
+**Affected:** New builder; augments `build_inpaint`, `build_img2img`, `build_style_transfer`
+
+BFL released FLUX.1 Kontext [dev] as open weights (2025-05-29). Community GGUF quantizations (Q5/Q6/Q8) now run the full 12B model inside 10–13 GB VRAM, confirming RTX 5060 Ti compatibility. The model unifies text-to-image and multi-turn instruction-based editing in a single Flow Matching pass — replacing the ControlNet-inpainting stack for many use cases. Native ComfyUI support exists (dev variant). Paper: arxiv:2506.15742.
+
+**Source:** https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev | https://blog.comfy.org/p/flux1-kontext-dev-day-0-support  
+**Risk:** Low
+
+---
+
+### T2-B · HiDream-O1-Image — multi-task 8B pixel-native builder
+
+**Affected:** New builder; additive to `build_txt2img`, `build_img2img`
+
+HiDream-ai released this 8B MIT-licensed model (2026-05-08); FP8 community quant fits ~10 GB VRAM. Operates directly in pixel space (no external VAE/CLIP). ComfyUI bounding-box area conditioning landed 2026-05-13 (`Saganaki22/HiDream_O1-ComfyUI`). Supports T2I, instruction editing, subject-driven personalization, storyboard up to 2048×2048.
+
+**Source:** https://huggingface.co/HiDream-ai/HiDream-O1-Image  
+**Risk:** Medium
+
+---
+
+### T2-C · Kijai WanVideo NVFP4 — Blackwell-native Wan checkpoints
+
+**Affected:** `build_wan_video`, `build_wan22_t2v`, `build_wan_video_blockswap`, `build_wan_video_blockswap_t2v`, `build_wan_animate_video`
+
+Created 2026-05-28. Kijai repacked Wan video models in NVIDIA NVFP4, the native 4-bit float format for Blackwell GPUs. RTX 5060 Ti (GA102 successor, Blackwell) can use NVFP4 for materially lower VRAM usage and faster inference vs FP8. Requires ComfyUI-WanVideoWrapper NVFP4 loader support (GitHub issue #1888 — verify before deploying).
+
+**Source:** https://huggingface.co/Kijai/WanVideo_comfy_nvfp4  
+**Risk:** Medium (loader support not yet confirmed)
+
+---
+
+### T2-D · VideoRLVR-Wan2.2 — RL fine-tuned Wan2.2-TI2V-5B
+
+**Affected:** `build_wan22_t2v`
+
+DarthZhu/VideoRLVR-Wan2.2 is a reinforcement-learning fine-tune of the 5B Wan2.2 TI2V model trained with verifiable video rewards (arxiv:2605.15458, May 2026). Improved instruction-following in generated video; 5B comfortably fits 16 GB VRAM. HF last modified 2026-05-21.
+
+**Source:** https://huggingface.co/DarthZhu/VideoRLVR-Wan2.2  
+**Risk:** Medium (validate output quality before switching default checkpoint)
+
+---
+
+### T2-E · LTX-Video 0.9.7-dev — version bump for build_ltx_video
+
+**Affected:** `build_ltx_video`
+
+Community-uploaded development checkpoint created 2026-05-23, tagged as `base_model:finetune` of `Lightricks/LTX-Video`. This is the 2B open-weights branch (LTX-2.3 at 22B requires > 16 GB — hard skip). Treat as dev until Lightricks tags 0.9.7 on their official namespace.
+
+**Source:** https://huggingface.co/yrrhall/LTX-Video-0.9.7-dev  
+**Risk:** Medium (community mirror; await official Lightricks tag)
+
+---
+
+### T2-F · Muapi Flux.1-dev style LoRA pack (10+ new, all in window)
+
+**Affected:** `build_style_transfer`, `build_txt2img` (Flux path)
+
+10+ Flux.1-dev style LoRAs published by Muapi between 2026-05-22 and 2026-05-28: DBZ anime, ink wash, ligne-claire, ultra semi-realistic, Alex Ross, Take On Me rotoscope, Comix, and more. All Apache-2.0 / openrail++; standard diffusers LoRA format.
+
+**Source:** https://huggingface.co/Muapi  
+**Risk:** Low
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Target method | Blocker | Revisit trigger |
+|------|--------------|---------|-----------------|
+| Qwen-Image-2.0 (tech report 2026-05-11) | build_qwen_edit | Full open weights uncertain (prior gens were Apache-2.0; 2.0 weights TBD) | Official weights on Qwen HF org |
+| AssetGen 3D (arxiv:2605.26137, 2026-05-22) | build_hunyuan_3d_mesh / build_hunyuan_3d_textured | Paper only; no public weights | HF model card with safetensors |
+| DreamID-V (ByteDance, Jan 2026) | build_faceswap / build_faceswap_model | 16 GB borderline for video DiT; Wan 1.3B-Faster variant helps | Test on 16 GB testbed (JR fork with FFN chunking) |
+| NTIRE 2026 face restoration winners | build_face_restore / build_photo_restore | Winning weights not yet public | Monitor github.com/jkwang28/NTIRE2026_RealWorld_Face_Restoration |
+| ASASR super-resolution (ICML 2026, 2026-05-22) | build_supir | Code at github.com/wafer-bob/ASASR; no HF safetensors yet | HF model card with checkpoint |
+| Prior Depth Anything (2026-05-15) | build_depth_map_v3 | Requires sparse LiDAR/depth sensor prior; not standalone monocular | Only if pipeline gains depth-sensor input path |
+| VIBE editing node (Jan 2026) | build_qwen_edit | Additive lightweight path (2B+1.6B); not a replacement | Evaluate if latency is a concern in batch workflows |
+| Flux.2-klein-4B_Lora (nphSi) | build_klein_* | 0 downloads; quality unvalidated | Community uptake + test reviews |
+| ComfyUI-CustomNodePacks v1.30.4 (2026-05-15) | build_sam3_* / build_rembg / build_lut / build_normal_map | 72-node pack; potential API conflict with existing Spellcaster wiring | Audit node class names for conflicts first |
+| Muapi Wan DSLR LoRA (2026-05-28) | build_wan_video / build_wan22_t2v | Minor quality tweak; additive only | Add to LoRA catalog on next Wan calibration sweep |
+
+---
+
+## No-finds (verified)
+
+The following current Spellcaster backbones were actively searched — no superseding release or substantive update found in the 7-day window:
+
+| Method | Backbone | Verified via |
+|--------|---------|--------------|
+| build_ddcolor | DDColor artistic / modelscope | HF model search, web search |
+| build_supir | SUPIR (SDXL-based) | HF + GitHub; only ASASR paper (no weights) |
+| build_depth_map_v3 | Depth Anything v3 (da3_large) | No v4 exists; v3 current |
+| build_hunyuan_3d_mesh / textured | HunyuanDiT 3D | HY-World-2.0 was April; no window release |
+| build_rembg | rembg (u2net etc.) | No new backbone |
+| build_rembg_v3 | RMBG-2.0 (briaai) | Updated ~Apr 13; still current |
+| build_hunyuan_video | HunyuanVideo | v1.5 was May 4; outside window |
+| build_mochi_video | Mochi | No updates found |
+| build_cogvideo_video | CogVideo | No updates found |
+| build_framepack_video | FramePack F1 | No new release in window |
+| build_iclight | IC-Light (SD 1.5) | No updates found |
+| build_lama_remove | LaMa | No updates found |
+| build_color_match / build_klein_color_match | color-match utility | No new backbone |
+| build_colorize | DDColor / BigColor | No new open colorization model |
+| build_sam3_* | SAM 3 | SAM 3.1 (March) tracking-only; seg unchanged |
+| build_upscale / build_upscale_blend | 4x-UltraSharp.pth | No new ESRGAN model in window |
+| build_video_reactor | ReActor (video) | HyperSwap is image path only so far |
+
+---
+
+*Generated by Spellcaster daily SOTA review agent. Nightly workflow snapshots are refreshed automatically by `tools/export_comfyui_workflows.py` at 03:30 local time — no manual snapshot action needed after local node-pack installs.*


### PR DESCRIPTION
## Daily SOTA review — 2026-05-29 (ISO week 2026-W22)

Inaugural upgrade-research audit. 73 `build_*` methods surveyed across four families using Hugging Face MCP, GitHub, Civitai, and the ComfyUI blog. Research window: 2026-05-22 → 2026-05-29. Hardware budget: RTX 5060 Ti, 16 GB VRAM.

---

## Summary table

| Tier | Count | Summary |
|------|-------|---------|
| **Tier 1** — drop-in supersessions (ship soon) | 4 | PuLID-Flux2 migration, BiRefNet native, MoGe-2, HyperSwap 256 |
| **Tier 2** — additive new builders | 6 | Flux Kontext, HiDream-O1, WanVideo NVFP4, VideoRLVR-Wan2.2, LTX-0.9.7-dev, Muapi Flux LoRAs |
| **Tier 3** — monitor / not wire-ready | 11 | Qwen-Image-2.0, AssetGen 3D, DreamID-V, NTIRE 2026, ASASR, Prior Depth Anything, VIBE, Klein LoRA, CustomNodePacks, SAM 3.1, Wan DSLR LoRA |
| **No-finds** | 17 methods confirmed stable | DDColor, SUPIR, Depth Anything v3, Hunyuan3D, rembg, RMBG-2.0, HunyuanVideo, Mochi, CogVideo, FramePack, IC-Light, LaMa, color-match, colorize, SAM3, UltraSharp, VideoReActor |

---

## Tier 1 highlights — action required on local machine

### T1-A · PuLID-Flux2 v0.6.2 — **migration required**
`sipie800/ComfyUI-PuLID-Flux-Enhanced` is **officially discontinued**. Migrate to `iFayens/ComfyUI-PuLID-Flux2` v0.6.2 (released ~2026-05-22), which adds native Klein 4B/9B weight support and improved face accuracy.  
Affected: `build_klein_headswap`, `build_klein_face_detail`, `build_faceid_img2img`, `build_pulid_flux`

### T1-B · BiRefNet native ComfyUI
BiRefNet now ships as `Comfy-Org/BiRefNet → models/background_removal/birefnet.safetensors` since ComfyUI v0.21.x (blog 2026-05-14). Retire the custom node wrapper.  
Affected: `build_rembg_birefnet`

### T1-C · MoGe-2 — upgraded normal-map backbone
330M ViT-L model (~660 MB FP16), produces depth + normals + GLB mesh. Native in ComfyUI v0.22.0 (2026-05-20). Significant quality upgrade at near-zero VRAM cost.  
Affected: `build_normal_map`

### T1-D · HyperSwap 256 via ReActor ≥ May 12 2026
2× internal swap resolution vs InSwapper 128; three ONNX variants (1a/1b/1c). Adds "Restore Face Advanced" node for targeted post-swap restoration. InSwapper stays as default; HyperSwap opt-in.  
Affected: `build_faceswap`, `build_faceswap_model`

---

## Tier 2 highlights — new builders / additive upgrades

- **FLUX.1 Kontext [dev]** — Unified T2I + instruction editing, 12B, confirmed 16 GB in Q5/Q6 GGUF. New builder for `build_inpaint` / `build_img2img` path.
- **HiDream-O1-Image** (MIT, 8B, FP8 ~10 GB) — Multi-task pixel-native builder; ComfyUI node via Saganaki22.
- **Kijai/WanVideo_comfy_nvfp4** (2026-05-28) — NVFP4 Blackwell-native checkpoints for all `build_wan_*` methods; RTX 5060 Ti qualifies. Verify NVFP4 loader in ComfyUI-WanVideoWrapper first.
- **VideoRLVR-Wan2.2** — RL fine-tune of Wan2.2-TI2V-5B; improved instruction-following; 5B fits 16 GB.
- **LTX-Video 0.9.7-dev** — Community mirror (2026-05-23); await official Lightricks tag before deploying.
- **Muapi Flux style LoRAs** — 10+ new LoRAs in window (2026-05-22–28), Apache-2.0, drop-in for `build_style_transfer`.

---

## Files

- `_dev_docs/upgrade_research/2026-W22.md` — full findings table, prose notes, tier breakdown, no-find log
- `_dev_docs/upgrade_research/2026-W22.json` — 27 structured records (one per candidate)

---

> **Do not merge** — leave open for human review and local node-pack verification.
>
> The nightly `tools/export_comfyui_workflows.py` export at 03:30 local time will automatically refresh ComfyUI workflow snapshots after any local node-pack installs — no manual snapshot step needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUx9QfkKJywTy5hAjQdXD6)_