### PR TITLE
chore(research): daily SOTA review 2026-06-01

### DIFF
--- a/_dev_docs/upgrade_research/2026-W23.json
+++ b/_dev_docs/upgrade_research/2026-W23.json
@@ -1,0 +1,322 @@
+[
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 Multiplex",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Drop-in checkpoint swap; 7x faster multi-object tracking via shared-memory multiplex module. Native ComfyUI PR #13408. Mar 27 2026. Also applies to build_sam3_mask, build_sam3_extract, build_magic_eraser."
+  },
+  {
+    "method": "build_sam3_mask",
+    "category": "checkpoint",
+    "name": "SAM 3.1 Multiplex",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Same as build_sam3_segment entry."
+  },
+  {
+    "method": "build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1 Multiplex",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Same as build_sam3_segment entry."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "node_pack",
+    "name": "BiRefNet native ComfyUI (PR #12747)",
+    "source": "github",
+    "url": "https://github.com/comfyanonymous/ComfyUI/pull/12747",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "First-party ComfyUI support shipped ~May 15-20 2026 per official ComfyUI blog. Model moves to models/background_removal/birefnet.safetensors. Removes third-party custom node dependency. Node class name change required in builder."
+  },
+  {
+    "method": "build_klein_img2img",
+    "category": "checkpoint",
+    "name": "FLUX.2 Small Decoder",
+    "source": "huggingface",
+    "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Drop-in 28M VAE decoder replacing 50M decoder across all FLUX.2 workflows. ~1.4x faster decode, ~30% less peak VRAM at decode step. Apache 2.0. Apr 8 2026. Applies to all 15 build_klein_* methods plus FLUX.2-based build_txt2img, build_img2img, build_inpaint, build_outpaint."
+  },
+  {
+    "method": "build_klein_batch_variations",
+    "category": "checkpoint",
+    "name": "FLUX.2-klein-9b-kv",
+    "source": "huggingface",
+    "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "KV-cache variant of Klein 9B; faster iterative/batch generation. FP8 variant (FLUX.2-klein-9b-kv-fp8) fits within 16 GB. Non-commercial license. Mar 9 2026. Especially beneficial for build_klein_batch_variations and build_klein_refine."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image-Dev-2604",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Pixel-native Unified Transformer (UiT), 9B, no VAE, no separate text encoder. MIT license. ~10 GB FP8. #8 on Artificial Analysis Arena. ComfyUI PR #13817 adds native support. New build_hidream_txt2img builder needed. May 8-14 2026. Also relevant to build_generate_anything."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "controlnet",
+    "name": "FLUX.2-dev ControlNet Union (alibaba-pai)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Multi-mode ControlNet Union for FLUX.2-dev (depth, canny, pose in one checkpoint). First ControlNet Union targeting FLUX.2-dev. Dec 2025 / updated Feb 2026. VRAM borderline at 16 GB with FP8 FLUX.2-dev base. Additive new capability, not a replacement."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Extends PuLID from FLUX.1 to full FLUX.2 ecosystem (Klein 4B/9B, Dev). Klein 4B path fits within 16 GB. Uses InsightFace + EVA-CLIP for face encoding. Mar 21 2026. Tier 3 until node-pack installed locally."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-2.0",
+    "source": "huggingface",
+    "url": "https://arxiv.org/abs/2605.10730",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "MMDiT architecture with Qwen3-VL condition encoder; 7B params; native 2K resolution; multilingual text rendering. Paper submitted May 11 2026. Weights not yet on HuggingFace as of June 1 2026. Monitor Qwen/ org. Companion VAE-2.0 paper at arxiv 2605.13565."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-VAE-2.0",
+    "source": "huggingface",
+    "url": "https://arxiv.org/abs/2605.13565",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Standalone high-compression VAE with asymmetric attention-free encoder-decoder. Compatible with any MMDiT diffusion model. Paper May 13 2026. No standalone weights released yet."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Full architectural replacement for LTX-Video 0.9.x. 22B DiT (vs 13B), joint audio+video generation, portrait 9:16 native, bundled spatial+temporal upscalers. Base model Mar 5 2026. ComfyUI v0.22.0 (May 20 2026) added VRAM-saving LTXV improvements directly benefiting this."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3-nvfp4 (quality update)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3-nvfp4",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "nvfp4 variant of LTX-2.3 using RTX Blackwell FP4 Tensor Cores — directly optimised for RTX 5060 Ti. Quality-improvement commit ~May 12 2026 (borderline in 7-day window). GGUF Q5_K_S or FP8 fits 16 GB."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "Sulphur-2-Base (LTX-2.3 fine-tune)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/SulphurAI/Sulphur-2-base",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "9B fine-tune of LTX-2.3 on 125k real-world clips. Realistic-motion focus. FP8 confirmed on 16 GB. 158k downloads, 600+ likes as of June 1. May 3 2026. Additive option alongside base LTX-2.3."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Wan 2.7",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI",
+    "risk": "high",
+    "confidence": 0.85,
+    "notes": "27B MoE DiT (14B active/pass), Apache 2.0. I2V + T2V + multi-person + vocal timbre. ComfyUI support in v0.18.5 (Apr 2026). GGUF Q8 + SageAttention + blockswap required on 16 GB; ~7 min for 5s at 1024x574. Applies to all 6 build_wan_* methods."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "Wan 2.7 T2V",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI",
+    "risk": "high",
+    "confidence": 0.85,
+    "notes": "Same Wan 2.7 upgrade; T2V path confirmed via ComfyUI blog post (blog.comfy.org)."
+  },
+  {
+    "method": "build_wan_flf",
+    "category": "checkpoint",
+    "name": "Wan 2.7 FLF",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI",
+    "risk": "high",
+    "confidence": 0.80,
+    "notes": "First-Last-Frame conditioning subsumed by Wan 2.7."
+  },
+  {
+    "method": "build_hunyuan_video",
+    "category": "checkpoint",
+    "name": "HunyuanVideo-1.5",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tencent/HunyuanVideo-1.5",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "8.3B full-attention DiT (vs 13B v1.0). Better quality via FP8 GEMM. Step-distilled 480p I2V fits 16 GB comfortably. T2V + I2V. Nov 2025 / step-distilled I2V Dec 2025."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 1a/1b/1c (FaceFusion Labs)",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "256-px ONNX variants (1a=speed, 1b=balanced, 1c=realism) vs inswapper_128's 128-px. ComfyUI-ReActor added support; models go to ComfyUI/models/hyperswap/. Open integration bugs (#183, #204, #208, #226) in late May 2026 — test on a clip before rollout. FaceFusion 3.6.1 Apr 2026. Also applies to build_faceswap_model, build_faceswap_mtb, build_video_reactor."
+  },
+  {
+    "method": "build_faceswap_model",
+    "category": "checkpoint",
+    "name": "HyperSwap 1a/1b/1c (FaceFusion Labs)",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Same as build_faceswap entry."
+  },
+  {
+    "method": "build_faceswap_mtb",
+    "category": "checkpoint",
+    "name": "HyperSwap 1a/1b/1c (FaceFusion Labs)",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Same as build_faceswap entry."
+  },
+  {
+    "method": "build_video_reactor",
+    "category": "checkpoint",
+    "name": "HyperSwap 1a/1b/1c (FaceFusion Labs)",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Same as build_faceswap entry. Additionally: BFS V3 LTX-2.3 IC-LoRA (Tier 3) offers a diffusion-native temporal face swap path."
+  },
+  {
+    "method": "build_video_reactor",
+    "category": "lora",
+    "name": "BFS V3 LTX-2.3 IC-LoRA",
+    "source": "huggingface",
+    "url": "https://huggingface.co/SSBOfficial/BFS-Best-Face-Swap-Video",
+    "risk": "high",
+    "confidence": 0.70,
+    "notes": "Diffusion-based temporal video face/head swap via IC-LoRA on LTX-2.3. Temporally stable vs frame-by-frame ONNX. Fork created May 25 2026 (in 7-day window). 16 GB tight at >720p/>4s. V3 'Focus Head' variant does full head+hair swap. Also relevant to build_klein_headswap."
+  },
+  {
+    "method": "build_save_face_model",
+    "category": "node_pack",
+    "name": "InsightFace SDK 1.0",
+    "source": "github",
+    "url": "https://github.com/deepinsight/insightface",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "SDK packaging release May 23 2026. NumPy 2.0+ compat fix — unblocks dependency chain issues on newer Python environments. No new swap model. Also relevant to build_faceswap*, build_video_reactor."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX Video Super Resolution (ComfyUI node)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Hardware-accelerated AI upscaling via RTX Tensor Cores. ~30x faster than traditional upscalers, near-zero VRAM overhead. RTX 5060 Ti supported. Node last updated Mar 22 2026. New parallel builder path. Also applies to build_upscale."
+  },
+  {
+    "method": "build_wavespeed_upscale",
+    "category": "checkpoint",
+    "name": "RunwayML Upscale V1 on WaveSpeed",
+    "source": "github",
+    "url": "https://wavespeed.ai/blog/posts/introducing-runway-upscale-v1-on-wavespeedai/",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "New upscaler option announced May 27 2026 (in 7-day window). API-based via WaveSpeed platform. Quality vs existing WaveSpeed models needs evaluation before wiring. Release is in-window."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 3.1",
+    "source": "github",
+    "url": "https://replicate.com/tencent/hunyuan-3d-3.1",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "8-view input support, improved texture fidelity and geometry. Announced May 2026. Available via Replicate API. Open weights on HuggingFace not yet confirmed as of June 1 2026. Monitor https://github.com/Tencent/Hunyuan3D-2. Also applies to build_hunyuan_3d_textured."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 3.1",
+    "source": "github",
+    "url": "https://replicate.com/tencent/hunyuan-3d-3.1",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "Same as build_hunyuan_3d_mesh entry."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "Vision Banana (Google DeepMind)",
+    "source": "huggingface",
+    "url": "https://arxiv.org/abs/2604.20329",
+    "risk": "high",
+    "confidence": 0.70,
+    "notes": "Unified model for depth + normals + segmentation + image generation. Outperforms DA3 on depth (delta1: 0.929 vs 0.918). No public weights as of June 1 2026. Monitor https://vision-banana.github.io/. Would also replace build_normal_map and build_sam3_* if/when weights drop. Apr 22 2026."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "Vision Banana (Google DeepMind)",
+    "source": "huggingface",
+    "url": "https://arxiv.org/abs/2604.20329",
+    "risk": "high",
+    "confidence": 0.70,
+    "notes": "Same as build_depth_map_v3 entry. No public weights."
+  },
+  {
+    "method": "build_klein_virtual_tryon",
+    "category": "checkpoint",
+    "name": "FLUX VTO (Black Forest Labs)",
+    "source": "github",
+    "url": "https://bfl.ai",
+    "risk": "high",
+    "confidence": 0.60,
+    "notes": "Virtual try-on model demonstrated by BFL in May 2026. No open weights confirmed as of June 1 2026. Klein tryon remains best open option. Monitor bfl.ai and black-forest-labs HF org."
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "Relit-LiVE (SIGGRAPH 2026)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2605.06658",
+    "risk": "high",
+    "confidence": 0.50,
+    "notes": "Video relighting via simultaneous environment-map prediction. Paper May 7 2026. No model weights released yet. Video-only (not still image). Likely >16 GB for full pipeline. Inspiration for a future build_video_relight builder."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W23.md
+++ b/_dev_docs/upgrade_research/2026-W23.md
@@ -1,0 +1,205 @@
+# Spellcaster daily SOTA review — 2026-06-01
+
+ISO week: `2026-W23`. Baseline: *(first report — no prior punch list)*.
+
+Hardware budget: RTX 5060 Ti 16 GB VRAM. Items requiring >16 GB are flagged High risk or skipped.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / Addition | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| `build_sam3_segment` | SAM 3 | **No** | SAM 3.1 Multiplex | https://huggingface.co/Comfy-Org/sam3.1 | Low | Drop-in checkpoint; 7× faster multi-object; native ComfyUI PR #13408. Mar 27 2026. |
+| `build_sam3_mask` | SAM 3 | **No** | SAM 3.1 Multiplex | https://huggingface.co/Comfy-Org/sam3.1 | Low | Same as above. |
+| `build_sam3_extract` | SAM 3 | **No** | SAM 3.1 Multiplex | https://huggingface.co/Comfy-Org/sam3.1 | Low | Same as above. |
+| `build_rembg_birefnet` | BiRefNet (custom node) | **No** | BiRefNet — native ComfyUI | https://huggingface.co/ZhengPeng7/BiRefNet | Low | ComfyUI PR #12747 adds first-party support ~May 15–20 2026; model to `models/background_removal/`. |
+| All `build_klein_*` (15 methods) | FLUX.2 Klein VAE | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Drop-in 28M decoder; ~1.4× faster decode; ~30% less peak VRAM at decode step. Apache 2.0. Apr 8 2026. |
+| `build_txt2img` | SDXL / Flux2 / Klein | **Partial** | +HiDream-O1-Image-Dev (additive) | https://huggingface.co/HiDream-ai/HiDream-O1-Image | Medium | Pixel-native UiT (no VAE), 9B, MIT, ~10 GB FP8. #8 on Arena. ComfyUI PR #13817. May 8–14 2026. New builder needed. |
+| `build_img2img` | SDXL / Flux2 | **Yes** | FLUX.2 Small Decoder (decode improvement) | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Decode-step improvement only; no backbone change needed. |
+| `build_inpaint` | SDXL / Flux2 | **Yes** | FLUX.2 Small Decoder (decode improvement) | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | See above. |
+| `build_outpaint` | SDXL / Flux2 | **Yes** | FLUX.2 Small Decoder (decode improvement) | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | See above. |
+| `build_generate_anything` | any arch | **Partial** | +HiDream-O1-Image-Dev (additive) | https://huggingface.co/HiDream-ai/HiDream-O1-Image | Medium | Same new builder as build_txt2img. |
+| `build_controlnet_gen` | SDXL ControlNet | **Partial** | +FLUX.2-dev ControlNet Union (additive) | https://huggingface.co/alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union | Medium | Multi-mode ControlNet for FLUX.2-dev; depth/canny/pose in one checkpoint. Dec 2025 / Feb 2026. VRAM borderline at 16 GB with FP8 base. |
+| `build_pulid_flux` | PuLID Flux v0.9.1 | **Partial** | +ComfyUI-PuLID-Flux2 v0.6.2 (additive) | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Medium | Extends PuLID to full FLUX.2 Klein 4B/9B/Dev. Klein 4B variant within 16 GB. Mar 21 2026. |
+| `build_qwen_edit` | Qwen-Image | **No (pending)** | Qwen-Image-2.0 | https://arxiv.org/abs/2605.10730 | Medium | Paper confirmed May 11 2026 (Qwen3-VL encoder, 7B, 2K native); weights not yet on HuggingFace. Monitor `Qwen/` org. |
+| `build_iclight` | IC-Light | **Yes** | — | — | — | IC-Light v2 is commercial-only (fal.ai); no open weights. Relit-LiVE (SIGGRAPH 2026, arxiv 2605.06658) is related but video-only and weights unavailable. |
+| `build_lumina2_txt2img` | Lumina-Image 2.0 | **Yes** | — | — | — | No update since Feb 2025 launch. Still current. |
+| `build_ltx_video` | LTX-Video 0.9.x | **No** | LTX-2.3 / LTX-2.3-nvfp4 | https://huggingface.co/Lightricks/LTX-2.3-nvfp4 | Medium | Full arch replacement: 22B DiT (vs 13B), joint audio+video, portrait 9:16. nvfp4 variant optimised for RTX Blackwell Tensor Cores; GGUF Q5_K_S / FP8 fits 16 GB. Base: Mar 5 2026; nvfp4 quality update ~May 12 2026. |
+| `build_wan_video` | Wan 2.1 I2V | **No** | Wan 2.7 | https://huggingface.co/Wan-AI | High | 27B MoE (14B active/pass), Apache 2.0, 5-ref-image I2V, vocal timbre, improved motion. GGUF Q8 + SageAttention + blockswap required at 16 GB; quality reduced vs 24 GB+. ComfyUI v0.18.5 (Apr 2026). |
+| `build_wan22_t2v` | Wan 2.2 T2V | **No** | Wan 2.7 T2V | https://huggingface.co/Wan-AI | High | Same Wan 2.7 upgrade; T2V path confirmed via ComfyUI blog post. |
+| `build_wan_flf` | Wan FLF | **No** | Wan 2.7 | https://huggingface.co/Wan-AI | High | First-Last-Frame conditioning path; Wan 2.7 subsumes Wan 2.1/2.2 FLF. |
+| `build_wan_animate_video` | Wan animate | **No** | Wan 2.7 | https://huggingface.co/Wan-AI | High | Wan 2.7 Multi-person animate replaces. |
+| `build_wan_video_blockswap` | Wan + blockswap | **No** | Wan 2.7 + blockswap | https://huggingface.co/Wan-AI | High | Blockswap architecture unchanged; checkpoint upgrade to Wan 2.7. |
+| `build_wan_video_blockswap_t2v` | Wan T2V + blockswap | **No** | Wan 2.7 T2V + blockswap | https://huggingface.co/Wan-AI | High | Same. |
+| `build_hunyuan_video` | HunyuanVideo 13B | **No** | HunyuanVideo-1.5 | https://huggingface.co/tencent/HunyuanVideo-1.5 | Medium | 8.3B full-attention DiT, T2V + I2V, FP8 GEMM, step-distilled 480p I2V fits 16 GB. Nov 2025 / step-distilled Dec 2025. |
+| `build_mochi_video` | Mochi-1 | **Yes** | — | — | — | No new release or open-weight successor found in any window. |
+| `build_cogvideo_video` | CogVideoX | **Yes** | — | — | — | CogVideoX-3 exists commercially (Z.AI) but open weights not confirmed. No change. |
+| `build_framepack_video` | FramePack | **Yes** | — | — | — | No update beyond F1 variant from mid-2025. |
+| `build_frame_assembly` | VHS combine utility | **Yes** | — | — | — | Utility node; no new release. |
+| `build_video_upscale` | 4x-UltraSharp | **Partial** | +NVIDIA RTX VSR node (additive) | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | Low | Hardware-accelerated upscaling via RTX Tensor Cores; ~30× faster, near-zero VRAM overhead. RTX 5060 Ti is supported. Mar 2026. New parallel builder. |
+| `build_seedvr2_video_upscale` | SeedVR2 3B FP8 | **Yes** | — | — | — | ICLR 2026 paper (arxiv 2506.05301, June 5) confirms quality; weights already in use are current. No change needed. |
+| `build_video_reactor` | ReActor / inswapper_128 | **No** | HyperSwap 1a/1b/1c (ONNX) | https://github.com/facefusion/facefusion | Medium | 256-px internal resolution vs 128-px; ComfyUI-ReActor added support. Caution: open ReActor integration issues (#183, #204, #208, #226). FaceFusion 3.6.1 Apr 2026. |
+| `build_wavespeed_upscale` | WaveSpeed | **Partial** | +RunwayML Upscale V1 on WaveSpeed | https://wavespeed.ai/blog/posts/introducing-runway-upscale-v1-on-wavespeedai/ | Medium | New upscaler option announced May 27 2026 (in window). Needs evaluation before wiring. |
+| `build_upscale` | ESRGAN / 4xUltraSharp | **Partial** | +NVIDIA RTX VSR node | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | Low | Same hardware upscaling node as build_video_upscale. |
+| `build_upscale_blend` | blend upscalers | **Yes** | — | — | — | No change to blend approach. |
+| `build_faceswap` | inswapper_128.onnx | **No** | HyperSwap 1a/1b/1c | https://github.com/facefusion/facefusion | Medium | 256-px ONNX; same VRAM profile. Caution: ReActor integration bugs (see above). |
+| `build_faceswap_model` | inswapper_128.onnx | **No** | HyperSwap 1a/1b/1c | https://github.com/facefusion/facefusion | Medium | Same. |
+| `build_faceswap_mtb` | inswapper_128.onnx | **No** | HyperSwap 1a/1b/1c | https://github.com/facefusion/facefusion | Medium | Same. |
+| `build_klein_headswap` | Klein / Flux2 | **Partial** | +BFS V3 LTX-2.3 IC-LoRA (Tier 3) | https://huggingface.co/SSBOfficial/BFS-Best-Face-Swap-Video | High | Diffusion-based head+hair swap via LTX-2.3 IC-LoRA; temporally stable. Fork created May 25 2026 (in window). 16 GB tight at >720p / >4s. |
+| `build_photobooth` | Photobooth | **Yes** | — | — | — | No direct replacement found. |
+| `build_save_face_model` | InsightFace | **Partial** | InsightFace SDK 1.0 (compat) | https://github.com/deepinsight/insightface | Low | NumPy 2.0+ compat fix; no new swap model. May 23 2026. |
+| `build_faceid_img2img` | FaceID Plus V2 | **Yes** | — | — | — | No V3 found. FaceCLIP paper exists (arxiv 2504.14202) but no public weights. |
+| `build_face_restore` | CodeFormer / GFPGAN | **Yes** | — | — | — | NTIRE 2026 challenge methods (arxiv 2604.10532) not publicly released yet. |
+| `build_photo_restore` | restoration chain | **Yes** | — | — | — | No new restoration model with open weights. |
+| `build_detail_hallucinate` | upscale + detail | **Yes** | — | — | — | No change. |
+| `build_supir` | SUPIR + SDXL | **Yes** | — | — | — | SUPIR v2 announced but not released (maintainer last commit May 13 2026, minor). |
+| `build_color_match` | color matching | **Yes** | — | — | — | No change. |
+| `build_klein_color_match` | Klein | **Yes** | — | — | — | No change. |
+| `build_colorize` | colorization pipeline | **Yes** | — | — | — | No new colorization model with open weights. |
+| `build_ddcolor` | DDColor artistic | **Yes** | — | — | — | No new ddcolor checkpoint. |
+| `build_lut` | LUT grading | **Yes** | — | — | — | No change. |
+| `build_rembg` | U2Net | **Yes** | — | — | — | U2Net itself unchanged; BiRefNet/RMBG-2.0 already supersede in practice (existing backlog, not new this week). |
+| `build_rembg_v3` | RMBG-2.0 | **Yes** | — | — | — | No update in window. |
+| `build_magic_eraser` | SAM3 + inpaint | **Partial** | SAM 3.1 Multiplex (segment step) | https://huggingface.co/Comfy-Org/sam3.1 | Low | Checkpoint upgrade for the SAM3 segment step within this workflow. |
+| `build_lama_remove` | LaMa | **Yes** | — | — | — | No update. |
+| `build_normal_map` | current | **Yes** | — | — | — | Vision Banana (Google DeepMind, arxiv 2604.20329) would supersede but no public weights as of June 1 2026. |
+| `build_depth_map_v3` | da3_large | **Yes** | — | — | — | Vision Banana outperforms DA3 (δ1: 0.929 vs 0.918) but no weights. DA3 remains best available option. |
+| `build_hunyuan_3d_mesh` | HunyuanDiT 3D 2.1 | **Partial** | Hunyuan3D 3.1 (API only) | https://replicate.com/tencent/hunyuan-3d-3.1 | Medium | Tencent announced 3.1 (8-view, better texture) in May 2026; API/Replicate only; open weights unconfirmed. |
+| `build_hunyuan_3d_textured` | HunyuanDiT 3D 2.1 | **Partial** | Hunyuan3D 3.1 (API only) | https://replicate.com/tencent/hunyuan-3d-3.1 | Medium | Same. |
+| `build_seedv2r` | SeedVR2 weights | **Yes** | — | — | — | ICLR 2026 paper confirms current weights are the published version. No change needed. |
+| `build_layer_blend` | compositing | **Yes** | — | — | — | No change. |
+| `build_inpaint_fooocus` | Fooocus | **Yes** | — | — | — | Fooocus stable; no supersession. |
+| `build_style_transfer` | IPAdapter + ControlNet | **Yes** | — | — | — | No change. |
+| `build_klein_img2img` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder + klein-9b-kv | https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv | Low | Incremental improvements to Klein backbone; KV-cache for faster iterative generation. Mar 9 2026. |
+| `build_klein_repose` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Decode step improvement. |
+| `build_klein_blend` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Same. |
+| `build_klein_inpaint` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Same. |
+| `build_klein_virtual_tryon` | Klein / Flux2 | **Partial** | +FLUX VTO (Tier 3) | https://bfl.ai | High | BFL FLUX VTO demonstrated May 2026 but no open weights confirmed. Klein tryon remains best open option. |
+| `build_klein_scene_img2img` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Decode improvement. |
+| `build_klein_refine` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Same. |
+| `build_klein_batch_variations` | Klein / Flux2 | **Partial** | FLUX.2-klein-9b-kv | https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv | Low | KV-cache especially beneficial for batch variation workflows. |
+| `build_klein_auto_inpaint` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Decode improvement. |
+| `build_klein_sam3_inpaint` | Klein + SAM3 | **No** | SAM 3.1 + FLUX.2 Small Decoder | https://huggingface.co/Comfy-Org/sam3.1 | Low | SAM3 → SAM3.1 for segment step; decode improvement on Klein step. |
+| `build_klein_generate_object` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Decode improvement. |
+| `build_klein_detail` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Same. |
+| `build_klein_face_detail` | Klein / Flux2 | **Partial** | FLUX.2 Small Decoder | https://huggingface.co/black-forest-labs/FLUX.2-small-decoder | Low | Same. |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+These are checkpoint or node swaps requiring no Python/workflow code changes. All fit within the 16 GB budget.
+
+### T1-1: SAM 3.1 Multiplex → `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract` / `build_magic_eraser`
+- **Model:** `sam3.1_multiplex_fp16.safetensors` from `Comfy-Org/sam3.1`
+- **Why:** 7× faster multi-object tracking via shared-memory multiplex module; identical API surface to SAM 3; native ComfyUI PR #13408.
+- **Action:** Drop `sam3.1_multiplex_fp16` into the SAM3 checkpoint path in each builder's node config.
+- **Risk:** Low — checkpoint swap, same node class.
+
+### T1-2: FLUX.2 Small Decoder → all `build_klein_*` + FLUX.2-based `build_txt2img` / `build_img2img` / `build_inpaint` / `build_outpaint`
+- **Model:** `FLUX.2-small-decoder` (28M params) from `black-forest-labs/FLUX.2-small-decoder` — Apache 2.0
+- **Why:** ~1.4× faster VAE decode; ~30% less VRAM at decode step — meaningful headroom on a 16 GB card for larger resolutions.
+- **Action:** Replace `VAELoader` checkpoint path from the full FLUX.2 decoder to the small decoder in all affected builders.
+- **Risk:** Low — drop-in, negligible quality loss confirmed by BFL.
+
+### T1-3: BiRefNet Native ComfyUI Node → `build_rembg_birefnet`
+- **Why:** ComfyUI PR #12747 (shipped ~May 15–20 2026) adds first-party BiRefNet support; removes dependency on the third-party custom node. Model path moves to `models/background_removal/birefnet.safetensors`.
+- **Action:** Update the node class name in `build_rembg_birefnet` from the custom-node class to the native ComfyUI class; update model path constant if needed.
+- **Risk:** Low — same model weights, new node name.
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install)
+
+These require new model downloads and/or ComfyUI node-pack installations on the local machine. They cannot be deployed from this remote session.
+
+### T2-1: LTX-2.3 / LTX-2.3-nvfp4 → replace `build_ltx_video`
+- **Model:** `Lightricks/LTX-2.3` (22B DiT) / `Lightricks/LTX-2.3-nvfp4`
+- **Why:** Full architectural replacement for LTX-Video 0.9.x. 22B parameters (vs 13B), native joint audio+video generation, portrait 9:16, new spatial+temporal upscalers. The nvfp4 variant uses RTX Blackwell FP4 Tensor Cores — directly optimised for the RTX 5060 Ti. GGUF Q5_K_S or FP8 fits 16 GB; ComfyUI v0.22.0 (May 20 2026) added VRAM-saving LTXV node improvements.
+- **Risk:** Medium — new backbone; existing LTX-Video 0.9.x presets incompatible.
+
+### T2-2: HiDream-O1-Image-Dev → new `build_hidream_txt2img` builder
+- **Model:** `HiDream-ai/HiDream-O1-Image` (Dev-2604 variant, 9B UiT, MIT)
+- **Why:** Pixel-native unified transformer — no VAE, no separate text encoder. ~10 GB in FP8. Ranked #8 on Artificial Analysis Arena (comparable to 56B FLUX.2). Genuinely distinct architecture alongside SDXL/Flux2/Klein options. ComfyUI PR #13817 adds native support.
+- **Risk:** Medium — new architecture, new ComfyUI node class; no backward compat with Klein/SDXL presets.
+
+### T2-3: Wan 2.7 → all `build_wan_*`
+- **Model:** `Wan-AI/Wan2.7` (27B MoE, 14B active/pass, Apache 2.0)
+- **Why:** Major generational upgrade over Wan 2.1/2.2: supports up to 5 reference images, vocal timbre conditioning, stronger motion dynamics. ComfyUI support in v0.18.5 (Apr 2026).
+- **VRAM note:** Full BF16 needs ~24 GB. GGUF Q8 + SageAttention + blockswap confirmed runnable on 16 GB at 1024×574, 5 s, ~7 min. Shorter clips at lower resolution are more practical.
+- **Risk:** High — 16 GB is marginal; quality vs 24 GB+ is noticeably reduced. Wan 2.2 remains usable for quality-critical runs.
+
+### T2-4: HyperSwap 1a/1b/1c → `build_faceswap` / `build_faceswap_model` / `build_faceswap_mtb` / `build_video_reactor`
+- **Model:** HyperSwap ONNX variants from FaceFusion Labs; models go to `ComfyUI/models/hyperswap/`
+- **Why:** 256-px internal resolution vs inswapper_128's 128-px; noticeably sharper identity transfer. Drop-in via ComfyUI-ReActor.
+- **Caution:** Open integration bugs in ComfyUI-ReActor (#183, #204, #208, #226) as of late May 2026. Verify on a test clip before rolling out.
+- **Risk:** Medium — ONNX VRAM profile similar; ReActor bugs are the main concern.
+
+### T2-5: HunyuanVideo-1.5 → `build_hunyuan_video`
+- **Model:** `tencent/HunyuanVideo-1.5` (8.3B full-attention DiT, T2V + I2V)
+- **Why:** Fewer parameters than v1.0 (8.3B vs 13B) with better quality due to FP8 GEMM and improved training. Step-distilled 480p I2V variant generation time comparable to RTX 4090. Fits comfortably on 16 GB at 480p.
+- **Risk:** Medium — backbone change; preset tuning needed.
+
+### T2-6: FLUX.2-klein-9b-kv → all `build_klein_*`
+- **Model:** `black-forest-labs/FLUX.2-klein-9b-kv` / `FLUX.2-klein-9b-kv-fp8` (FP8 fits 16 GB)
+- **Why:** KV-cache variant of Klein 9B; significantly faster for iterative/multi-image generation (relevant to `build_klein_batch_variations`, `build_klein_refine`, etc.).
+- **Risk:** Low — same Klein 9B quality baseline, additive KV-cache acceleration.
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| # | Candidate | Target builder(s) | Blocker | ETA signal |
+|---|---|---|---|---|
+| 1 | **Qwen-Image-2.0** (arxiv 2605.10730, Qwen3-VL encoder, 7B) | `build_qwen_edit` | Weights not yet on HuggingFace as of June 1 | Monitor `Qwen/` org; Alibaba's Apache-2.0 track record suggests imminent release |
+| 2 | **BFS V3 LTX-2.3 IC-LoRA** (SSBOfficial, May 25 2026) | `build_video_reactor`, `build_klein_headswap` | 16 GB tight at >720p / >4 s; community fork, not official LTX release | Evaluate on short clips; fork kingkladze created Jun 1 2026 — active community |
+| 3 | **VOID** (Netflix, `netflix/void-model`, Apr 4 2026) | New `build_video_removal` builder | ~14–16 GB tight (CogVideoX-Fun-5B base + two adapters); no current spellcaster builder for video object deletion | ComfyUI native support ~May 2026; monitor for memory-optimized wrapper |
+| 4 | **Vision Banana** (Google DeepMind, arxiv 2604.20329, Apr 22 2026) | `build_depth_map_v3`, `build_normal_map`, `build_sam3_*` | No public weights as of June 1 2026 | Would unify depth+normals+segmentation in one model (DA3: δ1 0.918 → Vision Banana: 0.929). Watch https://vision-banana.github.io/ |
+| 5 | **Hunyuan3D 3.1** (Tencent, May 2026) | `build_hunyuan_3d_mesh`, `build_hunyuan_3d_textured` | API/Replicate only; open weights not confirmed | Monitor https://github.com/Tencent/Hunyuan3D-2 |
+| 6 | **NVIDIA RTX VSR** (ComfyUI node, Mar 2026) | `build_video_upscale`, `build_upscale` | Needs `Comfy-Org/Nvidia_RTX_Nodes_ComfyUI` node-pack install; hardware path, near-zero VRAM | Node exists now; install when local node-packs are refreshed |
+| 7 | **FLUX VTO** (BFL, May 2026) | `build_klein_virtual_tryon` | Demonstrated but no open weights as of June 1 2026 | Monitor bfl.ai and `black-forest-labs` HF org |
+| 8 | **ComfyUI-PuLID-Flux2 v0.6.2** (Mar 21 2026) | `build_pulid_flux` | Needs node-pack install/upgrade to `iFayens/ComfyUI-PuLID-Flux2`; Klein 4B path within 16 GB | Active maintenance; stable v0.6.2 |
+| 9 | **RunwayML Upscale V1 on WaveSpeed** (May 27 2026) | `build_wavespeed_upscale` | Released in-window; API-based; needs evaluation of quality vs existing WaveSpeed models | wavespeed.ai integration; assess before wiring |
+| 10 | **alibaba-pai FLUX.2-dev ControlNet Union** (Feb 2026) | `build_controlnet_gen` | FLUX.2-dev base requires ~16–20 GB; FP8 path borderline on 16 GB | Evaluate VRAM with FP8 quantised FLUX.2-dev |
+
+---
+
+## No-finds (verified)
+
+The following methods were searched and no relevant new open-weight release was found in the May 25 – June 1 2026 window, nor in the preceding 30 days beyond what is already captured above:
+
+- `build_iclight`: IC-Light v2 is commercial/hosted (fal.ai) — no open weights.
+- `build_lumina2_txt2img`: Lumina-Image 2.0 unchanged since Feb 2025.
+- `build_mochi_video`: Mochi-1 — no successor or checkpoint update found.
+- `build_cogvideo_video`: CogVideoX open weights — CogVideoX-3 commercial only (Z.AI).
+- `build_framepack_video`: FramePack — no update beyond F1 variant (mid-2025).
+- `build_supir`: SUPIR v2 announced but maintainer last commit May 13 2026 was minor; no release.
+- `build_ddcolor`: No new ddcolor checkpoint; no open colorization successor found.
+- `build_faceid_img2img`: IP-Adapter FaceID Plus still V2; FaceCLIP (arxiv 2504.14202) has no public weights.
+- `build_face_restore` / `build_photo_restore`: NTIRE 2026 Face Restoration challenge (arxiv 2604.10532) winning methods not publicly released.
+- `build_inpaint_fooocus`: Fooocus stable; no update.
+- `build_style_transfer`: No change to IP-Adapter + ControlNet SDXL stack.
+- `build_lama_remove`: LaMa unchanged.
+- `build_colorize` / `build_color_match` / `build_klein_color_match` / `build_lut`: No new models.
+- `build_rembg` (U2Net): U2Net itself unchanged; BiRefNet/RMBG-2.0 (already in spellcaster) are the current SOTA.
+- `build_rembg_v3` (RMBG-2.0): No new RMBG checkpoint.
+- `build_photobooth`: No direct successor.
+- `build_frame_assembly`: Utility; no change.
+- `build_upscale_blend`: No change to blend approach.
+- `build_seedv2r` / `build_seedvr2_video_upscale`: ICLR 2026 paper (arxiv 2506.05301) confirms current weights are the published release — no change needed.
+- `build_normal_map`: RoSE paper (Feb 2026) — no public weights.
+- `build_layer_blend`: No change.
+- `build_detail_hallucinate`: No change.
+
+---
+
+## Search coverage
+
+| Source | Queries issued | Results |
+|---|---|---|
+| HuggingFace `hub_repo_search` | ~20 queries across model/space types | Sparse API returns for recent date ranges; supplemented by web |
+| HuggingFace `paper_search` | ~8 queries | Good coverage for arxiv papers |
+| WebSearch + WebFetch | ~30 queries across civitai, github, blog.comfy.org, vendor blogs | Primary source for release dates and ComfyUI integration status |
+
+*Note: HF hub search API showed indexing gaps for recently-created repos (<30 days). Some release dates are inferred from "N days ago" language and carry ±2-day uncertainty.*


### PR DESCRIPTION
## Daily SOTA review — 2026-06-01 (ISO week 2026-W23)

First edition; establishes `_dev_docs/upgrade_research/` baseline. 73 `build_*` methods audited across four model families using HuggingFace MCP (`hub_repo_search`, `paper_search`), WebSearch, and WebFetch against civitai.com, github.com, and blog.comfy.org.

---

## Summary table

| Tier | Count | Description |
|---|---|---|
| **Tier 1 — drop-in supersessions** | 3 | Ship soon; checkpoint/node swap only, no code changes |
| **Tier 2 — additive new builders** | 6 | Needs local node-pack install + new builder wiring |
| **Tier 3 — monitor** | 10 | Weights missing, VRAM concern, or needs evaluation |
| **No-finds (verified)** | 20+ | Confirmed no new release in window or preceding 30 days |

---

## Tier 1 — Drop-in supersessions (ship soon)

| # | What | Affects | Source | Risk |
|---|---|---|---|---|
| T1-1 | **SAM 3.1 Multiplex** — 7× faster multi-object; drop-in checkpoint | `build_sam3_segment/mask/extract`, `build_magic_eraser` | [Comfy-Org/sam3.1](https://huggingface.co/Comfy-Org/sam3.1) | Low |
| T1-2 | **FLUX.2 Small Decoder** — 28M VAE decoder; ~1.4× faster decode, ~30% less VRAM | All 15 `build_klein_*` + FLUX.2-based txt2img/img2img/inpaint/outpaint | [black-forest-labs/FLUX.2-small-decoder](https://huggingface.co/black-forest-labs/FLUX.2-small-decoder) | Low |
| T1-3 | **BiRefNet native ComfyUI** (PR #12747, ~May 15-20 2026) — removes third-party custom node | `build_rembg_birefnet` | [ZhengPeng7/BiRefNet](https://huggingface.co/ZhengPeng7/BiRefNet) | Low |

## Tier 2 — Additive new builders (needs local node-pack install)

| # | What | Affects | Source | Risk |
|---|---|---|---|---|
| T2-1 | **LTX-2.3 / nvfp4** — 22B DiT, audio+video, RTX Blackwell FP4 optimised; full LTX-Video 0.9.x replacement | `build_ltx_video` | [Lightricks/LTX-2.3-nvfp4](https://huggingface.co/Lightricks/LTX-2.3-nvfp4) | Medium |
| T2-2 | **HiDream-O1-Image-Dev** — pixel-native UiT (no VAE), 9B, MIT, ~10 GB FP8; new builder needed | new `build_hidream_txt2img` | [HiDream-ai/HiDream-O1-Image](https://huggingface.co/HiDream-ai/HiDream-O1-Image) | Medium |
| T2-3 | **Wan 2.7** — 27B MoE, Apache 2.0, 5-ref-image, vocal timbre; replaces all Wan 2.1/2.2 (GGUF Q8 needed on 16 GB) | all 6 `build_wan_*` | [Wan-AI HF org](https://huggingface.co/Wan-AI) | High |
| T2-4 | **HyperSwap 1a/1b/1c** — 256-px ONNX (vs 128-px); drop-in via ComfyUI-ReActor | `build_faceswap*`, `build_video_reactor` | [facefusion/facefusion](https://github.com/facefusion/facefusion) | Medium |
| T2-5 | **HunyuanVideo-1.5** — 8.3B DiT (vs 13B), FP8 GEMM, 480p distilled fits 16 GB | `build_hunyuan_video` | [tencent/HunyuanVideo-1.5](https://huggingface.co/tencent/HunyuanVideo-1.5) | Medium |
| T2-6 | **FLUX.2-klein-9b-kv** — KV-cache variant; faster batch/iterative generation | all `build_klein_*` | [black-forest-labs/FLUX.2-klein-9b-kv](https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv) | Low |

## Tier 3 — Monitor / not wire-ready

- **Qwen-Image-2.0** (paper arxiv 2605.10730, May 11 2026): weights pending → `build_qwen_edit`
- **BFS V3 LTX-2.3 IC-LoRA** (fork May 25 2026, in window): diffusion video face swap, 16 GB tight → `build_video_reactor`, `build_klein_headswap`
- **VOID** (Netflix, Apr 2026): physics-aware video object deletion, ~14-16 GB → new `build_video_removal` capability
- **Vision Banana** (Google DeepMind, paper Apr 2026, no weights): would unify `build_depth_map_v3` + `build_normal_map` + `build_sam3_*`
- **Hunyuan3D 3.1** (May 2026, API/Replicate only): → `build_hunyuan_3d_mesh/textured`
- **NVIDIA RTX VSR node**: hardware upscaling, near-zero VRAM → `build_video_upscale`, `build_upscale`
- **FLUX VTO** (BFL, May 2026, no open weights): → `build_klein_virtual_tryon`
- **ComfyUI-PuLID-Flux2 v0.6.2** (Mar 2026): extends PuLID to FLUX.2 Klein 4B/9B → `build_pulid_flux`
- **RunwayML Upscale V1 on WaveSpeed** (May 27 2026, **in window**): needs quality eval → `build_wavespeed_upscale`
- **alibaba-pai FLUX.2 ControlNet Union** (Feb 2026): multi-mode ControlNet for FLUX.2-dev, VRAM borderline → `build_controlnet_gen`

---

## Files

- `_dev_docs/upgrade_research/2026-W23.md` — full findings table + per-tier narrative
- `_dev_docs/upgrade_research/2026-W23.json` — structured records (one per candidate, 33 entries)

---

> **Note for reviewers:** Implementation upgrades (checkpoint swaps, new node-pack installs) can only be performed on the local machine. The nightly `tools/export_comfyui_workflows.py` will refresh ComfyUI workflow snapshots automatically after any local changes are applied. This PR is research-only — do not merge without human review.

https://claude.ai/code/session_017wjbYoEge75PrHMvGLV79u

---
_Generated by [Claude Code](https://claude.ai/code/session_017wjbYoEge75PrHMvGLV79u)_