### PR TITLE
chore(research): daily SOTA review 2026-06-04

### DIFF
--- a/_dev_docs/upgrade_research/2026-W23.json
+++ b/_dev_docs/upgrade_research/2026-W23.json
@@ -1,0 +1,362 @@
+[
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Kijai/WanVideo_comfy (Jun 2 update)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "IN WINDOW (Jun 2). Re-pull checkpoint; likely ComfyUI v0.22 compatibility fix. No code changes needed."
+  },
+  {
+    "method": "build_wan_video_blockswap",
+    "category": "checkpoint",
+    "name": "Kijai/WanVideo_comfy_fp8_scaled (Jun 1 update)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "IN WINDOW (Jun 1). Same as above — re-pull."
+  },
+  {
+    "method": "build_wan_video_blockswap_t2v",
+    "category": "checkpoint",
+    "name": "Kijai/WanVideo_comfy_nvfp4",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy_nvfp4",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "IN WINDOW (created May 28). NVFP4-quantized WAN for RTX 50-series. 3x faster, 60% VRAM reduction vs FP16. All WAN builders benefit."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "Wan 2.7",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI",
+    "risk": "high",
+    "confidence": 0.85,
+    "notes": "Tier 3. 27B/14B active MoE. Unified T2V+I2V+R2V+FLF in one model. GGUF needed for 16 GB RTX 5060 Ti. Kijai wrapper may not support yet. Monitor Wan-AI HF org."
+  },
+  {
+    "method": "build_wan_flf",
+    "category": "checkpoint",
+    "name": "Wan 2.7 (FLF support)",
+    "source": "github",
+    "url": "https://wan27.org/blog/wan-2-7-open-source-guide",
+    "risk": "high",
+    "confidence": 0.85,
+    "notes": "Tier 3. Same Wan 2.7 — native first+last frame in one pass. Supersedes build_wan_flf architecturally. GGUF needed."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3",
+    "risk": "medium",
+    "confidence": 0.91,
+    "notes": "Tier 1. Object multiplexing: 16 objects in one pass at 32 FPS. ComfyUI v0.20.0 support added Apr 27 2026. Gated model — verify HF access. Also affects build_sam3_mask, build_sam3_extract, build_magic_eraser, build_klein_sam3_inpaint."
+  },
+  {
+    "method": "build_sam3_mask",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "huggingface",
+    "url": "https://ai.meta.com/blog/segment-anything-model-3/",
+    "risk": "medium",
+    "confidence": 0.91,
+    "notes": "Tier 1. Same SAM 3.1 upgrade."
+  },
+  {
+    "method": "build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "huggingface",
+    "url": "https://ai.meta.com/blog/segment-anything-model-3/",
+    "risk": "medium",
+    "confidence": 0.91,
+    "notes": "Tier 1. Same SAM 3.1 upgrade."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "Depth Anything 3 BASE (DA3-BASE)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/depth-anything/DA3-BASE",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "Tier 1. Apache-2.0. 135M params, outperforms DA2 by >10% on ETH3D. Also adds multi-view pose estimation. Released Nov 2025. Use BASE not LARGE (CC-BY-NC-4.0)."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "node_pack",
+    "name": "PuLID-Flux2 v0.6.2",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Tier 1. Updated Mar 21 2026. Adds Klein 4B/9B support — much more VRAM-friendly for 16 GB. Also: ComfyUI-PuLID-Flux-Chroma fork adds Chroma checkpoint support."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "ComfyUI-ReActor + HyperSwap 1b/1c",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Tier 1. ReActor May 12 2026 release adds HyperSwap model support (3 tiers: 1a speed / 1b balanced / 1c quality), Face Similarity QA node, ReActorSetWeight. HyperSwap 1a has black-circle artifact reports; use 1b as default. Models go in models/hyperswap/."
+  },
+  {
+    "method": "build_faceswap_mtb",
+    "category": "node_pack",
+    "name": "HyperSwap via ReActor",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Tier 1. Same HyperSwap upgrade path as build_faceswap."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "node_pack",
+    "name": "facerestore_advanced",
+    "source": "github",
+    "url": "https://github.com/flickleafy/facerestore_advanced",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Tier 1. Drop-in replacement for facerestore_cf node. Adds SSIM/artifact/color-bleed multi-metric analysis, intelligent caching, CodeFormer fidelity control, auto-fallback. GPLv3. No model change."
+  },
+  {
+    "method": "build_photo_restore",
+    "category": "node_pack",
+    "name": "facerestore_advanced",
+    "source": "github",
+    "url": "https://github.com/flickleafy/facerestore_advanced",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Tier 1. Same facerestore_advanced upgrade as build_face_restore."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "node_pack",
+    "name": "comfyui_controlnet_aux refresh",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Ttdf/comfyui_controlnet_aux",
+    "risk": "low",
+    "confidence": 0.70,
+    "notes": "Tier 1. IN WINDOW (May 31). HF mirror refreshed. Update node package for latest preprocessors."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "FlashVSR v1.1 (CVPR 2026)",
+    "source": "github",
+    "url": "https://github.com/OpenImagingLab/FlashVSR",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Tier 2. One-step diffusion streaming video SR. ~17 FPS at 768x1408. VRAM tiling via ComfyUI-FlashVSR_Stable for 16 GB. Wins on real-footage clips; SeedVR2 still preferred for short AI clips. New builder: build_flashvsr_video_upscale. HF: https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1"
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "IC-Light V2 (Flux-based)",
+    "source": "github",
+    "url": "https://github.com/lllyasviel/IC-Light",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Tier 2. Flux 16-channel VAE backbone. Far higher detail retention vs SD1.5 original. ComfyUI node: ComfyUI_IC-Light-v2_fal. Requires FP8 on 16 GB. V2-Vary variant for stronger illumination. Direct upgrade to build_iclight."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "RealRestorer",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Tier 2. Step1X-Edit backbone. 9 degradation types (blur/rain/reflection/low-light/noise/haze/moire/flare/artifact). Apache-2.0. ComfyUI node: StartHua/Comfyui_RealRestorer. Complement to build_supir (SUPIR still preferred for prompt-guided upscaling). New builder: build_realrestorer. Released Mar 2026."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 3.0",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/hunyuan-3d-30-in-comfyui-state-of",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Tier 2. Text+image-to-3D with PBR materials. ComfyUI Partner Node. Released Feb 13 2026. Direct upgrade from Hunyuan3D 2.0. Also: Pixal3D (MIT, May 24) is a competing option with TRELLIS.2 backbone."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "Pixal3D (TRELLIS.2 backbone)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/TencentARC/Pixal3D",
+    "risk": "medium",
+    "confidence": 0.87,
+    "notes": "Tier 2. IN WINDOW (HF May 24). SIGGRAPH 2026. Near-reconstruction fidelity, 4K PBR, 100K poly GLB in ~3.2s. MIT license. ComfyUI: Saganaki22/Pixal3D-ComfyUI. Needs TRELLIS.2-4B (25 GB disk, 16 GB VRAM minimum). Paper: https://arxiv.org/abs/2605.10922"
+  },
+  {
+    "method": "build_faceid_img2img",
+    "category": "node_pack",
+    "name": "InfiniteYou (ByteDance, ICCV 2025)",
+    "source": "github",
+    "url": "https://github.com/bytedance/ComfyUI_InfiniteYou",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Tier 2. InfuseNet injects identity into FLUX DiT. Official ByteDance ComfyUI node. Zero-shot single-reference and multi-reference combine. More mature than WithAnyone."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "node_pack",
+    "name": "ComfyUI v0.22.0 LTX enhancements",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Tier 2. ComfyUI v0.22.0 (May 20 2026) adds LTXV downscaled IC-LoRA support and optional attention_mask input. Expose these in build_ltx_video."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "controlnet",
+    "name": "Qwen DiffSynth ControlNets (Canny + Depth)",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "risk": "low",
+    "confidence": 0.60,
+    "notes": "Tier 2. ComfyUI added Qwen DiffSynth ControlNet support (exact date unconfirmed). Additive spatial conditioning for build_qwen_edit."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "DreamID-V (ByteDance, Wan-1.3B-Faster)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/XuGuo699/DreamID-V",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Tier 2. Video face swap via DiT with identity-coherence RL. Wan-1.3B-Faster variant targets <=16 GB. Paper: https://hf.co/papers/2601.01425. ComfyUI: TTPlanetPig/Comfyui_DreamID-V_wrapper. Proposed new builder: build_dreamidv_faceswap for video."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Chroma v10 HD",
+    "source": "huggingface",
+    "url": "https://huggingface.co/lodestones/Chroma1-HD",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Tier 3. IN WINDOW (Jun 1). Flux-distilled 8.9B, Apache-2.0. Different family from Klein/FLUX.2 — community Flux distill, not BFL. Needs eval vs Klein for prompt adherence. Also: https://civitai.com/models/1330309/chroma"
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Nucleus-Image 17B MoE",
+    "source": "huggingface",
+    "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
+    "risk": "high",
+    "confidence": 0.75,
+    "notes": "Tier 3. Apr 14 2026. 17B total / 2B active MoE DiT. GenEval 0.87, DPG-Bench 88.79. ComfyUI native node unconfirmed. Paper: https://arxiv.org/abs/2604.12163"
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "ERNIE-Image 8B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/baidu/ERNIE-Image",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Tier 3. Apr 17 2026. Needs GGUF Q8 loader for 16 GB. Strong on structured layouts (posters, comics). Apache-2.0. ERNIE-Image-Turbo (8-step) also available."
+  },
+  {
+    "method": "build_faceid_img2img",
+    "category": "checkpoint",
+    "name": "WithAnyone (ICLR 2026 Spotlight)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/WithAnyone/WithAnyone",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Tier 3. Multi-identity generation on FLUX.1-dev/Kontext. WithAnyone.Ke.preview adds face editing. License: other (non-standard — check before adopting). 16 GB borderline."
+  },
+  {
+    "method": "build_klein_face_detail",
+    "category": "node_pack",
+    "name": "ComfyUI Impact Pack v8.28.3 DETAILER_PIPE schema change",
+    "source": "github",
+    "url": "https://github.com/ltdrdata/ComfyUI-Impact-Pack",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Tier 3 (watch). Apr 19 2026. Pipeline schema change may break existing DETAILER_PIPE workflows in build_klein_face_detail. Test after update; rewire if broken."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "NTIRE 2026 Face Restoration Challenge winners",
+    "source": "github",
+    "url": "https://ntire-face.github.io/2026/",
+    "risk": "high",
+    "confidence": 0.70,
+    "notes": "Tier 3 (watch). Apr 2026. 9 teams outperform CodeFormer on NTIRE benchmark. No public weights yet. Watch for drops."
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "Learning Illumination Control in Diffusion Models (arXiv 2604.24877)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2604.24877",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Tier 3. Apr 27 2026. Open-source Flux.1-dev relighting with instruction control. Outperforms SD1.5/SDXL baselines. Weights URL not located — verify repo. If weights available, strongest build_iclight upgrade candidate."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "GARD (arXiv 2605.26230)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2605.26230",
+    "risk": "high",
+    "confidence": 0.60,
+    "notes": "Tier 3. IN WINDOW (May 25). Diffusion-based geometry+imagery restoration using DA3 backbone. No packaged weights yet. Future relevance to build_depth_map_v3 and 3D pipelines."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "ICEdit (arXiv 2504.20690)",
+    "source": "huggingface",
+    "url": "https://hf.co/papers/2504.20690",
+    "risk": "high",
+    "confidence": 0.72,
+    "notes": "Tier 3. Apr 29 2026. Zero-shot instruction-based DiT editing, LoRA-MoE hybrid. Potential build_qwen_edit replacement if ComfyUI node materialises."
+  },
+  {
+    "method": "build_inpaint",
+    "category": "node_pack",
+    "name": "LanPaint (training-free inpainting)",
+    "source": "github",
+    "url": "https://www.runcomfy.com/comfyui-nodes/LanPaint",
+    "risk": "low",
+    "confidence": 0.60,
+    "notes": "Tier 2. Seamless inpainting without a dedicated inpaint model — uses existing checkpoint. Useful for build_inpaint/build_outpaint where inpaint-specific models are unavailable."
+  },
+  {
+    "method": "build_layer_blend",
+    "category": "node_pack",
+    "name": "Comfyui-LayerForge",
+    "source": "github",
+    "url": "https://github.com/Azornes/Comfyui-LayerForge",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "Tier 2. Multi-layer canvas editor: masks, blend modes, precise transforms, optional AI background removal. Additive UI for build_layer_blend and build_outpaint workflows."
+  },
+  {
+    "method": "build_rembg",
+    "category": "checkpoint",
+    "name": "BEN2 (in ComfyUI-RMBG v3.0.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2501.06230",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Tier 2. BEN2 now integrated in ComfyUI-RMBG v3.0.0 (Jan 2026). Confidence-Guided Matting for dichotomous segmentation. Additive option alongside RMBG-2.0."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W23.md
+++ b/_dev_docs/upgrade_research/2026-W23.md
@@ -1,0 +1,264 @@
+# Spellcaster daily SOTA review — 2026-06-04
+
+ISO week: `2026-W23`. Baseline: **none** (first run — no prior review files in `_dev_docs/upgrade_research/`).
+
+Survey window: **2026-05-28 → 2026-06-04** (7 days).
+Hardware budget: RTX 5060 Ti, 16 GB VRAM.
+Research sources: HuggingFace Hub/Papers MCP, WebSearch (GitHub, CivitAI, blog.comfy.org, arXiv).
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / upgrade (if not) | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| build_wan_video | WAN 2.2 (Kijai weights) | Checkpoint freshened | Re-pull Kijai/WanVideo_comfy (updated Jun 2) | https://huggingface.co/Kijai/WanVideo_comfy | Low | IN WINDOW: Jun 2 update |
+| build_wan22_t2v | WAN 2.2 | Superseded (arch) | Wan 2.7 (27B/14B MoE, T2V+I2V+R2V) | https://wan27.org/blog/wan-2-7-open-source-guide | High | GGUF needed for 16 GB; Tier 3 |
+| build_wan_flf | WAN 2.2 first-last-frame | Superseded (arch) | Wan 2.7 (native FLF in one pass) | https://blog.comfy.org/p/wan27-is-now-available-in-comfyui | High | GGUF needed for 16 GB; Tier 3 |
+| build_wan_video_blockswap | WAN 2.2 + blockswap | Checkpoint freshened | Re-pull Kijai/WanVideo_comfy_fp8_scaled (Jun 1) | https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled | Low | IN WINDOW: Jun 1 update |
+| build_wan_video_blockswap_t2v | WAN 2.2 + blockswap | NVFP4 path available | New Kijai/WanVideo_comfy_nvfp4 repo (RTX 50 series) | https://huggingface.co/Kijai/WanVideo_comfy_nvfp4 | Low | IN WINDOW: created May 28 — 3× speed, 60% VRAM cut on RTX 50xx |
+| build_wan_animate_video | WAN animate | Monitor | Wan 2.7 R2V subsumes this | https://wan27.org | High | Tier 3 |
+| build_ltx_video | LTX-Video (LTX-2.3) | Additive update | ComfyUI v0.22.0 IC-LoRA + attention_mask | https://docs.comfy.org/changelog | Low | ComfyUI v0.22 adds new LTX inputs; Tier 2 |
+| build_hunyuan_video | HunyuanVideo 1.5 | Yes — no v2 | — | — | — | No HunyuanVideo 2.0 found |
+| build_mochi_video | Mochi | Yes | — | — | — | No new release found |
+| build_cogvideo_video | CogVideoX-5b | Yes (open weights) | CogVideoX-3 API-only via Z.AI | https://docs.z.ai/guides/video/cogvideox-3 | — | No open-weight CogVideoX-3 found |
+| build_framepack_video | FramePack | Yes | — | — | — | No new release found |
+| build_video_upscale | 4x-UltraSharp | No | FlashVSR v1.1 (CVPR 2026, streaming, tiling) | https://github.com/OpenImagingLab/FlashVSR | Medium | Complement; wins on real-footage; Tier 2 |
+| build_seedvr2_video_upscale | SeedVR2 v2.5 | Yes | — | — | — | ICLR 2026; no new checkpoint |
+| build_seedv2r | SeedVR | Yes | — | — | — | No change |
+| build_wavespeed_upscale | SeedVR2/WaveSpeed | Yes | — | — | — | No change |
+| build_txt2img | SDXL / Flux | Additive options | Chroma v10 HD (Flux-distilled, Jun 1), Nucleus-Image 17B MoE (Apr 2026) | https://huggingface.co/lodestones/Chroma1-HD | Low / Med-High | Chroma: IN WINDOW; Nucleus-Image: ComfyUI node status unconfirmed; Tier 3 |
+| build_img2img | SDXL / Flux | Yes | — | — | — | No major change |
+| build_inpaint | Flux/SDXL inpaint | Additive | LanPaint (training-free, no dedicated inpaint model needed) | https://www.runcomfy.com/comfyui-nodes/LanPaint | Low | Node-only; Tier 2 |
+| build_outpaint | SDXL | Additive | LanPaint + Comfyui-LayerForge (layered canvas) | https://github.com/Azornes/Comfyui-LayerForge | Low | Node-only; Tier 2 |
+| build_inpaint_fooocus | Fooocus inpaint | Yes | — | — | — | No change |
+| build_controlnet_gen | ControlNet preprocessors | Minor refresh | comfyui_controlnet_aux mirror updated May 31 + Qwen DiffSynth ControlNets | https://huggingface.co/Ttdf/comfyui_controlnet_aux | Low | IN WINDOW: May 31; Tier 1 |
+| build_generate_anything | SDXL | Yes | — | — | — | No change |
+| build_style_transfer | SDXL/Flux | Yes | — | — | — | No change |
+| build_klein_img2img | Klein Flux2 4B/9B | Yes | — | — | — | No new Black Forest Klein release |
+| build_klein_img2img_ref | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_inpaint | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_refine | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_scene_img2img | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_color_match | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_blend | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_detail | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_face_detail | Klein Flux2 | Attention | Impact Pack v8.28.3 DETAILER_PIPE schema change | https://github.com/ltdrdata/ComfyUI-Impact-Pack | Low-Med | Rewire needed after Impact Pack update |
+| build_klein_repose | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_headswap | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_virtual_tryon | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_generate_object | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_batch_variations | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_auto_inpaint | Klein Flux2 | Yes | — | — | — | No change |
+| build_klein_sam3_inpaint | Klein + SAM3 | Upgrade available | SAM 3.1 (ComfyUI v0.20.0 support, Mar 2026) | https://ai.meta.com/blog/segment-anything-model-3/ | Med | SAM 3.1 = object multiplexing 32fps; Tier 1 |
+| build_pulid_flux | PuLID-Flux | Upgrade available | PuLID-Flux2 v0.6.2 (Mar 21, Klein 4B support) + Chroma fork | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Low | Direct upgrade; Tier 1 |
+| build_lumina2_txt2img | Lumina2 | Yes | — | — | — | No new release found |
+| build_qwen_edit | Qwen-based editing | Additive | Qwen DiffSynth ControlNets (Canny+Depth); ICEdit paper (no weights yet) | https://hf.co/papers/2504.20690 | Low | ControlNet additive; ICEdit research-only; Tier 2 / Tier 3 |
+| build_iclight | IC-Light (SD1.5) | No | IC-Light V2 (Flux-based, community-tested) | https://github.com/lllyasviel/IC-Light | Low-Med | Direct upgrade; Tier 2 |
+| build_layer_blend | — | Yes | — | — | — | LayerForge is additive UI, not replacement |
+| build_magic_eraser | SAM3 + LaMa | Upgrade available | SAM 3.1 for segmentation step | https://ai.meta.com/blog/segment-anything-model-3/ | Med | Part of SAM 3.1 upgrade |
+| build_lama_remove | LaMa | Yes | — | — | — | No new LaMa release |
+| build_faceswap | ReActor + inswapper_128 | Upgrade available | HyperSwap 1b/1c in ReActor (May 12 release) | https://github.com/Gourieff/ComfyUI-ReActor | Low | Drop-in via ReActor; Tier 1 |
+| build_faceswap_model | ReActor model training | Yes | — | — | — | No change |
+| build_faceswap_mtb | MTB face swap | Upgrade available | HyperSwap via MTB/ReActor | https://github.com/Gourieff/ComfyUI-ReActor | Low | Same HyperSwap path |
+| build_klein_headswap | Klein Flux2 | Yes | — | — | — | DirectSwap (research-only, no ComfyUI node) |
+| build_photobooth | Iterative frame ref | Yes | — | — | — | No change |
+| build_save_face_model | InsightFace embed | Yes | — | — | — | No change |
+| build_faceid_img2img | FaceID/IPAdapter | Upgrade available | InfiniteYou (ByteDance, ICCV 2025) or WithAnyone (ICLR 2026) | https://github.com/bytedance/ComfyUI_InfiniteYou | Med | Both have ComfyUI nodes; Tier 2 |
+| build_face_restore | CodeFormer | Additive | facerestore_advanced node (smarter orchestration) | https://github.com/flickleafy/facerestore_advanced | Low | Drop-in node replacement; Tier 1 |
+| build_photo_restore | Upscale + CodeFormer | Additive | Same facerestore_advanced upgrade | https://github.com/flickleafy/facerestore_advanced | Low | Tier 1 |
+| build_detail_hallucinate | Upscale + detail | Yes | — | — | — | No change |
+| build_supir | SUPIR (SDXL-based) | Complemented | RealRestorer (9-degradation, Apache-2.0, ComfyUI node) | https://huggingface.co/RealRestorer/RealRestorer | Med | Blind-degradation complement; Tier 2 |
+| build_color_match | Color match | Yes | — | — | — | No change |
+| build_colorize | Klein + DDColor | Yes | — | — | — | No new colorization model |
+| build_ddcolor | DDColor | Yes | — | — | — | No change |
+| build_lut | LUT | Yes | — | — | — | No change |
+| build_rembg | RMBG | Yes | BEN2 (in ComfyUI-RMBG v3.0.0) as alt | https://huggingface.co/papers/2501.06230 | Low | Additive option; no RMBG-3.0 found |
+| build_rembg_birefnet | BiRefNet | Yes | — | — | — | No BiRefNet v2 found |
+| build_rembg_v3 | RMBG-2.0 | Yes | — | — | — | No RMBG-3.0 found |
+| build_sam3_segment | SAM3 | Upgrade available | SAM 3.1 (ComfyUI v0.20.0) | https://ai.meta.com/blog/segment-anything-model-3/ | Med | 32fps, 16-object multi-track; Tier 1 |
+| build_sam3_mask | SAM3 | Upgrade available | SAM 3.1 | https://ai.meta.com/blog/segment-anything-model-3/ | Med | Tier 1 |
+| build_sam3_extract | SAM3 | Upgrade available | SAM 3.1 | https://ai.meta.com/blog/segment-anything-model-3/ | Med | Tier 1 |
+| build_normal_map | Depth/normal model | Yes | — | — | — | ComfyUI-Lotus is available but pre-window |
+| build_depth_map_v3 | Depth Anything v2/v3 | Superseded | DA3-BASE (Apache-2.0, Nov 2025, outperforms DA2 by >10%) | https://huggingface.co/depth-anything/DA3-BASE | Low | Already on HF since Nov; adopt DA3-BASE; Tier 1 |
+| build_hunyuan_3d_mesh | Hunyuan3D 2.0 | Superseded | Hunyuan3D 3.0 (ComfyUI Partner Nodes, Feb 2026) OR Pixal3D (May 24) | https://blog.comfy.org/p/hunyuan-3d-30-in-comfyui-state-of | Med | Both compete; Tier 2 |
+| build_hunyuan_3d_textured | Hunyuan3D 2.0 | Superseded | Hunyuan3D 3.0 / Pixal3D | https://huggingface.co/TencentARC/Pixal3D | Med | Tier 2 |
+| build_seedv2r | SeedVR | Yes | — | — | — | No change |
+| build_upscale | Upscale model | Yes | — | — | — | No new general upscaler |
+| build_upscale_blend | Upscale blend | Yes | — | — | — | No change |
+| build_frame_assembly | Frame assembly | Yes | — | — | — | No change |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+These items are confirmed-available, low-integration-risk upgrades that can be adopted without new node-pack installs beyond what's already in the stack.
+
+### T1-1: WAN checkpoint refresh (Kijai repos)
+- **What:** Re-pull `Kijai/WanVideo_comfy` (updated Jun 2) and `Kijai/WanVideo_comfy_fp8_scaled` (updated Jun 1) to pick up latest WAN 2.2 refinements and ComfyUI v0.22 compatibility fixes.
+- **Affects:** build_wan_video, build_wan_video_blockswap, build_wan_video_blockswap_t2v, build_wan_flf
+- **Action:** Download fresh checkpoint files; no code changes needed.
+- **Source:** https://huggingface.co/Kijai/WanVideo_comfy · https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled
+
+### T1-2: WAN NVFP4 path for RTX 5060 Ti (new repo — IN WINDOW)
+- **What:** `Kijai/WanVideo_comfy_nvfp4` (created May 28, 2026) — NVFP4-quantized WAN targeting RTX 50-series tensor cores. NVIDIA claims 3× faster generation and 60% VRAM reduction vs FP16.
+- **Affects:** All WAN builders — additive quantization path.
+- **Action:** Install checkpoint; add NVFP4 backend routing in builders (or via ComfyUI model loader option).
+- **Source:** https://huggingface.co/Kijai/WanVideo_comfy_nvfp4
+
+### T1-3: SAM 3.1 via ComfyUI v0.20.0
+- **What:** SAM 3.1 (Meta, Mar 27, 2026) adds object multiplexing — 16 objects in one pass at 32 FPS. ComfyUI v0.20.0 added native support Apr 27, 2026.
+- **Affects:** build_sam3_segment, build_sam3_mask, build_sam3_extract, build_magic_eraser, build_klein_sam3_inpaint
+- **Action:** Update ComfyUI to v0.20.0+; swap SAM3 base weights for SAM 3.1 weights. Verify gated HF model access (`facebook/sam3`).
+- **Source:** https://ai.meta.com/blog/segment-anything-model-3/
+
+### T1-4: Depth Anything 3 BASE
+- **What:** DA3-BASE (Apache-2.0, 135M params, Nov 2025) — outperforms DA2 by >10% on ETH3D, adds multi-view pose estimation. Spellcaster likely still on DA2.
+- **Affects:** build_depth_map_v3
+- **Action:** Download `depth-anything/DA3-BASE`; update builder's model path. Use BASE (Apache-2.0) not LARGE (CC-BY-NC-4.0).
+- **Source:** https://huggingface.co/depth-anything/DA3-BASE
+
+### T1-5: PuLID-Flux2 v0.6.2 (Klein 4B support)
+- **What:** PuLID-Flux2 v0.6.2 (Mar 21, 2026) adds Klein 4B/9B support alongside FLUX.1-dev. Klein 4B is much more VRAM-friendly for the 16 GB budget.
+- **Affects:** build_pulid_flux
+- **Action:** Update ComfyUI-PuLID-Flux2 node package; route Klein 4B presets through the Klein path.
+- **Source:** https://github.com/iFayens/ComfyUI-PuLID-Flux2
+
+### T1-6: HyperSwap in ComfyUI-ReActor
+- **What:** ReActor (May 12, 2026 release) now supports HyperSwap 1a/1b/1c ONNX models — intended successor to inswapper_128. Also adds Face Similarity QA node and ReActorSetWeight (0–100% blend).
+- **Affects:** build_faceswap, build_faceswap_mtb
+- **Action:** Update ComfyUI-ReActor; download HyperSwap 1b (balanced) into `models/hyperswap/`; test and set as default. Keep inswapper_128 as fallback.
+- **Note:** Community reports Apr 2026 black-circle artifacts with HyperSwap 1a; 1b/1c appear stable.
+- **Source:** https://github.com/Gourieff/ComfyUI-ReActor
+
+### T1-7: facerestore_advanced node
+- **What:** Drop-in replacement for the `facerestore_cf` node — adds intelligent caching, multi-metric SSIM/artifact/color-bleed analysis, CodeFormer fidelity control, and auto-fallback when primary model fails quality checks.
+- **Affects:** build_face_restore, build_photo_restore
+- **Action:** Install `flickleafy/facerestore_advanced`; replace `RestoreFace` node calls with the advanced variant.
+- **Source:** https://github.com/flickleafy/facerestore_advanced
+
+### T1-8: comfyui_controlnet_aux preprocessor refresh
+- **What:** HF mirror of `comfyui_controlnet_aux` refreshed May 31, 2026.
+- **Affects:** build_controlnet_gen
+- **Action:** Update the node package to pick up any new preprocessors.
+- **Source:** https://huggingface.co/Ttdf/comfyui_controlnet_aux
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install)
+
+Items that add new capability or upgrade a current builder but require installing a new ComfyUI node pack on the local machine.
+
+### T2-1: FlashVSR v1.1 — additive video upscaler (CVPR 2026)
+- **What:** One-step diffusion streaming video super-resolution. ~17 FPS at 768×1408 on A100. ~12× faster than multi-step diffusion SR. Uses WAN 2.1 VAE backbone. VRAM tiling available via `ComfyUI-FlashVSR_Stable`.
+- **Proposed builder:** `build_flashvsr_video_upscale` alongside existing `build_video_upscale`
+- **Use case:** Long real-footage clips (SeedVR2 wins on short AI clips; FlashVSR wins on long real footage).
+- **Node:** `1038lab/ComfyUI-FlashVSR` (auto model download) · `ComfyUI-FlashVSR_Stable` for tiling
+- **Source:** https://github.com/OpenImagingLab/FlashVSR · https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1
+
+### T2-2: IC-Light V2 upgrade for build_iclight
+- **What:** Flux-based IC-Light V2 (lllyasviel) — much higher detail retention vs SD1.5 original. Flux 16-channel VAE. ComfyUI node `ComfyUI_IC-Light-v2_fal` available.
+- **Proposed upgrade:** Replace SD1.5 IC-Light backbone with Flux-based V2 in build_iclight.
+- **VRAM:** Flux backbone; use FP8 on 16 GB. IC-Light V2-Vary variant for stronger illumination changes.
+- **Source:** https://github.com/lllyasviel/IC-Light · https://fal.ai/models/fal-ai/iclight-v2
+
+### T2-3: RealRestorer — additive restoration builder
+- **What:** Step1X-Edit based, 9-degradation-type universal restoration (blur, rain, reflection, low-light, noise, haze, moire, flare, artifact). Apache-2.0. ComfyUI node exists.
+- **Proposed builder:** `build_realrestorer` — blind restoration complement to `build_supir` (SUPIR still preferred for prompt-guided upscaling; RealRestorer for broader degradation types).
+- **Source:** https://huggingface.co/RealRestorer/RealRestorer · https://github.com/StartHua/Comfyui_RealRestorer
+
+### T2-4: Hunyuan3D 3.0 upgrade
+- **What:** Successor to Hunyuan3D 2.0/2.1. Text-to-3D + image-to-3D with PBR materials. Available as ComfyUI Partner Node (Feb 13, 2026).
+- **Proposed upgrade:** Update build_hunyuan_3d_mesh + build_hunyuan_3d_textured to Hunyuan3D 3.0.
+- **Source:** https://blog.comfy.org/p/hunyuan-3d-30-in-comfyui-state-of
+
+### T2-5: Pixal3D — alternative/replacement 3D builder (IN WINDOW)
+- **What:** TRELLIS.2-backbone image-to-3D. Near-reconstruction fidelity, 4K PBR textures, 100K polygon GLB in ~3.2s. MIT license. HF weights updated May 24. ComfyUI nodes: `Saganaki22/Pixal3D-ComfyUI`, `dreamrec/ComfyUI-Pixal3D`.
+- **VRAM:** 16 GB minimum; TRELLIS.2-4B backbone (~25 GB disk, ~14 GB VRAM at 1024³ low-VRAM mode).
+- **Proposed builder:** `build_pixal3d` or update build_hunyuan_3d_* to offer Pixal3D as a backend.
+- **Source:** https://huggingface.co/TencentARC/Pixal3D · https://arxiv.org/abs/2605.10922
+
+### T2-6: InfiniteYou — identity-preserving generation (ICCV 2025)
+- **What:** ByteDance's InfuseNet injects identity into FLUX DiT via residual connections. Official ComfyUI node (`bytedance/ComfyUI_InfiniteYou`). Supports multi-reference face combine and zero-shot single-reference.
+- **Proposed upgrade:** Add InfiniteYou as a backend option in build_faceid_img2img.
+- **Source:** https://github.com/bytedance/ComfyUI_InfiniteYou
+
+### T2-7: LTX-Video IC-LoRA + attention_mask (ComfyUI v0.22.0)
+- **What:** ComfyUI v0.22.0 (May 20, 2026) added downscaled IC-LoRA support and optional `attention_mask` input for LTXV. Temporal processing node also added.
+- **Proposed update:** Expose `attention_mask` and IC-LoRA params in build_ltx_video.
+- **Source:** https://docs.comfy.org/changelog
+
+### T2-8: Qwen DiffSynth ControlNets (Canny + Depth)
+- **What:** ComfyUI now supports Qwen-based DiffSynth ControlNet models for Canny and Depth conditioning on the Qwen model family.
+- **Proposed update:** Wire ControlNet inputs into build_qwen_edit where applicable.
+- **Source:** (ComfyUI changelog)
+
+### T2-9: DreamID-V video face swap (ByteDance, Jan 2026)
+- **What:** Diffusion-transformer video face swap with identity-coherence RL. `Wan-1.3B-Faster` variant targets ≤16 GB. 3 ComfyUI wrappers available.
+- **Proposed builder:** `build_dreamidv_faceswap` for video, complementing build_video_reactor.
+- **Note:** VRAM at boundary; test Wan-1.3B-Faster variant first.
+- **Source:** https://huggingface.co/XuGuo699/DreamID-V · https://github.com/TTPlanetPig/Comfyui_DreamID-V_wrapper
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+Items that are architecturally interesting but not yet ready for production wiring (no ComfyUI node, VRAM too high, research-only, or need more community vetting).
+
+| Item | Why not wire-ready | Watch trigger |
+|---|---|---|
+| **Wan 2.7** (27B/14B MoE) | GGUF needed; Kijai wrapper may not support yet; 16 GB limit borderline | Search "Wan2.7 GGUF" on HF; check Kijai wrapper issues |
+| **Chroma v10 HD** (Jun 1 update) | Alt Flux-distill backbone; not Black Forest Labs; needs eval vs Klein | Test on build_txt2img; compare prompt adherence |
+| **ERNIE-Image 8B** (Apr 17) | Needs GGUF Q8 for 16 GB; ComfyUI integration via diffusers | GGUF becomes available; structured layout use cases |
+| **Nucleus-Image 17B MoE** (Apr 14) | ComfyUI native node unconfirmed; 2B active params but untested on RTX 5060 Ti | ComfyUI node appears in registry |
+| **WithAnyone** (ICLR 2026) | License "other" (non-standard); Flux.1-dev borderline 16 GB | License clarified; Kontext variant weights confirmed |
+| **NTIRE 2026 Face Restoration winners** (Apr 2026) | No public weights yet | Check https://ntire-face.github.io/2026/ for weight drops |
+| **Learning Illumination Control** (arXiv 2604.24877) | Weights repo not located; Flux-based relighting | Verify code repo; if weights released → `build_iclight` upgrade candidate |
+| **LightLab** (SIGGRAPH 2026) | Weights not confirmed open-source | Check https://nadmag.github.io/LightLab/ |
+| **ICEdit** (arXiv 2504.20690) | No ComfyUI node; paper-only weights | ComfyUI node appears; potential build_qwen_edit replacement |
+| **GARD** (arXiv 2605.26230, May 25) | Research only; no packaged inference | Code + weights released |
+| **DiffSwap++ / LivingSwap / DirectSwap** | Research only; no ComfyUI nodes | Node wrappers published |
+| **OmniRestore** (IEEE 2026) | No public weights | Weights published on HF |
+| **HY-World 2.0** (Tencent) | Scene-level; likely >16 GB for quality | Local inference benchmarks appear |
+| **ComfyUI Impact Pack v8.28.3** | DETAILER_PIPE schema change may break build_klein_face_detail | Test after update; rewire if needed |
+| **Seedance 2.0** | Cloud API only; no local weights | Local weights released (unlikely) |
+
+---
+
+## No-finds (verified)
+
+The following items were actively searched and found to have **no notable release or update** in the survey window:
+
+- No FLUX.2 / Klein model update from Black Forest Labs
+- No new SDXL checkpoint with quality jump
+- No new Lumina2 release
+- No new Qwen-edit major release
+- No IC-Light v3
+- No HunyuanVideo 2.0 (latest remains v1.5, Nov 2025)
+- No open-weight CogVideoX-3
+- No new FramePack release
+- No BiRefNet v2 (official; third-party `wefttechnologies/BiRefNet2` is unofficial)
+- No RMBG-3.0 (BRIA RMBG-2.0 is latest)
+- No new DDColor release
+- No new colorization model with public weights
+- No new Mochi release
+- No new LTX-2.x checkpoint (latest is LTX-2.3, Mar 2026)
+- No new normal-map model
+
+---
+
+## Appendix: Items strictly within the 7-day window (2026-05-28 → 2026-06-04)
+
+| Item | Date | Type | Tier |
+|---|---|---|---|
+| Kijai/WanVideo_comfy_nvfp4 (new repo) | May 28 | Checkpoint | T1-2 |
+| Kijai/WanVideo_comfy_fp8_scaled update | Jun 1 | Checkpoint | T1-1 |
+| comfyui_controlnet_aux HF mirror refresh | May 31 | Node tooling | T1-8 |
+| Kijai/WanVideo_comfy update | Jun 2 | Checkpoint | T1-1 |
+| Chroma v10 HD checkpoint update | Jun 1 | Checkpoint | T3 |
+| GARD paper (arXiv 2605.26230) | May 25 | Paper | T3 |
+| Pixal3D HF weights updated | May 24 | Checkpoint | T2-5 |
+
+---
+
+*Note: `tools/export_comfyui_workflows.py` runs nightly at 03:30 local time and will automatically refresh ComfyUI workflow snapshots.*


### PR DESCRIPTION
## Daily SOTA review — 2026-06-04 (ISO week 2026-W23)

First run — no prior baseline. Four parallel research agents surveyed HuggingFace Hub/Papers, GitHub, CivitAI, and blog.comfy.org for the window **2026-05-28 → 2026-06-04**, covering all 74 `build_*` methods across four families.

---

## Finding counts

| Tier | Count | Description |
|---|---|---|
| **Tier 1** — drop-in supersessions | **8** | Low-risk, no new node-pack installs required |
| **Tier 2** — additive new builders | **9** | New capability; needs local node-pack install |
| **Tier 3** — monitor / not wire-ready | **13** | Research-only, VRAM too high, or ComfyUI node unconfirmed |
| **No-finds (verified)** | **15+** | Actively searched; nothing notable found |

---

## Tier 1 — Drop-in supersessions (ship soon)

| # | Item | Affects | Source |
|---|---|---|---|
| T1-1 | **WAN checkpoint refresh** — Kijai/WanVideo_comfy (Jun 2) + WanVideo_comfy_fp8_scaled (Jun 1) | all WAN builders | [HF](https://huggingface.co/Kijai/WanVideo_comfy) |
| T1-2 | **Kijai/WanVideo_comfy_nvfp4** ⚡ *IN WINDOW May 28* — NVFP4 for RTX 50-series, 3× faster / 60% VRAM | all WAN builders | [HF](https://huggingface.co/Kijai/WanVideo_comfy_nvfp4) |
| T1-3 | **SAM 3.1** — 16-object multiplexing at 32 FPS; ComfyUI v0.20.0 support | build_sam3_*, build_magic_eraser, build_klein_sam3_inpaint | [Meta](https://ai.meta.com/blog/segment-anything-model-3/) |
| T1-4 | **Depth Anything 3 BASE** — Apache-2.0, outperforms DA2 by >10% | build_depth_map_v3 | [HF](https://huggingface.co/depth-anything/DA3-BASE) |
| T1-5 | **PuLID-Flux2 v0.6.2** — Klein 4B/9B support (VRAM-friendly) | build_pulid_flux | [GitHub](https://github.com/iFayens/ComfyUI-PuLID-Flux2) |
| T1-6 | **HyperSwap 1b/1c in ReActor** — inswapper_128 successor + Face Similarity QA node | build_faceswap, build_faceswap_mtb | [GitHub](https://github.com/Gourieff/ComfyUI-ReActor) |
| T1-7 | **facerestore_advanced** — SSIM/artifact/color-bleed metrics + auto-fallback (drop-in node) | build_face_restore, build_photo_restore | [GitHub](https://github.com/flickleafy/facerestore_advanced) |
| T1-8 | **comfyui_controlnet_aux** ⚡ *IN WINDOW May 31* — preprocessor mirror refresh | build_controlnet_gen | [HF](https://huggingface.co/Ttdf/comfyui_controlnet_aux) |

---

## Tier 2 — Additive new builders (needs node-pack install)

| # | Item | Proposed builder | Source |
|---|---|---|---|
| T2-1 | **FlashVSR v1.1** (CVPR 2026) — 1-step streaming video SR, VRAM tiling | `build_flashvsr_video_upscale` | [GitHub](https://github.com/OpenImagingLab/FlashVSR) |
| T2-2 | **IC-Light V2** (Flux-based) — higher detail retention vs SD1.5 | upgrade `build_iclight` | [GitHub](https://github.com/lllyasviel/IC-Light) |
| T2-3 | **RealRestorer** — 9-degradation blind restoration, Apache-2.0, ComfyUI node | `build_realrestorer` | [HF](https://huggingface.co/RealRestorer/RealRestorer) |
| T2-4 | **Hunyuan3D 3.0** — Partner Node, PBR, Feb 2026 | upgrade `build_hunyuan_3d_*` | [comfy.org](https://blog.comfy.org/p/hunyuan-3d-30-in-comfyui-state-of) |
| T2-5 | **Pixal3D** ⚡ *IN WINDOW May 24* — TRELLIS.2 backbone, 4K PBR, MIT, SIGGRAPH 2026 | upgrade/replace `build_hunyuan_3d_*` | [HF](https://huggingface.co/TencentARC/Pixal3D) |
| T2-6 | **InfiniteYou** (ByteDance, ICCV 2025) — identity-preserving Flux DiT | augment `build_faceid_img2img` | [GitHub](https://github.com/bytedance/ComfyUI_InfiniteYou) |
| T2-7 | **LTX-Video IC-LoRA + attention_mask** (ComfyUI v0.22.0) | expose in `build_ltx_video` | [changelog](https://docs.comfy.org/changelog) |
| T2-8 | **Qwen DiffSynth ControlNets** (Canny + Depth) | extend `build_qwen_edit` | (ComfyUI changelog) |
| T2-9 | **DreamID-V Wan-1.3B-Faster** — video face swap DiT, Jan 2026 | `build_dreamidv_faceswap` | [HF](https://huggingface.co/XuGuo699/DreamID-V) |

---

## Tier 3 — Monitor / not wire-ready (highlights)

- **Wan 2.7** (27B/14B MoE): supersedes all WAN builders architecturally; needs GGUF for 16 GB + Kijai wrapper update
- **Chroma v10 HD** (*IN WINDOW Jun 1*): Flux-distilled alt backbone; needs eval vs Klein
- **Nucleus-Image 17B MoE** + **ERNIE-Image 8B**: new text-to-image SOTA; no confirmed ComfyUI native node / needs GGUF
- **WithAnyone** (ICLR 2026): multi-identity Flux; non-standard license
- **NTIRE 2026 face restoration winners**: beats CodeFormer; no public weights yet
- **GARD** (*IN WINDOW May 25*): depth+geometry diffusion; research-only paper
- Full table in [`_dev_docs/upgrade_research/2026-W23.md`](../../_dev_docs/upgrade_research/2026-W23.md)

---

## No-finds (15+ actively verified)

No notable release found for: FLUX.2/Klein (BFL), SDXL, Lumina2, Qwen-edit, IC-Light v3, HunyuanVideo 2.0, CogVideoX-3 open weights, FramePack, BiRefNet v2, RMBG-3.0, DDColor, Mochi, LTX-2.x checkpoint, normal-map SOTA.

---

## Files

| File | Description |
|---|---|
| [`_dev_docs/upgrade_research/2026-W23.md`](../../_dev_docs/upgrade_research/2026-W23.md) | Full findings table + tier details |
| [`_dev_docs/upgrade_research/2026-W23.json`](../../_dev_docs/upgrade_research/2026-W23.json) | Machine-readable records (35 entries) |

---

> **Do not merge** — leave open for human review.
>
> ℹ️ The nightly export at `tools/export_comfyui_workflows.py` runs at 03:30 local time and will automatically refresh ComfyUI workflow snapshots once any Tier-1/2 upgrades are applied locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDEjz8H1ZXS6fnXD7wMG2T)_