### PR TITLE
chore(research): daily SOTA review 2026-06-12

### DIFF
--- a/_dev_docs/upgrade_research/2026-W24.json
+++ b/_dev_docs/upgrade_research/2026-W24.json
@@ -1,0 +1,362 @@
+[
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 distilled FP8 (22B, 8-step)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "Direct replacement for ltx arch checkpoint. Distilled FP8 variant confirmed on RTX 5060 Ti 16 GB at 768p. 8-step inference, 20-second clips, redesigned VAE, NVFP8 2x speed on RTX 50-series. Released 2026-03-05. ComfyUI-LTXVideo node required: https://github.com/Lightricks/ComfyUI-LTXVideo"
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "WAN 2.7 (14B, 1080p, audio-visual)",
+    "source": "modelscope",
+    "url": "https://blog.comfy.org/p/wan27-is-now-available-in-comfyui",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Supersedes WAN 2.2. Adds 1080p native, ref-to-video (5 subjects), video edit/style, audio-driven video, 5000-char prompts. GGUF INT8 fits 16 GB VRAM. Weights on ModelScope + community HF GGUF repacks. Requires WanVideoWrapper (Kijai). Applies to all wan22/wan_video/wan_flf/wan_animate/wan_blockswap builders."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "WAN 2.7 (14B, 1080p, audio-visual)",
+    "source": "modelscope",
+    "url": "https://blog.comfy.org/p/wan27-is-now-available-in-comfyui",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Same as build_wan22_t2v. See that entry."
+  },
+  {
+    "method": "build_wan_flf",
+    "category": "checkpoint",
+    "name": "WAN 2.7 (14B, 1080p, audio-visual)",
+    "source": "modelscope",
+    "url": "https://blog.comfy.org/p/wan27-is-now-available-in-comfyui",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "WAN 2.7 includes first-last-frame interpolation mode. Same family upgrade."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Illustrious-XL v2.0 (natural language prompts)",
+    "source": "civitai",
+    "url": "https://civitai.com/models/1369089/illustrious-xl-20",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Released 2026-06-08 (within 7-day window). Adds natural language support to Illustrious; v1.x needed danbooru tags. Checkpoint path unchanged; prompt mode logic needs version-branching. Apply to build_img2img with illustrious preset as well."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Chroma1-HD (1024 px, 2.5x speed)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/lodestones/Chroma1-HD",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Released 2026-06-01 (within 7-day window). High-res Chroma variant: 1024 px native, 2.5x speed vs quantised FLUX. Same special CLIP type, no pipeline changes. Add chroma_v10HD.safetensors as chroma preset model option."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "controlnet",
+    "name": "Shakker-Labs FLUX.1-dev ControlNet Union Pro 2.0",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "Best-in-class multi-mode Flux ControlNet. 300k steps, 20M images. Adds soft_edge mode; removes tile mode vs v1. FP8 community variant available. Update flux ControlNet default and add soft_edge to mode enum."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "onnx_model",
+    "name": "HyperSwap 256px (1a / 1b / 1c variants)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "Drop-in into ComfyUI-ReActor v0.6.2 (already in Spellcaster). 2x native resolution (256 vs 128 px). Place in models/hyperswap/. Variants: 1a=speed, 1b=balanced, 1c=quality. ResearchRAIL-MS license: non-commercial use only. Applies also to build_faceswap_model."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "BiRefNet_HR (2048 px training, SDPA optimised)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ZhengPeng7/BiRefNet_HR",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Sept 2025 SDPA attention update reduces VRAM vs prior version. Trained at 2048x2048, sharper masks on high-res inputs (>1024 px). Same BiRefNet pipeline. Add as model option; prefer HR for high-res inputs."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "Hunyuan3D-2.1 (PBR materials: albedo + metallic + roughness)",
+    "source": "huggingface",
+    "url": "https://github.com/Tencent-Hunyuan/Hunyuan3D-2.1",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "Open weights + training code. PBR output is significant quality jump. Native texture gen requires ~21 GB VRAM; mmgp/Hunyuan3D-2GP offloading enables 16 GB. Shape-only fits 10 GB. Applies to build_hunyuan_3d_mesh (shape quality improvement). Released June 2025 but not yet in Spellcaster."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2 (Klein 4B/9B native)",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "v0.6.2 adds native FLUX.2 Klein 4B/9B weight support. Enables build_pulid_flux on Klein backbone. InsightFace + EVA-CLIP still required for face embedding. Klein 4B fits comfortably in 16 GB."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Ideogram 4.0 NF4 (9.3B, Qwen3-VL-8B text encoder, JSON prompts)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ideogram-ai/ideogram-4-nf4",
+    "risk": "medium",
+    "confidence": 0.97,
+    "notes": "New Tier-2 builder build_ideogram4 needed. NF4 variant confirmed on 16 GB. Day-0 ComfyUI v0.24.0 (2026-06-03). New DualModelGuider, Ideogram4Scheduler, CFGOverride nodes. Structured JSON prompt interface (colour palettes, bounding boxes). Non-commercial license (Ideogram Non-Commercial Agreement)."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Microsoft Lens / Lens-Turbo (3.8B, MIT, FLUX.2 VAE)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/microsoft/Lens",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "New Tier-2 builder build_lens needed. 3.8B dual-stream MMDiT, MIT licensed, GPT-OSS-20B text encoder, reuses FLUX.2 VAE. Lens-Turbo = 4-step distilled. Day-0 ComfyUI v0.23.0 (2026-06-01). Ideal for LoRA fine-tuning."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "NVIDIA PixelDiT-1300M (VAE-free, Gemma-2-2B-IT text encoder)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px",
+    "risk": "medium",
+    "confidence": 0.93,
+    "notes": "New Tier-2 builder build_pixeldit needed. 1.3B VAE-free pixel-space DiT; 5.25 GB checkpoint. Day-0 ComfyUI v0.23.0 (2026-06-01). Eliminates VAE encode/decode entirely; Gemma-2 text encoder is new. CVPR 2026 Best Paper Finalist."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "SkyReels V3 V2V-14B (video extension)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Skywork/SkyReels-V3-V2V-14B",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "New Tier-2 builder build_skyreels_v3_v2v needed. Video-to-video extension (14B). Via WanVideoWrapper (Kijai Pusa workflow). FP8 scaled weights at https://huggingface.co/Kijai/WanVideo_comfy_fp8_scaled. BlockSwap enables 16 GB. Also: R2V-14B (multi-subject), A2V-19B (lip-sync)."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "checkpoint",
+    "name": "FlashVSR v1.1 (CVPR 2026, LCSA streaming architecture)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "CVPR 2026. Locality-Constrained Sparse Attention + TCDecoder. ~12x faster than prior diffusion VSR. 2x/4x upscaling. Fits 16 GB with tiling or TCDecoder variant. ComfyUI nodes: https://github.com/1038lab/ComfyUI-FlashVSR and https://github.com/naxci1/ComfyUI-FlashVSR_Stable. Requires LCSA module -- verify node version."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "node_pack",
+    "name": "SeedVR2 7B v2.5 (4-node breaking arch change)",
+    "source": "github",
+    "url": "https://github.com/comfyorg/comfyui_seedvr2",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "v2.5 breaks existing single-node SeedVR2 workflows -- rebuild required. 7B quality upgrade via BlockSwap feasible on 16 GB. Smart FP8 (BF16 arithmetic only). GGUF 4-bit for 7B also available. Prefer official ComfyOrg repo over numz fork for long-term support. Applies to build_seedv2r."
+  },
+  {
+    "method": "build_lama_remove",
+    "category": "checkpoint",
+    "name": "LBM - Latent Bridge Matching (ICCV 2025 Highlight, single-step)",
+    "source": "github",
+    "url": "https://github.com/gojasper/LBM",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "ICCV 2025 Highlight. NFE=1 (single-step) object removal. ~8-10 GB VRAM. Outperforms LaMa and SDXL-Inpainting on RORD. New builder build_lbm_remove for fast path. LaMa stays as lightweight/batch fallback. Weights at gojasper org."
+  },
+  {
+    "method": "build_magic_eraser",
+    "category": "checkpoint",
+    "name": "OmniPaint (ICCV 2025, FLUX.1-dev LoRA dual removal+insertion)",
+    "source": "github",
+    "url": "https://github.com/yeates/OmniPaint",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "ICCV 2025. Built on FLUX.1-dev + LoRA. CycleFlow training for dual insertion/removal. Outperforms LaMa on complex scenes. ~12-16 GB VRAM. No dedicated ComfyUI node yet; use via FLUX inpaint workflow with OmniPaint LoRA. New builder build_omnipaint_remove."
+  },
+  {
+    "method": "build_rembg",
+    "category": "checkpoint",
+    "name": "BEN2 - Background Erase Network v2 (Confidence-Guided Matting)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/PramaLLC/BEN2",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Confidence-Guided Matting refiner targets uncertain pixels. Best for hair matting and fine edges. ~4-6 GB VRAM. ComfyUI node: https://github.com/PramaLLC/BEN2_ComfyUI. Also in ComfyUI-RMBG v3.0.0 unified pack. New builder build_rembg_ben2."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "lora",
+    "name": "IConFace (FLUX.2 Klein LoRA, identity-aware face restorer)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/zhangjinyang/IConFace",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "arXiv 2605.02814 (May 2026). First FLUX.2-Klein face restorer with public weights. Two modes: blind restoration and reference-aware (AdaFace IR50 anchor). Requires Klein-base-4B (~10 GB) + iconface_lora.safetensors. No dedicated ComfyUI node yet. Candidate for new build_face_restore_iconface builder."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX Nodes (RTX Video Super Resolution + NVFP4/FP8)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "GDC 2026. RTX VSR: hardware-accelerated real-time upscaling on RTX GPUs. NVFP4: 2.5x speed, 60% VRAM reduction on RTX 50-series (RTX 5060 Ti explicitly supported). Install via ComfyUI Manager 'RTX' search. Also affects LTX-2.3 and WAN builders via NVFP8."
+  },
+  {
+    "method": "build_klein_img2img",
+    "category": "lora",
+    "name": "FLUX.2 Klein Edit LoRA (gen+edit unified adapter)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/blog/black-forest-labs/flux-2-klein-lora",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "BFL Build Small Hackathon (June 5-15 2026). Edit LoRAs accept reference image + natural language instruction -- require additional reference-image input vs standard style LoRAs. Klein LoRA loader must branch on LoRA type (edit vs style). WaveSpeedAI Klein-4B Edit LoRA: https://wavespeed.ai/blog/posts/introducing-wavespeed-ai-flux-2-klein-4b-edit-lora-on-wavespeedai/"
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "node_pack",
+    "name": "ComfyUI-RMBG v3.0.0 (unified SAM3 + RMBG-2.0 + BiRefNet + BEN2 node pack)",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-RMBG",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Jan 1 2026. Single node pack unifying: RMBG-2.0, BEN, BEN2, BiRefNet, SDMatte, SAM, SAM2, SAM3, GroundingDINO. Reduces maintenance burden across build_rembg_* and build_sam3_*. Actively maintained."
+  },
+  {
+    "method": "build_photo_restore",
+    "category": "library_release",
+    "name": "InsightFace 1.0 (removes C++ build tools dependency)",
+    "source": "github",
+    "url": "https://www.insightface.ai/guides/insightface-1-0-tutorial",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Released 2026-05-23. Removes face3d Cython/C++ extension from default install. No API changes. Fixes most common Spellcaster install failure on clean Windows. Update requirements: insightface>=1.0. Applies to all face swap and restoration builders."
+  },
+  {
+    "method": "build_seedv2r",
+    "category": "node_pack",
+    "name": "SeedVR2 7B v2.5 (4-node breaking arch change)",
+    "source": "github",
+    "url": "https://github.com/comfyorg/comfyui_seedvr2",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Same upgrade as build_seedvr2_video_upscale. See that entry."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "Wan 3.0 MoE 60B (14B active) -- MONITOR ONLY",
+    "source": "github",
+    "url": "https://flowith.io/blog/wan-3-0-world-class-text-to-video-open-source-free-2026/",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Tier 3. 4K output, 30-second clips. API available April 2026; open weights expected Q2 2026 but NOT CONFIRMED as of 2026-06-12. ComfyUI node support unconfirmed. Do not adopt until weights confirmed and WanVideoWrapper updated."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-2.0 (20B, 2K native, Lightning LoRA 4-step)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
+    "risk": "high",
+    "confidence": 0.88,
+    "notes": "Tier 3. 20B+ parameters; FP8 marginal at 16 GB VRAM without GGUF. Lightning LoRA enables 4-step edits. Qwen-Image InstantX inpainting ControlNet: https://comfy.org/workflows/image_qwen_image_instantx_inpainting_controlnet-15538e51d812/. Monitor for GGUF quantization."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "research_benchmark",
+    "name": "NTIRE 2026 Real-World Face Restoration (AdaFace replaces ArcFace as identity standard)",
+    "source": "github",
+    "url": "https://github.com/jkwang28/NTIRE2026_RealWorld_Face_Restoration",
+    "risk": "high",
+    "confidence": 0.72,
+    "notes": "Tier 3. Defines current SOTA ceiling; top methods require >16 GB VRAM. Key signal: AdaFace is replacing ArcFace in new face restoration pipelines. DeSC-Face (#5, uses FLUX.2 Klein LoRA) is most feasible at 16 GB but code is confidential. Monitor for public weight releases."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "research_model",
+    "name": "BlazeEdit (Google, 195M, 5 editing tasks, CVPR 2026)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2605.28067",
+    "risk": "high",
+    "confidence": 0.72,
+    "notes": "Tier 3. No public weights. Presented CVPR 2026-06-06 (within window). 195M param text-free multi-task editor: removal, outpainting, tone correction, relighting, sticker gen. Task-selector replaces text prompt. Watch for Google Research open-source release."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "paper_only",
+    "name": "Hunyuan3D-2.5 (paper only -- no weights confirmed)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2506.16504",
+    "risk": "high",
+    "confidence": 0.72,
+    "notes": "Tier 3 / SKIP. Tencent appears to have paused open-weight releases for 2.5 (confirmed via GitHub issues #316, #232). Hunyuan3D-2.1 (Tier 1) is the actionable upgrade. Watch Tencent-Hunyuan/Hunyuan3D-2 for weight announcement."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "node_pack",
+    "name": "ComfyUI-DepthAnythingV3 (multi-view + 3D point cloud)",
+    "source": "github",
+    "url": "https://github.com/PozzettiAndrea/ComfyUI-DepthAnythingV3",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "No-find for depth: Spellcaster already uses da3_large.safetensors. This ComfyUI node (Nov 2025) unlocks multi-view cross-attention for video depth consistency and 3D point cloud export as a new capability. No DA4 found."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "SUPIR (no update) -- STILL SOTA",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2401.13627",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "No-find. No SUPIR v2 or open replacement found in window or recent months. NTIRE 2026 efficient SR challenge covers pure upscaling (SPANV2), not restoration+generation. SUPIR remains best open-source restoration pipeline."
+  },
+  {
+    "method": "build_ddcolor",
+    "category": "checkpoint",
+    "name": "DDColor (no update) -- STILL SOTA",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2212.11613",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "No-find. No DDColor successor in survey window. Oct 2025 frequency-correction paper (arXiv 2510.23399) re-optimises DDColor but introduces no new model architecture."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "checkpoint",
+    "name": "RMBG-2.0 (no RMBG-3.0) -- STILL SOTA",
+    "source": "huggingface",
+    "url": "https://huggingface.co/briaai/RMBG-2.0",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "No-find. No RMBG-3.0 exists. BRIA's newest model is briaai/Fibo-Edit (8B generative DiT for image editing, released 2026-01-16). RMBG-2.0 remains BRIA's latest background removal model."
+  },
+  {
+    "method": "build_faceswap_mtb",
+    "category": "checkpoint",
+    "name": "MTB faceswap (no update) -- STILL SOTA",
+    "source": "github",
+    "url": "",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "No-find. No MTB faceswap update found in window."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W24.md
+++ b/_dev_docs/upgrade_research/2026-W24.md
@@ -1,0 +1,226 @@
+# Spellcaster daily SOTA review — 2026-06-12
+
+ISO week: `2026-W24`. Baseline: none (inaugural audit — no prior `_dev_docs/upgrade_research/` files found).
+
+Hardware budget: **RTX 5060 Ti, 16 GB VRAM**. All items confirmed feasible unless marked ⚠️.
+
+---
+
+## Findings table
+
+### Image-gen + editing
+
+| Method | Current backbone | Still SOTA? | Replacement (if not) | Source URL | Risk | Notes |
+|--------|-----------------|:-----------:|---------------------|------------|:----:|-------|
+| `build_txt2img` / `build_img2img` (illustrious preset) | Illustrious-XL v1.x | **Partial** | Illustrious-XL v2.0 (prompt format only) | https://civitai.com/models/1369089/illustrious-xl-20 | low | Released 2026-06-08. v2.0 switches from danbooru-tag prompts to natural language. Checkpoint path unchanged; prompt mode logic needs branching. |
+| `build_txt2img` / `build_img2img` (chroma preset) | Chroma v2.5 | **Partial** | Chroma1-HD (June 1 HR variant) | https://huggingface.co/lodestones/Chroma1-HD | low | Chroma1-HD: 1024 px native, 2.5× speed vs quantised FLUX. Same special CLIP type — no pipeline change. |
+| `build_klein_*` family (all 15 methods) | FLUX.2 Klein 4B/9B | **Yes** | — | https://huggingface.co/black-forest-labs/FLUX.2-klein-base-4B | low | BFL Build Small Hackathon (June 5–15) produced new Edit LoRAs. Klein 4B↔Qwen3-4B and 9B↔Qwen3-8B encoder pairing must be enforced in the loader; mismatch causes inference failure. |
+| `build_controlnet_gen` (flux path) | InstantX / XLabs v3 ControlNet | **No** | Shakker-Labs FLUX.1-dev ControlNet Union Pro 2.0 | https://huggingface.co/Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0 | low | 300k steps, 20M images, adds soft-edge mode, removes tile. Current best-in-class Flux ControlNet. |
+| `build_qwen_edit` | Qwen-Image-Edit 1.x | **Partial** | Qwen-Image-2.0 | https://huggingface.co/Qwen/Qwen-Image-Edit | high | 20B+; FP8 marginal at 16 GB VRAM. Lightning LoRA enables 4-step edits. InstantX inpainting ControlNet adds new mask-based path. Monitor for GGUF. |
+| `build_lumina2_txt2img` | Lumina2 | **Yes** | — | — | — | No Lumina2 updates found in survey window. |
+| `build_generate_anything` / `build_style_transfer` | SDXL / Flux | **Partial** | Spectrum CVPR-2026 speed wrapper | https://github.com/hanjq17/Spectrum | medium | Training-free Chebyshev spectral acceleration for SDXL/WAN; no quality loss. ComfyUI nodes published June 2026. Optional add-on. |
+| `build_inpaint_fooocus` | Fooocus SDXL | **Yes** | — | — | — | No Fooocus replacement in window. |
+| `build_pulid_flux` | PuLID Flux1 weights | **Partial** | ComfyUI-PuLID-Flux2 v0.6.2 (adds Klein 4B/9B) | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | low | v0.6.2 adds native Klein weight support. Enables `build_pulid_flux` on Klein backbone. InsightFace + EVA-CLIP still required. |
+
+### Video-gen + upscale
+
+| Method | Current backbone | Still SOTA? | Replacement (if not) | Source URL | Risk | Notes |
+|--------|-----------------|:-----------:|---------------------|------------|:----:|-------|
+| `build_ltx_video` | LTX Video v0.9.x | **No** | LTX-2.3 distilled FP8 (22B, 8 steps) | https://huggingface.co/Lightricks/LTX-2.3-fp8 | low | Released 2026-03-05. Distilled FP8 confirmed on 16 GB VRAM at 768p. 20-second clips, redesigned VAE, NVFP8 2× speed on RTX 50-series. ComfyUI node: https://github.com/Lightricks/ComfyUI-LTXVideo |
+| `build_wan22_t2v` / `build_wan_video` / `build_wan_flf` / `build_wan_animate_video` / `build_wan_video_blockswap` | WAN 2.2 | **No** | WAN 2.7 (14B, 1080p native, audio-visual) | https://blog.comfy.org/p/wan27-is-now-available-in-comfyui | low | Released 2026-04. Adds ref-to-video (5 subjects), video edit/style-transfer, audio-driven video, 5000-char prompts. GGUF INT8 variants run on 16 GB. Weights on ModelScope + community HF repacks. WanVideoWrapper (Kijai) required. |
+| `build_seedvr2_video_upscale` | SeedVR2 3B FP8 | **Partial** | SeedVR2 7B v2.5 | https://github.com/comfyorg/comfyui_seedvr2 | low | v2.5 is a **breaking 4-node architecture change**. 7B quality upgrade feasible via BlockSwap on 16 GB. GGUF 4-bit and smart FP8 (BF16 arithmetic only) variants available. |
+| `build_video_upscale` / `build_wavespeed_upscale` | 4x-UltraSharp / WaveSpeed | **Partial** | FlashVSR v1.1 (CVPR 2026) | https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1 | low | Locality-Constrained Sparse Attention; streaming arch; PSNR competitive with SeedVR2 7B on real footage. ComfyUI nodes: https://github.com/1038lab/ComfyUI-FlashVSR. Use only LCSA-enabled nodes. |
+| `build_hunyuan_video` | HunyuanVideo | **Yes** | — | — | — | No HunyuanVideo update found in survey window. |
+| `build_cogvideo_video` | CogVideo | **Yes** | — | — | — | No CogVideo update in window. |
+| `build_mochi_video` | Mochi | **Yes** | — | — | — | No Mochi update in window. |
+| `build_framepack_video` | FramePack | **Yes** | — | — | — | No FramePack update in window. |
+
+### Face + portrait
+
+| Method | Current backbone | Still SOTA? | Replacement (if not) | Source URL | Risk | Notes |
+|--------|-----------------|:-----------:|---------------------|------------|:----:|-------|
+| `build_faceswap` / `build_faceswap_model` | inswapper_128.onnx (128 px) | **Partial** | HyperSwap 256 px (1a/1b/1c variants) | https://huggingface.co/facefusion/models-3.3.0 | low | Drop-in into ReActor v0.6.2 (already wired). 2× native resolution (256 vs 128 px). 1a = speed, 1c = quality. ResearchRAIL-MS license (non-commercial). |
+| `build_faceswap_mtb` | MTB faceswap | **Yes** | — | — | — | No MTB update in window. |
+| `build_face_restore` | CodeFormer v0.1.0 | **Partial** | IConFace (FLUX.2 Klein LoRA, arXiv 2605.02814) | https://huggingface.co/zhangjinyang/IConFace | medium | First FLUX.2-Klein face restorer with public weights. Reference-aware mode (AdaFace anchor). Requires Klein-base-4B (~10 GB) + iconface_lora.safetensors. No dedicated ComfyUI node yet. |
+| `build_photo_restore` | ESRGAN + CodeFormer | **Partial** | InsightFace 1.0 (requirements fix) + HyperSwap | https://www.insightface.ai/guides/insightface-1-0-tutorial | low | InsightFace 1.0 (2026-05-23) removes C++ build-tools hard dep from default install. Update requirements ≥1.0. |
+| `build_pulid_flux` | PuLID Flux1 | **Partial** | See image-gen table above | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | low | See image-gen table. |
+| `build_klein_headswap` | Klein + SAM3 | **Yes** | — | — | low | Dual-SAM3 pattern (face+hair separately) found in community workflows reduces hairline seam artifacts. Pattern improvement only, no new nodes. |
+| `build_detail_hallucinate` | ESRGAN + Flux | **Yes** | — | — | — | No replacement in window. |
+
+### Restore / style / 3D
+
+| Method | Current backbone | Still SOTA? | Replacement (if not) | Source URL | Risk | Notes |
+|--------|-----------------|:-----------:|---------------------|------------|:----:|-------|
+| `build_supir` | SUPIR (SDXL 5-stage) | **Yes** | — | — | — | No SUPIR v2 or open alternative found. Remains SOTA for restoration+generation. |
+| `build_depth_map_v3` | da3_large.safetensors | **Yes** | — | https://github.com/PozzettiAndrea/ComfyUI-DepthAnythingV3 | — | Already using DA3 (Nov 2025). No DA4 found. ComfyUI-DepthAnythingV3 node adds multi-view + 3D point cloud export if needed. |
+| `build_rembg_birefnet` | BiRefNet-general | **Partial** | BiRefNet_HR (2048 px training) | https://huggingface.co/ZhengPeng7/BiRefNet_HR | low | Sept 2025 SDPA update. Sharper masks on high-res inputs (>1024 px). Same pipeline, different model file. |
+| `build_rembg_v3` | RMBG-2.0 | **Yes** | — | — | — | No RMBG-3.0 exists. BRIA's newest model is Fibo-Edit (generative T2I), not background removal. |
+| `build_lama_remove` / `build_magic_eraser` | LaMa | **Partial** | LBM (single-step, ICCV 2025 Highlight) | https://github.com/gojasper/LBM | low | Latent Bridge Matching: 1-step inference, ~8-10 GB VRAM, outperforms LaMa on RORD. LaMa stays as fast fallback. OmniPaint (ICCV 2025) also relevant for complex scenes. |
+| `build_ddcolor` | DDColor artistic/modelscope | **Yes** | — | — | — | No DDColor successor in window. Oct 2025 frequency-correction paper re-optimises but no new architecture. |
+| `build_sam3_segment` / `build_sam3_extract` / `build_sam3_mask` | SAM3 | **Yes** | — | https://arxiv.org/abs/2511.16719 | — | Already on Nov 2025 SAM3. No SAM4 paper found. ComfyUI-RMBG v3.0.0 (Jan 2026) unifies SAM3 + RMBG + BiRefNet into one node pack. |
+| `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured` | HunyuanVideo 3D v2.0 | **No** | Hunyuan3D-2.1 PBR (open weights) | https://github.com/Tencent-Hunyuan/Hunyuan3D-2.1 | medium | PBR material output (albedo + metallic + roughness). Texture gen needs ~21 GB native; mmgp offloading enables 16 GB. Shape-only fits 10 GB. |
+| `build_colorize` / `build_ddcolor` | DDColor | **Yes** | — | — | — | No new colorization model in window. |
+| `build_normal_map` | Standard normal estimator | **Yes** | — | — | — | No update in window. |
+| `build_seedv2r` | SeedVR temporal consistency | **Partial** | SeedVR2 7B v2.5 (see video table) | — | low | Same upgrade path as `build_seedvr2_video_upscale`. |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+These require only checkpoint updates or minor code changes (no new node-pack installs beyond what Spellcaster already carries). Items are ordered by impact.
+
+### T1-01 · LTX-2.3 distilled FP8 → `build_ltx_video`
+**Current:** LTX Video v0.9.x checkpoint.
+**Replacement:** `ltx-2.3-22b-distilled-fp8.safetensors` — 22B parameters, 8-step distilled inference, confirmed on RTX 5060 Ti 16 GB at 768p. 20-second clips, redesigned VAE, NVFP8 2× speed on RTX 50-series.
+**Action:** Update default checkpoint path; set `steps=8`, `cfg=3.5` for distilled mode; verify ComfyUI-LTXVideo node version ≥ latestfor v2.3 support.
+**Source:** https://huggingface.co/Lightricks/LTX-2.3-fp8
+
+### T1-02 · WAN 2.7 → `build_wan22_t2v`, `build_wan_video`, `build_wan_flf`, `build_wan_animate_video`, `build_wan_video_blockswap`
+**Current:** WAN 2.2 (14B). Released April 2026, WAN 2.7 adds 1080p native output, reference-to-video (≤5 subjects), text-guided video edit, audio-driven video, and 5000-char prompts — while retaining the same 14B architecture.
+**Action:** Update WanVideoWrapper to latest; add GGUF INT8 model path for 16 GB; expose new task types. WAN 2.7 weights are on ModelScope and community HF GGUF repacks, not Wan-AI HuggingFace org.
+**Source:** https://blog.comfy.org/p/wan27-is-now-available-in-comfyui · ComfyUI docs: https://docs.comfy.org/tutorials/partner-nodes/wan/wan2-7
+
+### T1-03 · Illustrious-XL v2.0 prompt mode → `build_txt2img` / `build_img2img` (illustrious preset)
+**Current:** Illustrious-XL v0.1–v1.x (danbooru-tag prompts).
+**Change:** v2.0 (released 2026-06-08) adds natural language support. Prompt format should default to natural language for v2.0+ checkpoints.
+**Action:** Version-detect checkpoint and branch prompt guidance; no model-architecture change.
+**Source:** https://civitai.com/models/1369089/illustrious-xl-20
+
+### T1-04 · Chroma1-HD → `build_txt2img` / `build_img2img` (chroma preset)
+**Current:** Chroma v2.5 (8.9B, 512 px sweet spot).
+**Addition:** Chroma1-HD (released 2026-06-01) — same architecture, 1024 px training, 2.5× speed vs quantised FLUX. Same special CLIP tokenizer, so no pipeline change.
+**Action:** Add `chroma_v10HD.safetensors` as model option under the chroma preset.
+**Source:** https://huggingface.co/lodestones/Chroma1-HD
+
+### T1-05 · Shakker-Labs FLUX ControlNet Union Pro 2.0 → `build_controlnet_gen` (flux path)
+**Current:** Older InstantX / XLabs ControlNet.
+**Replacement:** Union Pro 2.0 — 300k training steps, 20M images, adds soft-edge mode, improves pose aesthetics, removes tile mode.
+**Action:** Update default flux ControlNet model path; add `soft_edge` to the mode enum.
+**Source:** https://huggingface.co/Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0
+
+### T1-06 · HyperSwap ONNX models → `build_faceswap` / `build_faceswap_model`
+**Current:** `inswapper_128.onnx` (128 px native).
+**Addition:** HyperSwap 1a/1b/1c (256 px), already supported by ComfyUI-ReActor v0.6.2. Drop model files into `models/hyperswap/` and expose via `swap_model` parameter. 1a = speed, 1c = quality. ⚠️ ResearchRAIL-MS license: non-commercial only.
+**Action:** Document new model paths; add `hyperswap_1c_256.onnx` as the quality option.
+**Source:** https://huggingface.co/facefusion/models-3.3.0
+
+### T1-07 · BiRefNet_HR → `build_rembg_birefnet`
+**Current:** `BiRefNet-general` (1024 px training).
+**Addition:** `BiRefNet_HR` (2048 px training, Sept 2025 SDPA update). Sharper masks on high-res inputs. Same pipeline.
+**Action:** Add HR as model option; prefer HR for inputs > 1024 px.
+**Source:** https://huggingface.co/ZhengPeng7/BiRefNet_HR
+
+### T1-08 · Hunyuan3D-2.1 PBR → `build_hunyuan_3d_textured`
+**Current:** HunyuanVideo 3D v2.0 (texture only).
+**Replacement:** Hunyuan3D-2.1 — open weights, PBR output (albedo + metallic + roughness maps). Training code available. Texture at 16 GB requires mmgp offloading; shape-only fits 10 GB.
+**Action:** Update checkpoint; add PBR output slots (albedo/metallic/roughness) to the save node.
+**Source:** https://github.com/Tencent-Hunyuan/Hunyuan3D-2.1
+
+### T1-09 · InsightFace 1.0 → `requirements.txt` / deployment docs
+**Current:** InsightFace (pre-1.0) — requires MSVC C++ build tools on Windows.
+**Change:** v1.0 (2026-05-23) removes the face3d Cython extension from the default install path. No API changes. Fixes the most common Spellcaster install failure on clean Windows systems.
+**Action:** Pin `insightface>=1.0` in requirements; update deployment docs.
+**Source:** https://www.insightface.ai/guides/insightface-1-0-tutorial
+
+### T1-10 · ComfyUI-PuLID-Flux2 v0.6.2 Klein → `build_pulid_flux`
+**Current:** PuLID targeting FLUX.1 weights.
+**Addition:** v0.6.2 adds native FLUX.2 Klein 4B/9B weight support. Klein 4B fits comfortably in 16 GB.
+**Action:** Update node version; add Klein model paths; test with both 4B and 9B Klein checkpoints.
+**Source:** https://github.com/iFayens/ComfyUI-PuLID-Flux2
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+### T2-01 · Ideogram 4.0 → new `build_ideogram4`
+9.3B DiT, Qwen3-VL-8B text encoder, structured JSON prompt interface (colour palettes, bounding boxes). **NF4 variant confirmed on RTX 5060 Ti 16 GB.** Day-0 ComfyUI v0.24.0 support (2026-06-03) — new `Ideogram4Scheduler`, `DualModelGuider`, and `CFGOverride` core nodes already available. Non-commercial license.
+**Source:** https://blog.comfy.org/p/ideogram-4-day-0-support-in-comfyui · https://huggingface.co/ideogram-ai/ideogram-4-nf4
+
+### T2-02 · Microsoft Lens / Lens-Turbo → new `build_lens`
+3.8B dual-stream MMDiT, MIT licensed, GPT-OSS-20B text encoder, reuses FLUX.2 VAE. Lens-Turbo = 4-step distilled. Day-0 ComfyUI v0.23.0 (2026-06-01). Ideal for LoRA fine-tuning at low compute cost.
+**Source:** https://huggingface.co/microsoft/Lens · https://docs.comfy.org/tutorials/image/lens/lens
+
+### T2-03 · NVIDIA PixelDiT-1300M → new `build_pixeldit`
+1.3B VAE-free pixel-space DiT, Gemma-2-2B-IT text encoder, 5.25 GB checkpoint, 1024 px. Day-0 ComfyUI v0.23.0 (2026-06-01). Removes VAE encode/decode from pipeline entirely.
+**Source:** https://huggingface.co/nvidia/PixelDiT-1300M-1024px · https://docs.comfy.org/tutorials/image/pixeldit/pixeldit
+
+### T2-04 · SkyReels V3 → new `build_skyreels_v3_v2v`, `build_skyreels_v3_r2v`, `build_skyreels_v3_a2v`
+V2V-14B (video extension), R2V-14B (multi-subject reference-to-video), A2V-19B (audio-driven lip-sync). Via ComfyUI-WanVideoWrapper (Kijai) with FP8 scaled weights + BlockSwap. V2V/R2V feasible at 16 GB with BlockSwap; A2V-19B may be tight.
+**Source:** https://huggingface.co/Skywork/SkyReels-V3-V2V-14B · https://github.com/SkyworkAI/SkyReels-V2
+
+### T2-05 · FlashVSR v1.1 → alternative option in `build_video_upscale`
+CVPR 2026. Locality-Constrained Sparse Attention (LCSA) + TCDecoder. Streaming architecture, ~12× faster than prior diffusion VSR. 2× and 4× upscaling. Fits 16 GB with tiling. Only use ComfyUI nodes that include the LCSA module (1038lab or naxci1).
+**Source:** https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1 · https://github.com/1038lab/ComfyUI-FlashVSR
+
+### T2-06 · SeedVR2 7B v2.5 (breaking change) → rebuild `build_seedvr2_video_upscale`
+Breaking 4-node architecture replaces previous single-node. 7B quality upgrade via BlockSwap on 16 GB. Smart FP8 (BF16 arithmetic only). Must rebuild existing SeedVR2 workflows. Prefer official ComfyOrg repo for long-term support.
+**Source:** https://github.com/comfyorg/comfyui_seedvr2
+
+### T2-07 · LBM (Latent Bridge Matching) → new `build_lbm_remove`
+ICCV 2025 Highlight. Single-step (NFE=1) object removal, ~8-10 GB VRAM, outperforms LaMa and SDXL-Inpainting on RORD dataset. Gojasper maintains weights. Fast-path complement to LaMa (which stays for lightweight/batch use).
+**Source:** https://arxiv.org/abs/2503.07535 · https://github.com/gojasper/LBM
+
+### T2-08 · OmniPaint → new `build_omnipaint_remove`
+ICCV 2025. FLUX.1-dev + LoRA, dual-task (object insertion + removal via CycleFlow). Outperforms LaMa, SD-Inpaint, and FLUX-Fill on removal quality. ~12-16 GB VRAM. Use via ComfyUI FLUX inpaint workflow with OmniPaint LoRA.
+**Source:** https://arxiv.org/abs/2503.08677 · https://github.com/yeates/OmniPaint
+
+### T2-09 · BEN2 → new `build_rembg_ben2`
+Confidence-Guided Matting (CGM) refiner targets uncertain pixels. Excels at hair matting and fine edges. ~4-6 GB VRAM. ComfyUI node: https://github.com/PramaLLC/BEN2_ComfyUI. Also wrapped in ComfyUI-RMBG v3.0.0 (unified node pack with SAM3 + RMBG-2.0 + BiRefNet).
+**Source:** https://huggingface.co/PramaLLC/BEN2
+
+### T2-10 · IConFace → new `build_face_restore_iconface` (candidate)
+First FLUX.2 Klein face restorer with public weights. Two modes: blind restoration and reference-aware (AdaFace IR50 identity anchor). Requires Klein-base-4B (~10 GB) + `iconface_lora.safetensors`. No dedicated ComfyUI node yet — needs custom loader.
+**Source:** https://arxiv.org/abs/2605.02814 · https://huggingface.co/zhangjinyang/IConFace
+
+### T2-11 · NVIDIA RTX Nodes → hardware upscale for RTX 50xx
+RTX Video Super Resolution (real-time, hardware-accelerated) + NVFP4 model loading (2.5× speed, 60% VRAM reduction on RTX 50-series). Released at GDC 2026. RTX 5060 Ti is explicitly supported. Install via ComfyUI Manager search 'RTX'.
+**Source:** https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI · https://blogs.nvidia.com/blog/rtx-ai-garage-flux-ltx-video-comfyui-gdc/
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+| Item | Reason not actionable | ETA / Watch signal |
+|------|-----------------------|--------------------|
+| **Wan 3.0 MoE (60B / 14B active)** | Weights not confirmed released; ComfyUI node support TBD | Q3 2026; watch Wan-AI HF org |
+| **Qwen-Image-2.0** | 20B+; marginal at 16 GB without GGUF quantization | Watch for GGUF release on HF |
+| **ReActor v0.7.0-alpha2** (InsightFace-free core) | Alpha — API surface unstable | Watch for v0.7.0 stable |
+| **BlazeEdit (Google, CVPR 2026-06-06)** | No public weights; Google Research internal | Watch for open-source release |
+| **IConFace ComfyUI node** | No dedicated node yet; needs custom loader | Watch GitHub cosmicrealm/IConFace |
+| **Hunyuan3D-2.5** | Paper only; Tencent paused open-weight releases (confirmed GitHub #316, #232) | Watch Tencent-Hunyuan/Hunyuan3D-2 |
+| **CDST style transfer** | Paper only (arXiv 2506.13770); no weights or code | Watch for code release |
+| **FC-VFI frame interpolation** | No ComfyUI node; promising 4×/8× frame-rate via I2V fine-tune | Watch GitHub for node |
+| **PrediT DiT acceleration** | No ComfyUI node yet; 4× FLUX speedup once available | Watch arXiv 2602.18093 + community ports |
+| **LoRAShop multi-LoRA spatial routing** | Complex integration; requires spatial mask per LoRA | Watch for production ComfyUI node |
+| **LTX-2.3 video face-swap LoRA** | 13B model tight at 16 GB VRAM; temporal approach promising | Watch for FP8 quantization |
+| **Seedance 2.0** | API-only, no local weights | Skip unless cloud API path is added |
+| **NTIRE 2026 Face Restoration** | Top methods require >16 GB; team code confidential | Watch for DeSC-Face public weights |
+| **NTIRE 2026 ESR / SPANV2** | Efficient SR only; does not replace SUPIR restoration+gen pipeline | Low priority |
+
+---
+
+## No-finds (verified STILL SOTA)
+
+| Method(s) | Backbone | Verification |
+|-----------|----------|-------------|
+| `build_supir` | SUPIR (SDXL 5-stage) | No SUPIR v2 or open replacement found. NTIRE 2026 covers efficient SR, not restoration+generation. |
+| `build_ddcolor` | DDColor artistic/modelscope | No DDColor successor in window. Oct 2025 frequency-correction paper re-optimises DDColor but introduces no new model. |
+| `build_rembg_v3` | RMBG-2.0 | No RMBG-3.0 exists. BRIA's latest product is Fibo-Edit (generative DiT), not background removal. |
+| `build_sam3_*` | SAM3 (Nov 2025) | Already on the Nov 2025 SAM3 weights. No SAM4 paper found anywhere. |
+| `build_depth_map_v3` | da3_large.safetensors | Code already references DA3. No DA4 paper found. Confirmed current SOTA. |
+| `build_lama_remove` (fast path) | LaMa | LBM and OmniPaint are Tier-2 *additions*, not strict replacements. LaMa stays as the lightweight/batch path. |
+| `build_hunyuan_video` | HunyuanVideo | No update found in survey window. |
+| `build_cogvideo_video` | CogVideo | No update in window. |
+| `build_mochi_video` | Mochi | No update in window. |
+| `build_framepack_video` | FramePack | No update in window. |
+| `build_lumina2_txt2img` | Lumina2 | No Lumina2 updates in window. |
+| `build_inpaint_fooocus` | Fooocus inpainting | No replacement in window. |
+| `build_normal_map` | Standard normal estimator | No update in window. |
+
+---
+
+## Methodology
+
+Four parallel sub-agents searched: HuggingFace Hub (model search, paper search, hub query), arXiv via HF papers API, GitHub (direct repo fetches), ComfyUI Registry, blog.comfy.org, civitai.com, runcomfy.com, and targeted web searches for each family. Survey window: 2026-06-05 to 2026-06-12; items outside the literal window included where they clearly supersede current Spellcaster builders and were not previously reviewed (inaugural audit).
+
+**Important:** This report covers research findings only. All Tier-1 and Tier-2 items require local node-pack installs and checkpoint downloads that can only be performed on the user's machine. The `tools/export_comfyui_workflows.py` nightly export (03:30 local) will automatically refresh ComfyUI workflow snapshots once any upgrades are applied.


### PR DESCRIPTION
## Daily SOTA review — 2026-06-12 (ISO week 2026-W24)

> Inaugural audit — no prior baseline in `_dev_docs/upgrade_research/`.
> Hardware budget: RTX 5060 Ti, 16 GB VRAM.

---

## Summary table

| Tier | Count | Key items |
|------|------:|-----------|
| **Tier 1 — drop-in supersessions** | 10 | LTX-2.3 FP8, WAN 2.7, Illustrious v2.0, Chroma1-HD, Flux ControlNet Union Pro 2.0, HyperSwap 256px, BiRefNet_HR, Hunyuan3D-2.1 PBR, InsightFace 1.0, PuLID-Flux2 v0.6.2 |
| **Tier 2 — additive new builders** | 11 | Ideogram 4.0, Microsoft Lens, NVIDIA PixelDiT, SkyReels V3, FlashVSR v1.1, SeedVR2 7B v2.5, LBM, OmniPaint, BEN2, IConFace, NVIDIA RTX Nodes |
| **Tier 3 — monitor / not wire-ready** | 14 | Wan 3.0 MoE, Qwen-Image-2.0, ReActor v0.7.0-alpha2, BlazeEdit, Hunyuan3D-2.5 (no weights), PrediT, FC-VFI, LoRAShop, Seedance 2.0 (API-only), NTIRE 2026 face top methods, others |
| **No-finds (verified STILL SOTA)** | 13 | SUPIR, DDColor, RMBG-2.0, SAM3, DA3, LaMa (fast path), HunyuanVideo, CogVideo, Mochi, FramePack, Lumina2, Fooocus inpaint, MTB faceswap |

---

## Tier-1 highlights (items needing attention soonest)

**Video:**
- `build_ltx_video` → **LTX-2.3 distilled FP8** (8-step, confirmed 16 GB, 20-second clips, NVFP8 2× speed on RTX 50-series)
- `build_wan22_t2v` + wan family → **WAN 2.7** (1080p, ref-to-video, audio-driven, 5000-char prompts — WAN 2.2 is superseded)

**Image-gen:**
- `build_txt2img` (illustrious preset) → **Illustrious-XL v2.0** (2026-06-08, natural-language prompts replace danbooru tags)
- `build_txt2img` (chroma preset) → **Chroma1-HD** (2026-06-01, 1024 px, 2.5× speed)
- `build_controlnet_gen` (flux path) → **Shakker-Labs Union Pro 2.0** (soft-edge mode added, tile removed)

**Face:**
- `build_faceswap` → **HyperSwap 256 px** (model files only, ReActor v0.6.2 already wired; 2× resolution)
- Requirements → **InsightFace 1.0** (removes C++ build-tools hard dep, pin `insightface>=1.0`)

**Restore/3D:**
- `build_rembg_birefnet` → **BiRefNet_HR** (high-res variant, same pipeline)
- `build_hunyuan_3d_textured` → **Hunyuan3D-2.1 PBR** (albedo + metallic + roughness maps; needs mmgp offload for 16 GB)

**Face ID:**
- `build_pulid_flux` → **ComfyUI-PuLID-Flux2 v0.6.2** (adds native Klein 4B/9B weight support)

---

## Tier-2 highlights (new builders needed)

Three new base models arrived with day-0 ComfyUI core node support (no extra installs):
- **Ideogram 4.0** (NF4 on 16 GB, DualModelGuider, JSON prompt interface) — `build_ideogram4`
- **Microsoft Lens / Lens-Turbo** (3.8B, MIT licensed, FLUX.2 VAE reuse) — `build_lens`
- **NVIDIA PixelDiT-1300M** (VAE-free, 1.3B, CVPR 2026) — `build_pixeldit`

Video gaps:
- **SkyReels V3** V2V/R2V/A2V — video extension, multi-subject, lip-sync (via WanVideoWrapper + BlockSwap)
- **FlashVSR v1.1** (CVPR 2026) — SeedVR2 quality competitor, streaming arch, 16 GB with tiling
- **SeedVR2 7B v2.5** — breaking 4-node arch change; quality upgrade via BlockSwap; official ComfyOrg repo preferred

Object removal:
- **LBM** (ICCV 2025 Highlight, single-step) — `build_lbm_remove`, fast LaMa alternative
- **OmniPaint** (ICCV 2025, FLUX LoRA) — `build_omnipaint_remove`, complex-scene removal

---

> **Reminder:** All Tier-1 and Tier-2 items require local node-pack installs and checkpoint downloads that can only happen on your machine. The `tools/export_comfyui_workflows.py` nightly export at **03:30 local time** will automatically refresh ComfyUI workflow snapshots once any upgrades are applied.

---

*Do not merge — leave open for human review.*"

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9JX2SgPNeDtZ5fpWtNG2G)_