### PR TITLE
chore(research): daily SOTA review 2026-06-03

### DIFF
--- a/_dev_docs/upgrade_research/2026-W23.json
+++ b/_dev_docs/upgrade_research/2026-W23.json
@@ -1,0 +1,192 @@
+[
+  {
+    "method": "build_supir",
+    "category": "node_pack",
+    "name": "NVIDIA PiD (Pixel Diffusion Decoder)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/nvidia/PiD",
+    "risk": "low",
+    "confidence": 0.97,
+    "notes": "IN 7-DAY WINDOW (May 25 2026 weights; May 27 ComfyUI node; June 2 SDXL checkpoint). Drop-in pixel-diffusion VAE decoder replacement that simultaneously decodes and upscales 4x/8x in one step. Compatible with SDXL (SUPIR backbone), Flux, Klein, SD3, ZIT. ComfyUI nodes: Merserk/ComfyUI-PiD, tsolful/ComfyUI-PiD. VRAM: ComfyUI staged pipeline stable on 12 GB, RTX 5060 Ti 16 GB comfortable. arXiv:2605.23902."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Microsoft Lens / Lens-Turbo",
+    "source": "huggingface",
+    "url": "https://huggingface.co/microsoft/Lens",
+    "risk": "low",
+    "confidence": 0.97,
+    "notes": "IN 7-DAY WINDOW (May 25 2026 weights; ComfyUI PR #14077 merged ~May 26-27). Dual-stream MMDiT, 3.8B params, MIT license. Variants: Lens-Turbo (4 steps, 0.84s/image), Lens (20 steps), Lens-Base (50 steps). Up to 1440x1440. Lens-Turbo confirmed on 16 GB without CPU offload. Comfy-Org weights at hf.co/Comfy-Org/Lens. arxiv:2605.21573."
+  },
+  {
+    "method": "build_wan_video_blockswap",
+    "category": "node_pack",
+    "name": "Wan2GP v11.88",
+    "source": "github",
+    "url": "https://github.com/deepbeepmeep/Wan2GP",
+    "risk": "low",
+    "confidence": 0.99,
+    "notes": "IN 7-DAY WINDOW (May 27-29 2026). Launcher update. Changes: MKV+MOV output containers, ProRes422/MOV input, LoRA format fixes, LoRA inpainting crash fix, animate LoRA support, keyboard toolbar, Finetune Creator/Editor. No workflow JSON change required. Also applies to build_wan_video_blockswap_t2v."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "ComfyUI-ReActor v0.6.2 + HyperSwap 1c",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Released April 25 2026. HyperSwap 1a/1b/1c ONNX support (256px native vs inswapper_128 128px). New Restore Face Advanced node (restoration targets only swapped faces). HyperSwap weights at facefusion/facefusion-labs HF. VRAM: ~2-4 GB ONNX. Upgrades build_faceswap, build_faceswap_model. Also improve build_face_restore and build_photo_restore."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Released ~May 20 2026. First PuLID for FLUX.2 Klein 4B/9B. Auto-detects Klein 4B/9B/FLUX.2 Dev. Klein 4B ~6-8 GB, Klein 9B ~12-14 GB — both fit 16 GB. Weights: hf.co/Fayens/Pulid-Flux2. Supersedes FLUX.1-only PuLID implementations."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "github",
+    "url": "https://github.com/facebookresearch/sam3",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "Released March 27 2026. Object Multiplex multi-object tracking. 2x speed (16->32 FPS), half VRAM (8 GB->4 GB FP16) vs SAM 3.0. HF: facebook/sam3.1. Also applies to build_sam3_mask and build_sam3_extract."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "Depth Anything 3",
+    "source": "github",
+    "url": "https://depth-anything-3.github.io/",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Released November 14 2025. DINOv2 encoder; depth + camera pose + 3D geometry. Beats DA2 on monocular depth. Small model well under 16 GB. ComfyUI node: Ltamann/ComfyUI-DepthAnythingV3-TBG. arXiv:2511.10647."
+  },
+  {
+    "method": "build_hunyuan_video",
+    "category": "checkpoint",
+    "name": "HunyuanVideo 1.5",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tencent/HunyuanVideo-1.5",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "Released November 24 2025. Lighter DiT + SSTA attention. Glyph-aware text encoding. Built-in video super-resolution. 800K DL, 993 likes. Gated license. ComfyUI node update needed for 1.5 checkpoint format."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 (ltx-2-3-fast)",
+    "source": "github",
+    "url": "https://ltx.io/model/ltx-2-3",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Released March 5 2026. 22B params, Apache 2.0. ltx-2-3-fast in FP8/NVFP4 likely fits 16 GB. Up to 4K/50fps/20s with stereo 24kHz audio. No standalone ComfyUI node confirmed at audit date; check github.com/Lightricks/LTX-Video."
+  },
+  {
+    "method": "build_seedv2r",
+    "category": "node_pack",
+    "name": "FlashVSR v1.1",
+    "source": "github",
+    "url": "https://github.com/OpenImagingLab/FlashVSR",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Released November 2025. CVPR 2026. One-step 4x video super-res, ~17 FPS on A100 at 768x1408. Low-VRAM variant; >=12 GB. ComfyUI: 1038lab/ComfyUI-FlashVSR. HF: JunhaoZhuang/FlashVSR-v1.1."
+  },
+  {
+    "method": "build_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX VSR ComfyUI Node",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Released March 22 2026. RTX hardware video upscale (dedicated engine, not CUDA). RTX 5060 Ti supported; WSL2 issue tracked. Complementary speed pass — not a diffusion quality replacement."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D-Omni",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tencent/Hunyuan3D-Omni",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Released August 2025. 3.3B params. Controllable 3D from point clouds, voxels, bounding boxes, skeletal poses. 10 GB VRAM shape-only. Also applies to build_hunyuan_3d_textured. GitHub: Tencent-Hunyuan/Hunyuan3D-Omni."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image-Dev-2604",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev-2604",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Released May 14 2026. Pixel-native 8B UiT; no external VAE; instruction editing, personalization, storyboard gen; up to 2048x2048. FP8 ~10 GB (drbaph/HiDream-O1-Image-Dev-2604-FP8). MIT. ComfyUI native. Cannot use existing VAE/T5 paths — new build_hidream_edit builder required."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "WAN 2.7",
+    "source": "github",
+    "url": "https://github.com/Wan-Video",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "Cloud launch April 22 2026; open weights NOT yet released June 3 2026. 27B total/14B active MoE. T2V+I2V+Reference-to-Video+instruction editing. First+last frame, 9-image I2V. Monitor hf.co/Wan-AI. ETA late June-July 2026."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-2.0",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2605.10730",
+    "risk": "high",
+    "confidence": 0.80,
+    "notes": "Paper May 11 2026. Qwen3-VL encoder + MMDiT. Up to 1K token instructions; text-rich editing, multilingual typography. Weights NOT yet public June 3 2026. Monitor hf.co/Qwen. Will supersede build_qwen_edit backbone."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "RealRestorer",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "high",
+    "confidence": 0.85,
+    "notes": "Released March 2026. Step1X-Edit DiT + Flux-VAE. 9 degradation types; no text prompt needed. Apache 2.0 code / non-commercial weights. VRAM: ~16-20 GB borderline — validate before wiring. GitHub: yfyang007/RealRestorer. arXiv:2603.25502."
+  },
+  {
+    "method": "build_supir",
+    "category": "node_pack",
+    "name": "LucidFlux",
+    "source": "huggingface",
+    "url": "https://huggingface.co/W2GenAI/LucidFlux",
+    "risk": "medium",
+    "confidence": 0.87,
+    "notes": "Sep 2025; ComfyUI Oct 2025; ICLR 2026. Flux.1 DiT + SigLip; caption-free; 8-12 GB via ComfyUI. GitHub: W2GenAI-Lab/LucidFlux."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "BFS Head LoRA V5 (Klein/Qwen2511)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+    "risk": "high",
+    "confidence": 0.80,
+    "notes": "Released March 29 2026. LoRA for Qwen Image Edit 2509/2511 and FLUX.2 Klein 4B/9B. Head V5 trained 5500+ steps on Qwen 2511. Video variant available. Diffusion-edit approach; no dedicated ComfyUI node — manual workflow needed. Klein 4B: ~6-8 GB; 9B: ~12-14 GB."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "node_pack",
+    "name": "DirectSwap video head swap",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2512.09417",
+    "risk": "high",
+    "confidence": 0.72,
+    "notes": "December 2025. Mask-free diffusion video head swap; motion-aware reconstruction loss. No public ComfyUI node. Also: Controllable One-Shot Video Head Swapping (hf.co/papers/2506.16852, Jun 2025). Monitor for ComfyUI port."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W23.md
+++ b/_dev_docs/upgrade_research/2026-W23.md
@@ -1,0 +1,226 @@
+# Spellcaster daily SOTA review — 2026-06-03
+
+ISO week: `2026-W23`. Baseline: **none — first audit run** (directory created this cycle).
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / upgrade | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| `build_txt2img` / `build_generate_anything` | SDXL / Flux1-dev | ⚠️ Additive | **Microsoft Lens** (May 25 2026) | https://hf.co/microsoft/Lens | Low | IN WINDOW — 3.8B dual-stream MMDiT, MIT, 4-step Turbo, ComfyUI native |
+| `build_supir` + all pipelines (VAE decoder) | SUPIR SDXL + standard VAE | ❌ No | **NVIDIA PiD** (May 25 2026) | https://hf.co/nvidia/PiD | Low | IN WINDOW — drop-in pixel-diffusion decoder+upscaler; ComfyUI node May 27; SDXL checkpoint June 2 |
+| `build_wan_video_blockswap` / `build_wan_video_blockswap_t2v` | WAN 2.2 + Wan2GP launcher | ⚠️ Tooling outdated | **Wan2GP v11.88** (May 29 2026) | https://github.com/deepbeepmeep/Wan2GP | Low | IN WINDOW — MKV/MOV/ProRes422, LoRA fixes, Finetune Creator |
+| `build_faceswap` / `build_faceswap_model` | ReActor + inswapper_128 | ❌ No | **ReActor v0.6.2** (Apr 25 2026) | https://github.com/Gourieff/ComfyUI-ReActor | Low | HyperSwap 1c support (256px vs 128px); Restore Face Advanced node |
+| `build_pulid_flux` | PuLID (Flux.1 only) | ❌ No | **PuLID-Flux2 v0.6.2** (~May 20 2026) | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Low | Klein 4B/9B native weights; auto-detects architecture; 16 GB safe |
+| `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract` | SAM 3.0 | ❌ No | **SAM 3.1** (Mar 27 2026) | https://github.com/facebookresearch/sam3 | Low | 2× speed, half VRAM vs SAM 3.0; Object Multiplex tracking |
+| `build_depth_map_v3` | Depth Anything v2 / DA3 | ❌ No | **Depth Anything 3** (Nov 14 2025) | https://depth-anything-3.github.io/ | Low | DINOv2 encoder; depth + camera pose + 3D geometry; ComfyUI node available |
+| `build_hunyuan_video` | HunyuanVideo 13B | ❌ No | **HunyuanVideo 1.5** (Nov 24 2025) | https://hf.co/tencent/HunyuanVideo-1.5 | Medium | 800K DL, lighter DiT + SSTA; SOTA quality; ComfyUI node update needed |
+| `build_ltx_video` | LTX-Video 0.9.7-distilled | ❌ No | **LTX-2.3** (Mar 5 2026) | https://ltx.io/model/ltx-2-3 | Medium | 22B; ltx-2-3-fast FP8 likely fits 16 GB; 4K/50fps/20s + stereo audio |
+| `build_seedv2r` / `build_video_upscale` | SeedVR2 / 4x-UltraSharp | ⚠️ Additive | **FlashVSR v1.1** (Nov 2025) | https://github.com/OpenImagingLab/FlashVSR | Medium | One-step streaming 4× VSR; ComfyUI node; Low-VRAM variant; CVPR 2026 |
+| `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured` | Hunyuan3D 2.x | ❌ No | **Hunyuan3D-Omni** (Aug 2025) | https://github.com/Tencent-Hunyuan/Hunyuan3D-Omni | Medium | 3.3B; controllable 3D from point clouds/voxels/skeletal pose; 10 GB VRAM |
+| `build_qwen_edit` | Qwen Image Edit 2509 + Qwen2.5-VL | ❌ No | **Qwen-Image-2.0** (May 11 2026) | https://hf.co/papers/2605.10730 | High | Paper only; Qwen3-VL + MMDiT; substantially better; weights not yet public |
+| `build_video_upscale` / `build_upscale` | 4x-UltraSharp / SeedVR2 | ⚠️ Additive | **NVIDIA RTX VSR** ComfyUI node (Mar 22 2026) | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | Low | RTX hardware upscale; complementary speed pass; RTX 5060 Ti supported |
+| `build_wan_video` / `build_wan_flf` / `build_wan_animate_video` | WAN 2.2 | ⚠️ Successor coming | **WAN 2.7** (cloud Apr 22; weights TBD) | https://github.com/Wan-Video | Medium | 27B MoE, multi-image I2V, instruction editing; open weights not yet released |
+| `build_klein_headswap` | Klein + inpaint | ⚠️ Research available | **BFS Head LoRA V5** (Mar 2026) | https://hf.co/Alissonerdx/BFS-Best-Face-Swap | High | Diffusion-edit headswap LoRA for Klein/Qwen; no ComfyUI node, manual workflow |
+| `build_supir` | SUPIR (SDXL-based) | ⚠️ Research available | **RealRestorer** (Mar 2026) | https://hf.co/RealRestorer/RealRestorer | High | Flux-VAE+Step1X-Edit DiT; no text prompt needed; borderline 16 GB |
+| `build_supir` | SUPIR (SDXL-based) | ⚠️ Research available | **LucidFlux** (Sep 2025) | https://hf.co/W2GenAI/LucidFlux | Medium | Flux.1 DiT, caption-free, 8–12 GB via ComfyUI node |
+| `build_qwen_edit` / `build_img2img` | Qwen Edit 2509 / Flux1 | ⚠️ Additive | **HiDream-O1-Image-Dev-2604** (May 14 2026) | https://hf.co/HiDream-ai/HiDream-O1-Image-Dev-2604 | Medium | Pixel-native 8B UiT; FP8 ~10 GB; MIT; instruction editing; new loader needed |
+| `build_txt2img` / `build_img2img` (flux_kontext) | FLUX.1 Kontext (experimental) | ✅ Already integrated | — | https://hf.co/black-forest-labs/FLUX.1-Kontext-dev | — | **ALREADY KNOWN** — `flux_kontext` arch in architectures.py; TensorRT acceleration landing |
+| `build_wan22_t2v` | WAN 2.2 T2V-A14B | ✅ Already integrated | — | https://hf.co/Wan-AI/Wan2.2-T2V-A14B | — | **ALREADY KNOWN** |
+| `build_wan_video` | WAN 2.2 I2V-A14B | ✅ Already integrated | — | https://hf.co/Wan-AI/Wan2.2-I2V-A14B | — | **ALREADY KNOWN** — canonical WAN 2.2 I2V builder |
+| `build_framepack_video` | FramePack (Hunyuan-derived) | ✅ Current | No in-window upgrade | https://github.com/lllyasviel/FramePack | — | **ALREADY KNOWN** — last release Apr 18 2026 |
+| `build_seedvr2_video_upscale` | SeedVR2 3B | ✅ Current | No in-window upgrade | — | — | **ALREADY KNOWN** — stable |
+| `build_iclight` | IC-Light v1 | ⚠️ V2 pending | IC-Light V2 (weights not open) | https://github.com/lllyasviel/IC-Light/discussions/98 | — | V2 announced Oct 2024; still fal.ai API only; no open weights in window |
+| `build_rembg_v3` | RMBG-2.0 / BiRefNet | ✅ Current | No in-window upgrade | — | — | No new version in window |
+| `build_ddcolor` / `build_colorize` | DDColor / Klein | ✅ Current | No in-window upgrade | — | — | No new model in window |
+| `build_faceswap_mtb` | MTB face swap | ✅ Adequate | No in-window upgrade | — | — | comfy_mtb last commit Mar 19 2026; no window activity |
+| `build_mochi_video` | Mochi-1 | ✅ Adequate | No in-window upgrade | — | — | No 2026 update |
+| `build_cogvideo_video` | CogVideoX | ✅ Adequate | No in-window upgrade | — | — | 2025-only minor updates |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+### 1. NVIDIA PiD — all latent-diffusion pipelines including `build_supir`
+**Released:** May 25, 2026 (weights + paper). ComfyUI node: May 27. SDXL / Qwen-Image checkpoint: June 2. **IN 7-DAY WINDOW.**
+- Replaces the standard VAE decoder with a single-step pixel-diffusion process that simultaneously decodes AND upscales 4× or 8×
+- Compatible: Flux, Flux.2, Klein 4B/9B, SD3, ZIT, SDXL, Qwen-Image, Qwen-Image-2512, DINOv2 RAE, SigLIP Scale-RAE
+- VRAM: ComfyUI staged pipeline (`PiD Prepare → PiD Sample → PiD Finalize`) confirmed stable on 12 GB; RTX 5060 Ti (16 GB) comfortable
+- ComfyUI nodes: `Merserk/ComfyUI-PiD`, `tsolful/ComfyUI-PiD`
+- **Action:** Install ComfyUI-PiD; integrate as optional `use_pid=True` flag in `build_supir` and optionally `build_upscale`. The SDXL checkpoint (landed June 2) means SUPIR is the immediate target.
+- Sources: https://hf.co/nvidia/PiD | https://github.com/nv-tlabs/PiD | arxiv:2605.23902
+
+### 2. Microsoft Lens — `build_txt2img` / `build_generate_anything`
+**Released:** May 25, 2026 (weights). ComfyUI PR #14077 merged (~May 26–27). **IN 7-DAY WINDOW.**
+- Dual-stream MMDiT, 3.8B parameters; three variants: Lens (20 steps), Lens-Turbo (4 steps, 0.84 s/image), Lens-Base (50 steps)
+- MIT license — commercial use allowed
+- Up to 1440×1440 resolution
+- VRAM: Lens-Turbo runs on 16 GB without CPU offload confirmed by community
+- ComfyUI-Org weights: `hf.co/Comfy-Org/Lens`; tutorial: `docs.comfy.org/tutorials/image/lens/lens`
+- **Action:** Add `build_lens_txt2img` builder as a fast-path alternative for `build_txt2img` / `build_generate_anything`. No new node-pack install needed — native ComfyUI support merged.
+- Sources: https://hf.co/microsoft/Lens | https://github.com/microsoft/Lens | arxiv:2605.21573
+
+### 3. Wan2GP v11.88 — `build_wan_video_blockswap` / `build_wan_video_blockswap_t2v`
+**Released:** May 27–29, 2026. **IN 7-DAY WINDOW.**
+- Adds MKV + MOV output containers, ProRes422/MOV video input support
+- Fixes LoRA format handling; fixes LoRA inpainting crash; adds animate LoRA support
+- New Toolbar with keyboard shortcuts
+- Finetune Creator/Editor (in-UI from-scratch model finetune)
+- VRAM: runs WAN 2.1/2.2 on 8–16 GB via block-swap
+- **Action:** Update Wan2GP to v11.88 on the production machine. No workflow JSON change required — existing `build_wan_video_blockswap` is immediately compatible with new output containers.
+- Source: https://github.com/deepbeepmeep/Wan2GP/commits/main/
+
+### 4. ComfyUI-ReActor v0.6.2 — `build_faceswap` / `build_faceswap_model` / `build_face_restore`
+**Released:** April 25, 2026.
+- HyperSwap 1a/1b/1c ONNX support (256px native vs inswapper's 128px; better identity at high resolution)
+- New "Restore Face Advanced" node — applies face restoration only to swapped faces, not full image
+- Enhanced `Load Face Model` node with `FACE_MODEL_NAME` output
+- VRAM: ONNX inference, ~2–4 GB, well within 16 GB
+- HyperSwap weights: `facefusion/facefusion-labs` HF (place in `ComfyUI/models/hyperswap/`)
+- **Action:** Update `comfyui-reactor-node` to v0.6.2; download `hyperswap_1c_256.onnx`; test against current inswapper in `build_faceswap`. Integrate "Restore Face Advanced" node into `build_face_restore` and `build_photo_restore`.
+- Sources: https://github.com/Gourieff/ComfyUI-ReActor/releases | https://github.com/facefusion/facefusion-labs
+
+### 5. ComfyUI-PuLID-Flux2 v0.6.2 — `build_pulid_flux`
+**Released:** ~May 20, 2026.
+- First PuLID implementation supporting FLUX.2 Klein 4B/9B natively
+- Auto-detects Klein 4B / Klein 9B / FLUX.2 Dev; rebuilt injection for FLUX.2 block structure
+- Klein 4B: ~6–8 GB VRAM; Klein 9B: ~12–14 GB — both fit RTX 5060 Ti 16 GB
+- Weights: `hf.co/Fayens/Pulid-Flux2`
+- **Action:** Install `iFayens/ComfyUI-PuLID-Flux2`; update `build_pulid_flux` to support Klein model targets in addition to existing Flux.1 path.
+- Sources: https://github.com/iFayens/ComfyUI-PuLID-Flux2 | https://hf.co/Fayens/Pulid-Flux2
+
+### 6. SAM 3.1 — `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract`
+**Released:** March 27, 2026.
+- "Object Multiplex" shared-memory joint multi-object tracking
+- 2× speed (16 → 32 FPS) and half VRAM (8 GB → 4 GB FP16) vs SAM 3.0
+- Image inference: comfortably under 16 GB
+- HuggingFace: `facebook/sam3.1`; GitHub: `facebookresearch/sam3`
+- **Action:** Update SAM checkpoint to 3.1 in the workflows that call `build_sam3_*`. Verify ComfyUI SAM node compatibility with 3.1 checkpoint format.
+- Source: https://github.com/facebookresearch/sam3
+
+### 7. Depth Anything 3 — `build_depth_map_v3`
+**Released:** November 14, 2025.
+- Single plain transformer (vanilla DINOv2 encoder) predicting spatially consistent depth, camera pose, and 3D geometry
+- Beats DA2 on monocular depth; superior camera pose accuracy vs VGGT
+- Small model fits well under 16 GB
+- ComfyUI node: `Ltamann/ComfyUI-DepthAnythingV3-TBG`
+- **Action:** Update `build_depth_map_v3` checkpoint target to Depth Anything 3. Verify node compatibility.
+- Source: https://depth-anything-3.github.io/ | arxiv:2511.10647
+
+### 8. HunyuanVideo 1.5 — `build_hunyuan_video`
+**Released:** November 24, 2025 (800K DL, 993 likes on HF).
+- Lighter DiT + Selective and Sliding Tile Attention (SSTA)
+- Glyph-aware text encoding; built-in video super-resolution network
+- Available: `tencent/HunyuanVideo-1.5` (HF, gated license)
+- **Action:** Update `build_hunyuan_video` checkpoint target. Verify ComfyUI node compatibility with 1.5 format before wiring.
+- Source: https://hf.co/tencent/HunyuanVideo-1.5
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install or model download)
+
+### 9. LTX-2.3 — new `build_ltx23_video` or upgrade `build_ltx_video`
+**Released:** March 5, 2026.
+- 22B params; `ltx-2-3-fast` and `ltx-2-3-pro` variants; Apache 2.0
+- Up to 4K/50 fps/20 seconds; stereo 24 kHz audio generation built in
+- VRAM: `ltx-2-3-fast` in FP8/NVFP4 likely fits 16 GB (NVIDIA GDC announcement March 2026); confirm before wiring
+- No official standalone ComfyUI node confirmed; check `Lightricks/LTX-Video` repo
+- Sources: https://ltx.io/model/ltx-2-3 | https://github.com/Lightricks/LTX-Video
+
+### 10. FlashVSR v1.1 — additive for `build_seedv2r` / `build_video_upscale`
+**Released:** November 2025 (v1.1 recommended). CVPR 2026 accepted.
+- One-step diffusion for streaming 4× video super-resolution; ~17 FPS on A100 at 768×1408
+- ~12× faster than prior one-step diffusion VSR models
+- Low-VRAM variant available; ≥12 GB recommended
+- ComfyUI node: `1038lab/ComfyUI-FlashVSR`
+- Sources: https://github.com/OpenImagingLab/FlashVSR | https://hf.co/JunhaoZhuang/FlashVSR-v1.1
+
+### 11. NVIDIA RTX VSR ComfyUI node — additive for `build_video_upscale` / `build_upscale`
+**Released:** March 22, 2026.
+- `Comfy-Org/Nvidia_RTX_Nodes_ComfyUI` — official NVIDIA node
+- Real-time hardware upscaling via RTX Video Super Resolution (dedicated video engine, not CUDA)
+- RTX 5060 Ti (Blackwell) supported; WSL2 issue tracked upstream
+- Complements (does not replace) SeedVR2/FlashVSR temporal diffusion quality
+- Source: https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI
+
+### 12. Hunyuan3D-Omni — additive upgrade for `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured`
+**Released:** August 2025.
+- 3.3B parameters; controllable 3D generation from point clouds, voxels, bounding boxes, and skeletal poses
+- Input: text, image, sketch; 10 GB VRAM for shape-only
+- GitHub: https://github.com/Tencent-Hunyuan/Hunyuan3D-Omni
+- HuggingFace: https://hf.co/tencent/Hunyuan3D-Omni
+
+### 13. HiDream-O1-Image-Dev-2604 — additive `build_hidream_edit`
+**Released:** May 14, 2026 (parent May 8).
+- Pixel-native 8B UiT — no external VAE, no separate text encoder; runs diffusion on raw pixels
+- Instruction-based editing, subject-driven personalization, storyboard generation; up to 2048×2048
+- FP8 variant (~10 GB VRAM): `drbaph/HiDream-O1-Image-Dev-2604-FP8`
+- MIT license; ComfyUI native (PR #13817 merged); node: `Saganaki22/HiDream_O1-ComfyUI`
+- **Note:** Cannot be dropped into existing VAE/T5 node paths — requires new loader. Separate builder needed.
+- Sources: https://hf.co/HiDream-ai/HiDream-O1-Image-Dev-2604 | https://github.com/HiDream-ai/HiDream-O1-Image
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+### 14. WAN 2.7 — will supersede all `build_wan_*` workflows when weights drop
+**Cloud launch:** April 22, 2026. **Open weights:** Not yet released as of June 3, 2026.
+- 27B total / 14B active MoE; T2V + I2V + Reference-to-Video + instruction editing in one model
+- First+last frame, multi-image I2V (up to 9 images + 5 video references)
+- Monitor: https://github.com/Wan-Video and https://hf.co/Wan-AI
+- ETA: late June–July 2026 based on Alibaba historical pattern
+
+### 15. Qwen-Image-2.0 — future `build_qwen_edit` upgrade
+**Paper:** May 11, 2026. **Weights:** Not yet public on HF.
+- Qwen3-VL encoder + Multimodal Diffusion Transformer; up to 1K token instructions
+- Substantially outperforms Qwen Image Edit 2509; text-rich editing, multilingual typography
+- Monitor: https://hf.co/Qwen / https://hf.co/papers/2605.10730
+
+### 16. RealRestorer — alternative to `build_supir`
+**Released:** March 2026.
+- Step1X-Edit DiT + Flux-VAE; 9 degradation types; no text prompt needed; Apache 2.0 code / non-commercial weights
+- VRAM: ~16–20 GB minimum — borderline for 16 GB RTX 5060 Ti without offloading; needs validation
+- Sources: https://hf.co/RealRestorer/RealRestorer | https://github.com/yfyang007/RealRestorer
+
+### 17. LucidFlux — caption-free `build_supir` alternative
+**Released:** Sep 2025; ComfyUI Oct 2025; ICLR 2026 accepted.
+- Flux.1 DiT + SigLip priors; universal degradations; 8–12 GB via ComfyUI node
+- Sources: https://hf.co/W2GenAI/LucidFlux | https://github.com/W2GenAI-Lab/LucidFlux
+
+### 18. DirectSwap / one-shot video head swapping — context for `build_klein_headswap`
+**Released:** Dec 2025 (DirectSwap), Jun 2025 (Controllable One-Shot).
+- Diffusion-based video head swap; superior expression/identity vs landmark-warp
+- No ComfyUI node yet; high integration effort
+- Sources: https://hf.co/papers/2512.09417 | https://hf.co/papers/2506.16852
+
+### 19. HappyHorse 1.0 — general video generation
+**Announced:** April 2026. No downloadable weights as of June 3, 2026 (cloud API only).
+- 15B audio-video, ranked #1 on Artificial Analysis leaderboard
+- Monitor: https://hf.co/happyhorse-ai/happyhorse-1.0
+
+---
+
+## No-finds (verified)
+
+The following areas were searched and produced no novel findings within the 7-day window (May 27 – June 3, 2026):
+
+| Area | Status |
+|---|---|
+| BiRefNet / RMBG-2.0 (background removal) | No new version; RMBG v3 ComfyUI node Jan 2026 is current |
+| DDColor / colorization | No update; DDColor ICCV 2023 remains baseline |
+| ReActor / inswapper (new swap model) | v0.6.2 Apr 25 is most recent — no in-window release |
+| PuLID / IP-Adapter FaceID | PuLID-Flux2 v0.6.2 ~May 20 is latest; no in-window release |
+| CodeFormer / GFPGAN face restore | No 2026 update; CodeFormer 2022/2023 remains current |
+| FramePack | Last release Apr 18 2026; no in-window commits |
+| kijai/ComfyUI-WanVideoWrapper | Last commit May 24 2026 (3 days before window) |
+| Mochi-1 | No 2026 update |
+| CogVideoX | 2025-only minor updates |
+| InstantID | No v2; last update Mar 2025 (Flux port) |
+| PhotoMaker | V2 (Jul 2024) remains latest |
+| Normal map estimation | No new model in window |
+| IC-Light | V2 announced Oct 2024; weights remain fal.ai API only |
+
+---
+
+*Note: The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically. Implementation upgrades (checkpoint swaps, node-pack installs) must happen on the user's local machine — this report is research-only and does not implement any changes.*


### PR DESCRIPTION
## Daily SOTA Review — 2026-06-03 (ISO week 2026-W23)

First audit run — `_dev_docs/upgrade_research/` directory created this cycle. No prior baseline.

---

## Summary table (19 candidates)

| Tier | Count | Highlights |
|---|---|---|
| **Tier 1** — Drop-in supersessions | **8** | NVIDIA PiD, Microsoft Lens, Wan2GP v11.88, ReActor v0.6.2, PuLID-Flux2 v0.6.2, SAM 3.1, Depth Anything 3, HunyuanVideo 1.5 |
| **Tier 2** — Additive new builders | **5** | LTX-2.3, FlashVSR v1.1, RTX VSR node, Hunyuan3D-Omni, HiDream-O1-Image-Dev-2604 |
| **Tier 3** — Monitor / not wire-ready | **6** | WAN 2.7 (weights pending), Qwen-Image-2.0 (weights pending), RealRestorer, LucidFlux, DirectSwap, HappyHorse 1.0 |
| **No-finds (verified)** | 13 areas | BiRefNet, DDColor, FramePack, CodeFormer, Mochi-1, CogVideoX, IC-Light V2, MTB, etc. |

---

## In-window releases (May 27 – June 3, 2026)

Three confirmed items landed within the 7-day window:

1. **NVIDIA PiD** (May 25 weights → May 27 ComfyUI node → June 2 SDXL checkpoint) — drop-in pixel-diffusion VAE decoder + 4×/8× upscaler; directly upgrades `build_supir` and all latent-diffusion pipelines. Staged ComfyUI pipeline stable on 12 GB; RTX 5060 Ti (16 GB) comfortable.

2. **Microsoft Lens / Lens-Turbo** (May 25 weights; ComfyUI merged ~May 26–27) — 3.8B dual-stream MMDiT, MIT license, 4-step Turbo in 0.84 s/image, 16 GB VRAM no offload. Additive fast-path for `build_txt2img` / `build_generate_anything`.

3. **Wan2GP v11.88** (May 27–29) — tooling update for `build_wan_video_blockswap` / `build_wan_video_blockswap_t2v`: MKV/MOV/ProRes422 containers, LoRA format fixes, Finetune Creator. No workflow JSON change required.

---

## Top priority for Tier 1 (actionable on local machine)

- `build_supir` ← install `ComfyUI-PiD` (Merserk or tsolful), add SDXL checkpoint from `nvidia/PiD`
- `build_txt2img` ← `Comfy-Org/Lens` weights already on HF; native ComfyUI; add `build_lens_txt2img`
- `build_wan_video_blockswap` ← update Wan2GP to v11.88
- `build_faceswap` ← update `comfyui-reactor-node` to v0.6.2; download `hyperswap_1c_256.onnx`
- `build_pulid_flux` ← install `iFayens/ComfyUI-PuLID-Flux2`; download `Fayens/Pulid-Flux2` weights
- `build_sam3_*` ← update SAM checkpoint to `facebook/sam3.1`
- `build_depth_map_v3` ← update to Depth Anything 3; node: `Ltamann/ComfyUI-DepthAnythingV3-TBG`
- `build_hunyuan_video` ← update checkpoint to `tencent/HunyuanVideo-1.5` (gated)

## Key monitor items

- **WAN 2.7 open weights** — expected late June–July 2026 at `hf.co/Wan-AI`; will supersede all `build_wan_*` workflows
- **Qwen-Image-2.0 weights** — paper May 11 2026; model not yet public; monitor `hf.co/Qwen`

---

> ⚠️ **Do NOT merge** — this PR is a research audit trail. Implementation upgrades require local node-pack installs on the user's machine.
>
> The local **03:30 nightly export** at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQZHRLhAxbmVsxhyvXYTBR)_