### PR TITLE
chore(research): daily SOTA review 2026-06-15

### DIFF
--- a/_dev_docs/upgrade_research/2026-W25.json
+++ b/_dev_docs/upgrade_research/2026-W25.json
@@ -1,0 +1,322 @@
+[
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "i1 (3B fully-open DiT, Princeton)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/zlab-princeton/i1-3B",
+    "risk": "medium",
+    "confidence": 0.97,
+    "notes": "Published June 9, 2026 — within audit window. 3B params; fully open weights+data+code; outperforms all prior open T2I models by 29.5pp avg on GenEval/DPG/PRISM/CVTG-2K/LongText. Fits 16 GB. New builder needed."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Ideogram 4.0 (9.3B NextDiT, non-commercial)",
+    "source": "comfyui-blog",
+    "url": "https://blog.comfy.org/p/ideogram-4-day-0-support-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.97,
+    "notes": "Released June 3, 2026. Day-0 ComfyUI support via v0.24.0. 9.3B NextDiT/Lumina2-family with Qwen3-VL-8B text encoder. Non-commercial license. Best-in-class typography + JSON layout prompts. New Ideogram4Scheduler node needed."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Microsoft Lens (3.8B, 4-step Turbo variant)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/issues/14048",
+    "risk": "medium",
+    "confidence": 0.92,
+    "notes": "Released May 20, 2026. ComfyUI PR #14077 landed native support. GPT-OSS-20B MoE text encoder; dense-caption pretraining; 3.8B at 19% compute of 6B+ models. Lens-Turbo = 4 steps. Fits 16 GB well."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image (8B pixel-native UiT, MIT)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
+    "risk": "high",
+    "confidence": 0.85,
+    "notes": "Released May 8, 2026. MIT. Pixel-level Unified Transformer — no external VAE or text encoder; works in raw pixel space. Ranked #1 open-weights model on Artificial Analysis T2I Arena at launch. ComfyUI native workflow at docs.comfy.org. Novel architecture — high integration risk."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Nucleus-Image (17B MoE / ~2B active, sparse DiT)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/NucleusAI/Nucleus-Image",
+    "risk": "high",
+    "confidence": 0.80,
+    "notes": "Released April 14, 2026. arXiv:2604.12163. First fully-open sparse MoE diffusion transformer; 64 routed experts; Qwen3-VL-8B text encoder. Matches Qwen-Image / Seedream 3.0 on GenEval. No native ComfyUI nodes confirmed."
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "UniRelight (NVIDIA/UofT, 7B video relighting)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/nvidia/UniRelight",
+    "risk": "high",
+    "confidence": 0.75,
+    "notes": "NeurIPS 2025 paper; arXiv:2506.15673. 7B Transformer; 480x848; jointly estimates albedo + relit output in single pass. Supersedes IC-Light for video. No ComfyUI node yet. May stress 16 GB at FP16 — FP8 quantization needed."
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "Relit-LiVE (video relighting, May 2026)",
+    "source": "huggingface",
+    "url": "https://hf.co/papers/2605.06658",
+    "risk": "high",
+    "confidence": 0.72,
+    "notes": "May 7, 2026 paper. Avoids intrinsic decomposition; raw reference image injection; per-frame environment prediction in single diffusion pass. Code at github.com/zhuxing0/Relit-LiVE. No ComfyUI node."
+  },
+  {
+    "method": "build_klein_auto_inpaint",
+    "category": "checkpoint",
+    "name": "FLUX.2-Klein NVFP4 / FP8 quantized weights",
+    "source": "comfyui-blog",
+    "url": "https://blogs.nvidia.com/blog/rtx-ai-garage-flux-2-comfyui/",
+    "risk": "low",
+    "confidence": 0.93,
+    "notes": "NVFP4 and FP8 variants for FLUX.2 Klein 4B/9B; confirmed in ComfyUI June 2026 changelog. Up to 2.5x speed + 60% lower memory vs default precision. Drop-in for all build_klein_* pipelines on RTX 50-series. Already same model — speed optimization only."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Wan 2.7",
+    "source": "comfyui-blog",
+    "url": "https://blog.comfy.org/p/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Released ~April 22, 2026. Apache 2.0. Supersedes WAN 2.1 and 2.2 with FLF, 9-grid multi-image, instruction editing, 1080p/15s, audio, 5000-char prompts. ComfyUI partner nodes (v0.18.5). Kijai NVfp4 variant (May 28) for RTX 50-series. GGUF Q8 for 16 GB. Action: update all 6 WAN builders."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Wan 3.0 (27B MoE, not yet released)",
+    "source": "github",
+    "url": "https://wan3pro.com/",
+    "risk": "high",
+    "confidence": 0.55,
+    "notes": "Announced, weights not confirmed public as of June 15, 2026. 27B MoE; 4K; 30-sec clips; Apache 2.0 planned. VRAM: 24 GB+ at fp16. API via Together AI. Monitor Wan-AI HuggingFace org."
+  },
+  {
+    "method": "build_wan_video_blockswap",
+    "category": "checkpoint",
+    "name": "Kijai/WanVideo_comfy_nvfp4 (NVfp4 quantized WAN)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy_nvfp4",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Uploaded May 28, 2026. NVfp4 format for Blackwell (RTX 50-series) tensor cores. Reduces VRAM for blockswap builds. Not a new model — quantization optimization for RTX 5060 Ti specifically."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 (Lightricks, 22B)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Released March 5, 2026. 5.9M downloads, 1377 likes. I2V + T2V + audio-to-video + video-to-audio. 16 GB viable at FP8 dev checkpoints. Official ComfyUI node: Lightricks/ComfyUI-LTXVideo. Direct successor to LTX-Video 1.x — update build_ltx_video."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "checkpoint",
+    "name": "FlashVSR v1.1 (CVPR 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "v1.1 released April 1, 2026. CVPR 2026. Apache 2.0. 23.1K downloads. One-step diffusion streaming VSR; 3x faster than SeedVR2; locality-constrained sparse attention. Fits 16 GB with tiling. ComfyUI: 1038lab/ComfyUI-FlashVSR. Complementary to SeedVR2 (better for AI-generated footage). Add as new build_flashvsr_video_upscale builder."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "DreamID-V (ByteDance, image + video face swap)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/XuGuo699/DreamID-V",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Released January 2026. Apache 2.0. Diffusion Transformer face swap with temporal consistency via curriculum RL. Outperforms inswapper_128 on identity similarity and attribute preservation. Image (DreamID) and video (DreamID-V) variants. Credible successor to ReActor/inswapper_128."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "BFS-Best-Face-Swap (Flux2 Klein LoRA, June 8)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/chfm/BFS-Best-Face-Swap",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "IN AUDIT WINDOW: June 8, 2026. LoRA adapter for Qwen-Image-Edit-2511 and Flux2 Klein enabling face/head swap with natural tone blending. Two new HF repos on June 8. Also: BFS-Best-Face-Swap-Video for LTX-2.3. Needs evaluation before integrating; test against DreamID-V."
+  },
+  {
+    "method": "build_faceid_img2img",
+    "category": "checkpoint",
+    "name": "AuraFace v1 (fal, commercial-safe FaceID)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/fal/AuraFace-v1",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "Commercial-safe open-source identity encoder (ArcFace variant) with IP-Adapter for SD1.5. Gaining traction in 2026 as h94/IP-Adapter-FaceID commercial-safe replacement. Released Aug 2024 but newly relevant for users with commercial licensing concerns."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "lora",
+    "name": "ilkerzgi/face-swap (Flux.2-Klein LoRA, 10K+ downloads)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ilkerzgi/face-swap",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Released April 13, 2026. 10.3K downloads. LoRA for black-forest-labs/FLUX.2-klein-9B enabling diffusion-native face swap. Production-tested; integrates with existing Klein pipeline. Higher fidelity than GAN-based inswapper_128 for photorealistic subjects."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "ComfyUI v0.23.0 MediaPipe face detection node",
+    "source": "comfyui-blog",
+    "url": "https://blog.comfy.org/p/new-template-library-and-partner",
+    "risk": "low",
+    "confidence": 0.68,
+    "notes": "June 1, 2026. Dependency-free reimplementation of Google MediaPipe face detection as native ComfyUI node. Relevant for face detection steps in swap/restore pipelines without requiring insightface."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "RealRestorer (StepFun / SUSTech, 9 degradation types)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Released March 29, 2026. Diffusers-based pipeline fine-tuned on Step1X-Edit covering blur, rain, reflection, low-light, denoising, haze, moire, flare, artifacts at 1024x1024. Broader degradation coverage than SUPIR. Needs diffusers wrapper node for ComfyUI."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Meta, Object Multiplex, March 2026)",
+    "source": "github",
+    "url": "https://github.com/facebookresearch/sam3",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Released March 27, 2026. Apache 2.0. Object Multiplex: up to 16 tracked objects in single forward pass; 7x faster multi-object throughput; 32 FPS on H100. Drop-in checkpoint replacement for SAM 3. Multiple ComfyUI nodes updated (ComfyUI-TBG-SAM3, yolain/ComfyUI-Easy-Sam3). Update checkpoint path in all three SAM3 builders."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "EfficientSAM3.1 / SAM3.1-LiteText",
+    "source": "github",
+    "url": "https://github.com/SimonZeng7108/efficientsam3",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Released April 13, 2026. HuggingFace integration. Progressive knowledge distillation; up to 88% text encoder parameter reduction. Edge-friendly variant of SAM 3.1. Lower priority than main SAM 3.1 upgrade."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "Sapiens2 (Meta, human-centric vision transformers)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sapiens2",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "Released April 24, 2026 (normals/seg); May 15 (matting). CC-BY-NC-SA 4.0. 0.4B-5B ViT family on 1B human images. 45.6% error reduction for surface normals; +24.3 mIoU segmentation vs Sapiens v1. Human-centric — upgrading build_normal_map for portrait workflows. No dedicated ComfyUI node confirmed yet."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "Depth Anything 3 (ICLR 2026, DA3-BASE)",
+    "source": "github",
+    "url": "https://depth-anything-3.github.io/",
+    "risk": "medium",
+    "confidence": 0.92,
+    "notes": "ICLR 2026. Weights: depth-anything/DA3-BASE on HuggingFace. Single plain DINOv2 transformer; spatially consistent geometry from arbitrary views (monocular or multi-view, with or without camera poses). 35.7% camera pose accuracy gain; 23.6% geometric accuracy over DA2. Existing DepthAnythingV2Preprocessor node won't load DA3 directly — new node needed."
+  },
+  {
+    "method": "build_magic_eraser",
+    "category": "checkpoint",
+    "name": "Netflix VOID (video object deletion, quadmask)",
+    "source": "comfyui-blog",
+    "url": "https://blog.comfy.org/p/new-open-source-models-now-in-comfyui",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Announced May 14, 2026 via ComfyUI blog. Netflix open-sourced VOID: video inpainting that removes subject + causally linked elements (shadows, reflections, downstream motion) via 4-value quadmask rather than binary mask. Adjacent to build_magic_eraser / build_rembg for video removal use cases."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 2.5 (LATTICE 10B shape, PBR textures)",
+    "source": "huggingface",
+    "url": "https://arxiv.org/abs/2506.16504",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Released April 23, 2025; paper arXiv:2506.16504 (June 23, 2025). LATTICE: 10B shape foundation model. PBR textures via multi-view architecture. 25% latency reduction. Supersedes Hunyuan3D 2.0 which current builders use. Tencent GitHub: Tencent-Hunyuan/Hunyuan3D-2.5. No dedicated ComfyUI custom node confirmed."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "node_pack",
+    "name": "Hunyuan 3D 3.0 ComfyUI partner node",
+    "source": "comfyui-blog",
+    "url": "https://blog.comfy.org/p/hunyuan-3d-30-in-comfyui-state-of",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Tencent Hunyuan 3D 3.0 (September 2025) became available as ComfyUI partner node in early 2026. Cloud-API based. Text-to-3D, image-to-3D, multi-view (2-4 shots) to 3D with PBR maps and 3D parts decomposition. API-only — not local weights."
+  },
+  {
+    "method": "build_colorize",
+    "category": "checkpoint",
+    "name": "ColorFLUX (CVPR 2026, FLUX-based colorization)",
+    "source": "github",
+    "url": "https://arxiv.org/pdf/2603.28162",
+    "risk": "high",
+    "confidence": 0.70,
+    "notes": "CVPR 2026 paper. Structure-color decoupling for old photo colorization on FLUX.1 with SigLip vision encoder + LoRA rank-32. No public HuggingFace model repo confirmed as of June 15, 2026. Potentially supersedes DDColor when weights drop."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "RoSE (monocular normals via shading sequence, Feb 2026)",
+    "source": "huggingface",
+    "url": "https://hf.co/papers/2602.09929",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Published February 10, 2026. Reformulates normal estimation as shading sequence estimation via image-to-video generative models; resolves 3D misalignment in prior methods. SOTA on standard benchmarks. No ComfyUI node."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "High-Fidelity Diffusion Face Swapping (arXiv:2503.22179)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2503.22179",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "March 2025 paper. Decoupled condition injection + post-training refinement for diffusion face swapping. No public weights. Represents field direction away from GAN-based inswapper_128."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "checkpoint",
+    "name": "SeedVR2 v2.5 (ByteDance, 60% VRAM reduction)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ByteDance-Seed/SeedVR2-7B",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Released ~Nov 2025 (before audit window). 3B and 7B variants. 60% VRAM reduction, 2-3x faster than v1. Official ComfyUI node: numz/ComfyUI-SeedVR2_VideoUpscaler. Check if current builder uses v2.5 weights or v1."
+  },
+  {
+    "method": "build_photobooth",
+    "category": "checkpoint",
+    "name": "FaithfulFaces (pose-faithful face ID in T2V, May 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2605.04702",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "May 6, 2026 paper. Pose-shared identity alignment + Euler angle embeddings for face ID consistency in text-to-video. Potential upgrade path for identity-preserving video workflows. No public weights yet."
+  },
+  {
+    "method": "build_wavespeed_upscale",
+    "category": "checkpoint",
+    "name": "WaveSpeed LTX-2 19B Video Upscaler (API, June 12)",
+    "source": "github",
+    "url": "https://wavespeed.ai/blog/posts/introducing-wavespeed-ai-ltx-2-19b-video-upscaler-on-wavespeedai/",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "IN AUDIT WINDOW: June 12, 2026. WaveSpeedAI LTX-2-based cloud video upscaler with temporal consistency and motion-aware 4K upscaling. API-only — no open weights. Could signal future open-source LTX-2 upscaling."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W25.md
+++ b/_dev_docs/upgrade_research/2026-W25.md
@@ -1,0 +1,213 @@
+# Spellcaster daily SOTA review — 2026-06-15
+
+ISO week: `2026-W25`. Baseline: N/A (inaugural review — `_dev_docs/upgrade_research/` directory did not previously exist).
+
+Hardware budget: RTX 5060 Ti, 16 GB VRAM. Items requiring >16 GB at FP16 are flagged; GGUF/FP8/blockswap paths noted where available.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / upgrade | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| `build_txt2img` | Flux UNET + SDXL | Partly | Ideogram 4.0 (9.3 B), i1 (3 B), Microsoft Lens (3.8 B) | [blog.comfy.org](https://blog.comfy.org/p/ideogram-4-day-0-support-in-comfyui) | medium | Three new open-weight T2I models with ComfyUI day-0 support in last 3 weeks |
+| `build_generate_anything` | SDXL | Partly | i1 (3 B, fully-open, June 9 2026) | [hf.co/zlab-princeton/i1-3B](https://huggingface.co/zlab-princeton/i1-3B) | medium | Published June 9 — squarely inside this audit window |
+| `build_lumina2_txt2img` | Lumina2 DiT | Partly | Ideogram 4.0 (NextDiT/Lumina2-family) | [blog.comfy.org](https://blog.comfy.org/p/ideogram-4-day-0-support-in-comfyui) | medium | Ideogram 4 shares architectural lineage with Lumina2 |
+| `build_img2img` | Flux / SDXL | Yes | — | — | — | No new open img2img model in window |
+| `build_inpaint` | SDXL | Partly | Qwen-Image-ControlNet-Inpainting | [hf.co/InstantX/Qwen-Image-ControlNet-Inpainting](https://huggingface.co/InstantX/Qwen-Image-ControlNet-Inpainting) | medium | Sept 2025 release newly surfacing in community workflows |
+| `build_inpaint_fooocus` | Fooocus | Yes | — | — | — | No new Fooocus-style release in window |
+| `build_outpaint` | SDXL | Yes | — | — | — | No new outpaint model in window |
+| `build_controlnet_gen` | ControlNet preprocessors | Yes | — | — | — | No new ControlNet adapter released in window |
+| `build_style_transfer` | SDXL ref | Yes | — | — | — | No update in window |
+| `build_iclight` | IC-Light (SD1.5) | Partly | UniRelight (NVIDIA, 7 B) | [hf.co/nvidia/UniRelight](https://huggingface.co/nvidia/UniRelight) | high | Supersedes IC-Light conceptually; no ComfyUI node yet; 7 B may stress 16 GB |
+| `build_qwen_edit` | Qwen2.5-VL | Yes | — | — | — | No new instruction-edit open-weight model in window |
+| `build_layer_blend` | utility | Yes | — | — | — | N/A |
+| `build_magic_eraser` | SAM3 + LaMa | Partly | Netflix VOID (video quadmask) | [blog.comfy.org](https://blog.comfy.org/p/new-open-source-models-now-in-comfyui) | low | VOID adds causal element + shadow removal; May 14, 2026 |
+| `build_lama_remove` | LaMa | Yes | — | — | — | No LaMa successor in window |
+| `build_klein_*` (15 methods) | Flux2 Klein 4B / 9B | Yes | NVFP4 / FP8 quantization | [blogs.nvidia.com](https://blogs.nvidia.com/blog/rtx-ai-garage-flux-2-comfyui/) | low | Up to 2.5× speed-up + 60 % lower memory via NVFP4 on RTX 50-series; drop-in |
+| `build_pulid_flux` | PuLID Flux | Yes | — | — | — | FaithfulFaces paper (May 2026) shows direction; no weights yet |
+| `build_wan_video` | WAN 2.1 | **No** | **Wan 2.7** | [blog.comfy.org](https://blog.comfy.org/p/wan27-is-now-available-in-comfyui) | medium | Apache 2.0; released April 2026; 16 GB viable via GGUF |
+| `build_wan22_t2v` | WAN 2.2 | **No** | **Wan 2.7** | [blog.comfy.org](https://blog.comfy.org/p/wan27-is-now-available-in-comfyui) | medium | Wan 2.7 includes T2V, I2V, FLF, animate, audio natively |
+| `build_wan_flf` | WAN 2.x FLF | **No** | **Wan 2.7** (built-in FLF) | [blog.comfy.org](https://blog.comfy.org/p/wan27-is-now-available-in-comfyui) | medium | First-last-frame is native in Wan 2.7 |
+| `build_wan_animate_video` | WAN 2.2 Animate 14B | **No** | **Wan 2.7** | [blog.comfy.org](https://blog.comfy.org/p/wan27-is-now-available-in-comfyui) | medium | Wan 2.7 enhanced animate support with 9-grid multi-image |
+| `build_wan_video_blockswap` | WAN blockswap | **No** | **Wan 2.7 + NVfp4** | [hf.co/Kijai/WanVideo_comfy_nvfp4](https://huggingface.co/Kijai/WanVideo_comfy_nvfp4) | medium | Kijai NVfp4 variant (May 28, 2026) targets RTX 50-series Blackwell |
+| `build_wan_video_blockswap_t2v` | WAN blockswap T2V | **No** | **Wan 2.7 T2V blockswap** | [blog.comfy.org](https://blog.comfy.org/p/wan27-is-now-available-in-comfyui) | medium | Same as above |
+| `build_ltx_video` | LTX-Video 1.x | **No** | **LTX-2.3** (Lightricks, 22 B) | [hf.co/Lightricks/LTX-2.3](https://huggingface.co/Lightricks/LTX-2.3) | low | 5.9 M downloads; March 5, 2026; 16 GB viable at FP8; I2V+T2V+audio |
+| `build_hunyuan_video` | HunyuanVideo | Yes | — | — | — | No open-weight successor confirmed in window |
+| `build_mochi_video` | Mochi | Yes | — | — | — | No update in window |
+| `build_cogvideo_video` | CogVideo | Yes | — | — | — | No update in window |
+| `build_framepack_video` | FramePack F1/P1 | Yes | — | — | — | No new release or checkpoint in window; repo active |
+| `build_frame_assembly` | utility | Yes | — | — | — | N/A |
+| `build_video_upscale` | 4x-UltraSharp (trad.) | Partly | FlashVSR v1.1 | [hf.co/JunhaoZhuang/FlashVSR-v1.1](https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1) | low | Diffusion-based; adds detail recovery over traditional upscalers |
+| `build_seedvr2_video_upscale` | SeedVR2 | Partly | FlashVSR v1.1 (faster alt.) | [hf.co/JunhaoZhuang/FlashVSR-v1.1](https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1) | low | CVPR 2026; Apache 2.0; 3× faster; ComfyUI node at github.com/1038lab/ComfyUI-FlashVSR |
+| `build_wavespeed_upscale` | WaveSpeed | Partly | WaveSpeed LTX-2 19B (API) | [wavespeed.ai](https://wavespeed.ai/blog/posts/wan-2-7-coming-soon-major-upgrade/) | medium | API-only as of June 12, 2026; monitor for open weights |
+| `build_upscale` | 4x-UltraSharp etc. | Yes | — | — | — | No traditional upscaler replacement in window |
+| `build_upscale_blend` | blend utility | Yes | — | — | — | N/A |
+| `build_faceswap` | ReActor / inswapper_128 | Partly | DreamID-V (ByteDance) | [hf.co/XuGuo699/DreamID-V](https://huggingface.co/XuGuo699/DreamID-V) | low | Apache 2.0; image + video; Jan 2026; credible successor |
+| `build_faceswap_model` | ReActor model train | Yes | — | — | — | No model-train successor in window |
+| `build_faceswap_mtb` | MTB faceswap | Partly | DreamID-V | [hf.co/XuGuo699/DreamID-V](https://huggingface.co/XuGuo699/DreamID-V) | low | Same recommendation as build_faceswap |
+| `build_klein_headswap` | Klein Flux2 headswap | Yes | BFS-Best-Face-Swap (LoRA) | [hf.co/chfm/BFS-Best-Face-Swap](https://huggingface.co/chfm/BFS-Best-Face-Swap) | medium | **IN WINDOW** June 8, 2026; Flux2-Klein LoRA for headswap; needs evaluation |
+| `build_klein_face_detail` | Klein face detail | Yes | — | — | — | No successor in window |
+| `build_photobooth` | iterative face ref | Yes | — | — | — | No update in window |
+| `build_save_face_model` | face embed save | Yes | — | — | — | N/A |
+| `build_faceid_img2img` | IP-Adapter FaceID | Yes | AuraFace v1 (commercial-safe alt.) | [hf.co/fal/AuraFace-v1](https://huggingface.co/fal/AuraFace-v1) | low | Commercial-safe open-source alternative if license is a concern |
+| `build_face_restore` | CodeFormer | Yes | — | — | — | No weight-available CodeFormer successor in window; NTIRE 2026 competition winners not yet released |
+| `build_photo_restore` | CodeFormer + upscale | Yes | — | — | — | No change |
+| `build_detail_hallucinate` | detail hallucination | Yes | — | — | — | No update in window |
+| `build_supir` | SUPIR (SDXL) | Partly | RealRestorer (StepFun) | [hf.co/RealRestorer/RealRestorer](https://huggingface.co/RealRestorer/RealRestorer) | medium | 9 degradation types; diffusers-based; March 29, 2026 |
+| `build_color_match` | color match | Yes | — | — | — | No update in window |
+| `build_klein_color_match` | Klein color match | Yes | — | — | — | No update in window |
+| `build_colorize` | Klein colorize | Partly | ColorFLUX (no weights yet) | [arxiv:2603.28162](https://arxiv.org/pdf/2603.28162) | high | CVPR 2026 paper; FLUX.1-based; no public HF weights confirmed |
+| `build_ddcolor` | DDColor | Partly | ColorFLUX (no weights yet) | [arxiv:2603.28162](https://arxiv.org/pdf/2603.28162) | high | Same — paper only; not deployable yet |
+| `build_lut` | LUT grading | Yes | — | — | — | N/A |
+| `build_rembg` | rembg | Yes | — | — | — | No successor in window |
+| `build_rembg_birefnet` | BiRefNet-general | Yes | — | — | — | No BiRefNet v2 in window; ComfyUI-RMBG v3.0.0 released Jan 2026 |
+| `build_rembg_v3` | RMBG-2.0 | Yes | — | — | — | No change |
+| `build_sam3_segment` | SAM 3 | **No** | **SAM 3.1** (drop-in) | [ai.meta.com](https://ai.meta.com/blog/segment-anything-model-3/) | low | March 27, 2026; 7× faster multi-object; up to 32 FPS on H100 |
+| `build_sam3_mask` | SAM 3 | **No** | **SAM 3.1** | [ai.meta.com](https://ai.meta.com/blog/segment-anything-model-3/) | low | Same |
+| `build_sam3_extract` | SAM 3 | **No** | **SAM 3.1** | [ai.meta.com](https://ai.meta.com/blog/segment-anything-model-3/) | low | Same |
+| `build_normal_map` | normal map model | Partly | Sapiens2 (Meta, human-centric) | [hf.co/facebook/sapiens2](https://huggingface.co/facebook/sapiens2) | medium | 45.6 % error reduction for human normals; April 2026; 0.4 B–5 B variants |
+| `build_depth_map_v3` | Depth-Anything v3 | **No** | **Depth Anything 3** (ICLR 2026) | [depth-anything-3.github.io](https://depth-anything-3.github.io/) | medium | Multi-view or monocular; DA3-BASE on HuggingFace; 35.7 % pose accuracy gain |
+| `build_hunyuan_3d_mesh` | Hunyuan3D 2.0 | **No** | **Hunyuan 3D 2.5 / 3.0** | [arxiv:2506.16504](https://arxiv.org/abs/2506.16504) | medium | 2.5 released April 2025 (LATTICE 10B shape); 3.0 as ComfyUI partner node |
+| `build_hunyuan_3d_textured` | Hunyuan3D 2.0 texture | **No** | **Hunyuan 3D 2.5** (PBR) | [arxiv:2506.16504](https://arxiv.org/abs/2506.16504) | medium | PBR textures; 25 % latency reduction vs 2.0 |
+| `build_seedv2r` | SeedVR temporal | Yes | — | — | — | No update to SeedVR (non-SeedVR2) in window |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+All items below have open weights, confirmed ComfyUI node support, and fit the 16 GB VRAM budget (with quantization where noted).
+
+### 1. Wan 2.7 → all 6 WAN builders
+
+- **Replaces**: `build_wan_video`, `build_wan22_t2v`, `build_wan_flf`, `build_wan_animate_video`, `build_wan_video_blockswap`, `build_wan_video_blockswap_t2v`
+- **Released**: ~April 22, 2026. License: Apache 2.0. Weights: ModelScope (Wan-AI org); Kijai NVfp4 quantization on HuggingFace (May 28, 2026).
+- **Why**: Wan 2.7 supersedes Wan 2.1 and 2.2 with first-and-last-frame control, instruction-based editing, 9-grid multi-image input, 1080p / 15 s clips, audio support, and 5000-char prompts.
+- **16 GB path**: GGUF quantization (`Wan2.7-I2V-14B-Q8`) or NVfp4 via `Kijai/WanVideo_comfy_nvfp4`; blockswap still required for full 1080p.
+- **ComfyUI**: `ComfyUI-WanVideoWrapper` (Kijai). ComfyUI v0.18.5 added partner-node templates for all five task types.
+- **Action**: Update all six WAN builders to use Wan 2.7 model IDs and new node signatures.
+
+### 2. LTX-2.3 → `build_ltx_video`
+
+- **Replaces**: `build_ltx_video`
+- **Released**: March 5, 2026. License: Lightricks custom (non-commercial free). Weights: `Lightricks/LTX-2.3` (5.9 M downloads, 1377 likes).
+- **Why**: 22B model with I2V + T2V + audio-to-video; improved texture sharpness; first-last-frame; portrait 9:16 quality. CVPR accelerated per NVIDIA blog.
+- **16 GB path**: FP8 dev checkpoints from Lightricks run comfortably; GGUF community quantizations drop below 16 GB.
+- **ComfyUI**: `Lightricks/ComfyUI-LTXVideo` (official).
+- **Action**: Update `build_ltx_video` model path and node version.
+
+### 3. SAM 3.1 → `build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract`
+
+- **Replaces**: SAM 3 checkpoint in all three builders.
+- **Released**: March 27, 2026. License: Apache 2.0. Weights: Meta / HuggingFace.
+- **Why**: Object Multiplex processes up to 16 tracked objects in a single forward pass; 7× faster multi-object throughput, 32 FPS on H100; drop-in checkpoint replacement.
+- **16 GB path**: Fully compatible (smaller than SAM 3 base).
+- **ComfyUI**: Multiple nodes updated (`ComfyUI-TBG-SAM3`, `yolain/ComfyUI-Easy-Sam3`).
+- **Action**: Update SAM checkpoint path in all three builders to SAM 3.1 weights.
+
+### 4. FlashVSR v1.1 → new `build_flashvsr_upscale` builder (addendum to Tier 1)
+
+- **Complements**: `build_seedvr2_video_upscale`, `build_video_upscale`
+- **Released**: Oct 2025 (v1); v1.1 April 1, 2026. CVPR 2026 paper. License: Apache 2.0. Weights: `JunhaoZhuang/FlashVSR-v1.1` (23.1 K downloads).
+- **Why**: One-step diffusion streaming VSR; 3× faster than SeedVR2; locality-constrained sparse attention; SageAttention provides 20–30 % further speedup. Better on AI-generated / compressed footage than real-world. Complementary to SeedVR2 (which wins on longer real-footage clips).
+- **16 GB path**: 14 GB for 2 s 720p without tiling; tiled mode fits 10–12 GB.
+- **ComfyUI**: `1038lab/ComfyUI-FlashVSR` (official), also `naxci1/ComfyUI-FlashVSR_Stable`.
+- **Action**: Add `build_flashvsr_video_upscale` as alternative to `build_seedvr2_video_upscale`.
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install)
+
+### 1. i1 (Princeton) → new `build_i1_txt2img`
+
+- **Published**: June 9, 2026 (arXiv:2606.11289). **IN THIS AUDIT WINDOW.**
+- **Weights**: `zlab-princeton/i1-3B`. Fully open (weights + data + code).
+- **Why**: 3 B-parameter DiT; outperforms all prior fully-open T2I models by 29.5 pp average across GenEval/DPG/PRISM/CVTG-2K/LongText. Fits comfortably within 16 GB.
+- **Risk**: medium (new architecture; needs ComfyUI integration testing).
+
+### 2. Ideogram 4.0 → new `build_ideogram4_txt2img`
+
+- **Released**: June 3, 2026. Day-0 ComfyUI support (v0.24.0) via `Ideogram4Scheduler` + `DualModelGuider`.
+- **License**: Non-commercial. 9.3 B parameters.
+- **Why**: Best-in-class typography and JSON-structured layout prompting; strong for graphic design tasks. NextDiT/Lumina2-family architecture with Qwen3-VL-8B text encoder.
+- **Risk**: medium (non-commercial license limits production use; new scheduler node needed).
+
+### 3. Microsoft Lens → new `build_lens_txt2img`
+
+- **Released**: May 20, 2026. ComfyUI PR #14077 landed. Lens-Turbo = 4 steps.
+- **Why**: 3.8 B parameters; dense-caption pre-training; GPT-OSS-20B MoE text encoder; trained at 19 % the compute of 6 B+ models. Fits 16 GB well.
+- **Risk**: medium (new loader node; verify checkpoint format).
+
+### 4. DreamID-V (ByteDance) → new `build_dreamid_faceswap`
+
+- **Released**: Jan 2026. License: Apache 2.0. Weights: `XuGuo699/DreamID-V`.
+- **Why**: Diffusion Transformer face swap; outperforms inswapper_128 on identity similarity and attribute preservation; adds temporal consistency for video via curriculum RL. Credible successor to ReActor/inswapper_128.
+- **Risk**: low (Apache 2.0; consistent with existing diffusion pipeline).
+
+### 5. Depth Anything 3 → upgrade `build_depth_map_v3`
+
+- **Released**: ICLR 2026. Weights: `depth-anything/DA3-BASE` on HuggingFace.
+- **Why**: Plain DINOv2 transformer; spatially consistent geometry from arbitrary views (monocular or multi-view); 35.7 % camera pose accuracy gain and 23.6 % geometric accuracy over previous DA versions.
+- **Risk**: medium (new ComfyUI node needed; existing `DepthAnythingV2Preprocessor` won't load DA3 directly).
+
+### 6. RealRestorer (StepFun / SUSTech) → new `build_realrestorer`
+
+- **Released**: March 29, 2026. Weights: `RealRestorer/RealRestorer`. Diffusers-compatible.
+- **Why**: Covers 9 degradation types (blur, rain, reflection, low-light, denoising, haze, moiré, flare, artifacts) at 1024 × 1024. Broader than SUPIR's primarily upscaling-restoration focus.
+- **Risk**: medium (diffusers-based pipeline; needs ComfyUI diffusers wrapper node).
+
+### 7. Sapiens2 (Meta) → new `build_sapiens_normal`
+
+- **Released**: April 24, 2026 (normals/seg); May 15, 2026 (matting). Weights: `facebook/sapiens2`. License: CC-BY-NC-SA 4.0.
+- **Why**: 0.4 B–5 B ViT family pretrained on 1 B human images; 45.6 % error reduction for surface normals; +24.3 mIoU segmentation vs. Sapiens v1. Directly upgrades `build_normal_map` for human subjects.
+- **Risk**: medium (no dedicated ComfyUI node confirmed yet; needs integration work).
+
+### 8. Netflix VOID → new `build_void_remove`
+
+- **Released**: May 14, 2026 (announced via ComfyUI blog). Open source.
+- **Why**: Video inpainting with causal element removal (shadows, reflections, downstream motion effects) via 4-value quadmask. Extends `build_magic_eraser`'s reach to video.
+- **Risk**: low (ComfyUI blog announced it; likely has node support).
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Reason not ready | Watch for |
+|---|---|---|
+| **Wan 3.0** | Weights not confirmed released as of June 15, 2026; 24 GB VRAM min | Weight release on Wan-AI HuggingFace org or ModelScope |
+| **UniRelight** (NVIDIA 7B) | No ComfyUI node; 7 B may exceed 16 GB at FP16 | ComfyUI node PR; FP8 quantization |
+| **Relit-LiVE** (May 2026) | Paper-only; code at github.com/zhuxing0/Relit-LiVE; no ComfyUI node | ComfyUI wrapper |
+| **HiDream-O1-Image** (MIT, 8 B) | Pixel-native architecture; no external VAE; novel ComfyUI integration needed | ComfyUI official tutorial (docs.comfy.org) |
+| **Nucleus-Image** (17 B MoE) | High VRAM; no native ComfyUI nodes confirmed | Active quantization reduces effective size; watch 1038lab |
+| **BFS-Best-Face-Swap** (June 8 LoRA) | LoRA adapter; needs evaluation on Klein pipeline before integrating | Community testing; evaluate against DreamID-V |
+| **ColorFLUX** (CVPR 2026) | No public HF weights confirmed | Watch first author's GitHub / HuggingFace for weight release |
+| **RoSE normal map** (Feb 2026) | No ComfyUI node; research paper only | ComfyUI wrapper |
+| **Hunyuan 3D 3.0** | ComfyUI partner node is cloud-API only; local weights status unclear | Tencent open-source release |
+| **Hunyuan 3D 2.5** | Released April 2025 (weights via Tencent GitHub); no dedicated ComfyUI custom node confirmed | pip install hunyuan3d or community wrapper |
+| **HappyHorse 1.0**, **Seedance 2.0**, **Vidu Q2** | API-only; no open weights | Monitor for open-source weight release |
+| **FLUX.2 Klein NVFP4/FP8** | Already in use; speed improvement only; no new architecture | Drop-in when RTX 50-series users report results |
+| **WaveSpeed LTX-2 19B upscaler** | API-only (announced June 12, 2026 — in window) | Open-weight release |
+| **EfficientSAM3.1 / SAM3.1-LiteText** | Supplementary to SAM 3.1 main upgrade; edge-focused | Integrate after SAM 3.1 main upgrade |
+
+---
+
+## No-finds (verified)
+
+The following categories were actively searched and returned no novel releases in the June 8–15, 2026 window:
+
+- **New ControlNet adapters** for SDXL or Flux — none released in window.
+- **SDXL2 / Stable Diffusion 4 successor** — not announced.
+- **BiRefNet v2** — no new background removal model in window; ComfyUI-RMBG v3.0.0 (Jan 2026) is latest wrapper update.
+- **FramePack** new checkpoint — no new release; repo remains active (F1 / P1 from 2025 still current).
+- **PuLID Flux successor** — no new identity-embedding model with open weights in window.
+- **CodeFormer successor** — NTIRE 2026 winning methods not yet publicly released.
+- **MAI-Image-2.5** (Microsoft) — announced June 2, 2026 but closed-API only (Azure AI Foundry); not locally usable.
+- **New DDColor / colorization model with weights** — ColorFLUX paper only.
+
+---
+
+## Research methodology
+
+- Four parallel sub-agents (general-purpose, image-gen / video / face / restore+3D families) ran concurrent searches via HuggingFace MCP (`hub_repo_search`, `paper_search`, `hub_repo_details`) and WebSearch (GitHub, Civitai, blog.comfy.org, wavespeed.ai, ai.meta.com, NVIDIA blog).
+- Main agent additionally ran direct HF and web searches cross-checking VRAM requirements and ComfyUI availability.
+- VRAM estimates from community benchmarks on RTX 5060 Ti 16 GB (Blackwell) where available; otherwise sourced from official model cards and NVIDIA guides.


### PR DESCRIPTION
## Spellcaster daily SOTA review — 2026-06-15 (ISO week 2026-W25)\n\nInaugural review — no prior baseline. Four parallel research agents (image-gen, video, face, restore/3D) ran concurrent HuggingFace MCP + WebSearch sweeps for the June 8–15, 2026 window.\n\n### Files added\n- `_dev_docs/upgrade_research/2026-W25.md` — full findings table, tier breakdown, methodology\n- `_dev_docs/upgrade_research/2026-W25.json` — 31 structured records\n\n---\n\n### Summary table\n\n| Tier | Count | Highlights |\n|---|---|---|\n| **Tier 1 — Drop-in supersessions** | **4** | Wan 2.7 (all 6 WAN builders), LTX-2.3, SAM 3.1, FlashVSR v1.1 |\n| **Tier 2 — Additive new builders** | **8** | i1 (June 9 🔴 in window), Ideogram 4.0, Microsoft Lens, DreamID-V, Depth Anything 3, RealRestorer, Sapiens2, Netflix VOID |\n| **Tier 3 — Monitor / not wire-ready** | **13** | Wan 3.0 (no weights), UniRelight, HiDream-O1, Nucleus-Image, BFS-Face-Swap LoRA, ColorFLUX, HappyHorse, Seedance 2.0, Vidu Q2, … |\n| **No-finds (verified)** | **8 categories** | ControlNet, BiRefNet v2, FramePack update, PuLID successor, CodeFormer successor, SDXL2, MAI-Image-2.5 (API-only), DDColor successor |\n\n---\n\n### Tier 1 detail (actionable on machine with node-pack installs)\n\n**1. Wan 2.7** → replaces all 6 WAN builders (`build_wan_video`, `build_wan22_t2v`, `build_wan_flf`, `build_wan_animate_video`, `build_wan_video_blockswap`, `build_wan_video_blockswap_t2v`)\n- Released April 2026, Apache 2.0. 16 GB viable via GGUF Q8 or Kijai NVfp4 (May 28). First/last-frame, 1080p/15s, audio, instruction editing built-in.\n- ComfyUI: `ComfyUI-WanVideoWrapper` (Kijai); partner-node templates in v0.18.5.\n\n**2. LTX-2.3** (Lightricks, 22B) → replaces `build_ltx_video`\n- Released March 5, 2026. 5.9M HF downloads. I2V+T2V+audio. 16 GB at FP8. Official node: `Lightricks/ComfyUI-LTXVideo`.\n\n**3. SAM 3.1** (Meta, March 27, 2026) → replaces SAM 3 checkpoint in `build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract`\n- Drop-in weight replacement. 7× faster multi-object (Object Multiplex, up to 16 objects/pass). Apache 2.0. ComfyUI nodes already updated.\n\n**4. FlashVSR v1.1** (CVPR 2026) → new `build_flashvsr_video_upscale` alongside `build_seedvr2_video_upscale`\n- Apache 2.0. 23.1K HF downloads. 3× faster than SeedVR2; one-step streaming diffusion VSR. Fits 16 GB with tiling. ComfyUI: `1038lab/ComfyUI-FlashVSR`.\n\n---\n\n### Items released strictly in the June 8–15 window\n\n- **i1** (Princeton, 3B fully-open T2I) — published **June 9, 2026**. [`zlab-princeton/i1-3B`](https://huggingface.co/zlab-princeton/i1-3B)\n- **BFS-Best-Face-Swap** LoRA (Flux2 Klein headswap) — created **June 8, 2026** on HuggingFace. [`chfm/BFS-Best-Face-Swap`](https://huggingface.co/chfm/BFS-Best-Face-Swap)\n- **WaveSpeed LTX-2 19B Video Upscaler** (API) — announced **June 12, 2026**.\n\n---\n\n### Hardware note (RTX 5060 Ti 16 GB)\n\nAll Tier 1 items confirmed viable at 16 GB with quantization (GGUF/FP8/NVfp4/tiling). Wan 3.0 and UniRelight require 24 GB+ at FP16 and are in Tier 3.\n\n---\n\n> ⚠️ **Do not merge** — leave open for human review and local node-pack installation.\n>\n> 🔔 The local nightly export at `tools/export_comfyui_workflows.py` (scheduled 03:30) will automatically refresh ComfyUI workflow snapshots once the node-pack installs are done locally — no manual trigger needed.\n\n---\n\nGenerated by the remote Spellcaster daily SOTA review agent (2026-W25)."

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtVozGYF45hdcPtYhxxMoJ)_