### PR TITLE
chore(research): daily SOTA review 2026-06-22

### DIFF
--- a/_dev_docs/upgrade_research/2026-W26.json
+++ b/_dev_docs/upgrade_research/2026-W26.json
@@ -1,0 +1,182 @@
+[
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Bernini-R",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/Bernini-R",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Tier 1. ByteDance WAN 2.2-T2V-A14B with in-context reference conditioning (IC-RoPE + APG). ComfyUI v0.25.0 native support June 16 2026. Enables T2V/I2V/V2V/R2V from one checkpoint — V2V and R2V are capabilities absent from current Spellcaster WAN builders. GGUF Q5/Q8 at neuregex/Bernini-R-GGUF fits 16 GB RTX 5060 Ti at 720p. fp8 needs 24 GB (not viable). New builder build_bernini_video needed. Node pack: ComfyUI-BerniniR (neuregex) or native v0.25.0 nodes."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "Bernini-R",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/Bernini-R",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Tier 1. Same as build_wan_video — Bernini-R unifies T2V+I2V+V2V+R2V on WAN 2.2 backbone. See build_wan_video entry."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "SCAIL-2",
+    "source": "github",
+    "url": "https://github.com/zai-org/SCAIL-2",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Tier 2. Skeleton-free character motion transfer — no pose maps required. WAN 2.1 14B backbone. ComfyUI v0.25.0 native June 16 2026. GGUF required on 16 GB (bf16 peaks 47 GB); community confirms Q5 viable on RTX. GGUF weights at realrebelai/SCAIL-2_GGUF. Different capability class from build_video_reactor (face swap). Suggested new builder: build_scail2_animate. Not a replacement for existing WAN builders."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Tier 2. Meta SAM 3.1 with shared-memory multi-object multiplexing. Released March 27 2026. Comfy-Org repackaged as sam3.1_multiplex_fp16.safetensors. Native ComfyUI core nodes: SAM3_Detect, SAM3_VideoTrack, SAM3_TrackToMask, SAM3_TrackPreview. Drop-in checkpoint upgrade. Still-image safe at 8-10 GB. Video tracking 18-25 GB — skip video tracking on 16 GB."
+  },
+  {
+    "method": "build_sam3_mask",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Tier 2. Drop-in checkpoint upgrade from SAM 3.0 to sam3.1_multiplex_fp16.safetensors. See build_sam3_segment entry."
+  },
+  {
+    "method": "build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/sam3.1",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Tier 2. Drop-in checkpoint upgrade from SAM 3.0 to sam3.1_multiplex_fp16.safetensors. See build_sam3_segment entry."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "node_pack",
+    "name": "BiRefNet native ComfyUI core (v0.21.0+)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/new-open-source-models-now-in-comfyui",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Tier 2. BiRefNet added to ComfyUI core in v0.21.0 (May 11 2026). Action: remove ComfyUI_BiRefNet_ll / viperyl/ComfyUI-BiRefNet custom node dependency and switch to native nodes. Supports BiRefNet-general, BiRefNet-lite, BiRefNet-HR, BiRefNet-Portrait. Apache 2.0 weights via Comfy-Org/BiRefNet. VRAM: 2-4 GB general; 6-8 GB HR. Not a new model — dependency simplification only."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "MoGe-2",
+    "source": "github",
+    "url": "https://github.com/zade23/ComfyUI-MoGe2",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Tier 2. Microsoft MoGe-2 yields metric-scale depth + normals + point cloud + FOV in a single forward pass. Consolidates build_depth_map_v3 + build_normal_map. 6-8 GB ViT-L. ComfyUI-MoGe2 node by zade23. HF model: Ruicheng/moge-2-vitl-normal. DA3 still preferable for video depth consistency across arbitrary viewpoints; MoGe-2 wins on per-image metric accuracy. ComfyUI v0.22.0 (May 20) added MoGe v1 native support."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "MoGe-2",
+    "source": "github",
+    "url": "https://github.com/zade23/ComfyUI-MoGe2",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Tier 2. MoGe-2 consolidates depth + normal estimation into a single pass. See build_depth_map_v3 entry."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Tier 2. First PuLID implementation for FLUX.2 / Klein 4B+9B+Dev. Auto model detection. InsightFace AntelopeV2 + EVA-CLIP. Improved face recognition, fewer artifacts. TeaCache/WaveSpeed compatible. Original PuLID-for-FLUX ComfyUI workflow formally discontinued on Civitai. VRAM: Klein 9B + overhead ~17-18 GB — weight streaming recommended. v0.6.2 exact date not pinned but actively maintained in 2026. Confidence 0.75 due to date ambiguity."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Ideogram 4.0",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/Ideogram-4",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Tier 2. Released June 3 2026 (outside window). 9.3B single-stream DiT. Day-0 ComfyUI support (Comfy-Org/Ideogram-4, 170 likes). fp8 ~13 GB; nf4 ~10 GB — both fit 16 GB. GGUF at leejet/ideogram-4-GGUF (19.5K downloads). Class-leading text rendering, bbox layout JSON prompts, native transparency. Turbo LoRA ostris/ideogram_4_turbotime_lora (June 17, in window) reduces to 2-4 steps. Non-commercial license — commercial use needs separate agreement. No inpainting/ControlNet ecosystem yet. Confidence 0.75 that it warrants integration vs established Flux."
+  },
+  {
+    "method": "build_colorize",
+    "category": "checkpoint",
+    "name": "ColorFLUX",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2603.28162",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Tier 3. CVPR 2026 paper (arXiv March 30 2026). FLUX-based old photo colorization with structure-color decoupling + Progressive Direct Preference Optimization (Pro-DPO). Outperforms DDColor, CtrlColor, DeOldify on DeQA, VisualQuality-R1, and aesthetics benchmarks. Weights NOT YET PUBLIC as of June 22 2026. FLUX-based inference ~12-16 GB quantized (borderline on 16 GB). Monitor post-CVPR 2026 for code + weights release."
+  },
+  {
+    "method": "build_ddcolor",
+    "category": "checkpoint",
+    "name": "ColorFLUX",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2603.28162",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Tier 3. Same as build_colorize — ColorFLUX is the candidate DDColor replacement. Weights not yet public. Monitor."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 3.0",
+    "source": "github",
+    "url": "https://docs.comfy.org/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Tier 3. Hunyuan3D 3.0 open-sourced Sep 2025; ComfyUI partner nodes February 2026. 1536^3 geometric resolution (3x over v2). Shape-only local: ~11.5 GB — fits 16 GB. Full textured local: ~24.5 GB — OVER BUDGET. ComfyUI partner node uses API-based inference. Hunyuan3D 3.1 API-only on Tencent global platform. Monitor for open-source 3.1 weights."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 3.0",
+    "source": "github",
+    "url": "https://docs.comfy.org/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0",
+    "risk": "high",
+    "confidence": 0.85,
+    "notes": "Tier 3. Full textured pipeline requires ~24.5 GB — OVER 16 GB budget for local inference. Shape-only (11.5 GB) is feasible. Textured output requires API-based partner node or cloud offload."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "checkpoint",
+    "name": "V-RMBG 3.0 (Bria)",
+    "source": "github",
+    "url": "https://www.prnewswire.com/news-releases/bria-launches-v-rmbg-3-0-state-of-the-art-video-background-removal-model-302796516.html",
+    "risk": "high",
+    "confidence": 0.85,
+    "notes": "Tier 3. June 10 2026 press release — VIDEO background removal only (temporal-aware architecture, previous-frame alpha mask carry-forward, 9x faster claimed). No still-image RMBG-3.0 announced. No public HuggingFace weights — commercial API / on-prem deployment only. No ComfyUI node confirmed. Do NOT conflate with still-image build_rembg_v3. Monitor Bria for a still-image RMBG-3.0 announcement."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Wan 2.7",
+    "source": "github",
+    "url": "https://comfyui.org/en/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Tier 3 — NOT new in June 15-22 window (released Mar/Apr 2026). ModelScope weights only; no Comfy-Org/Wan_2.7_ComfyUI_Repackaged on HuggingFace. Same 14B VRAM profile as WAN 2.2. ComfyUI partner nodes exist. Watch for HF repackage before committing pipeline work. Wan 3.0 (60B, 4K target, Apache 2.0) pre-announced but not yet released as of June 22 2026."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "HunyuanWorld-Mirror 2.0",
+    "source": "github",
+    "url": "https://github.com/Tencent-Hunyuan/HunyuanWorld-Mirror",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Tier 3. April 16 2026, ICML 2026 acceptance. Feed-forward 3D reconstruction (not generation) — image to point cloud + depth + normals + 3D Gaussians in one pass. Augments not replaces build_hunyuan_3d_mesh. ComfyUI node by cedarconnor. VRAM unconfirmed (~8-12 GB estimated). Watch VRAM confirmation before wiring."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W26.md
+++ b/_dev_docs/upgrade_research/2026-W26.md
@@ -1,0 +1,228 @@
+# Spellcaster daily SOTA review — 2026-06-22
+
+ISO week: `2026-W26`. Baseline: none (first run — no prior punch list in `_dev_docs/upgrade_research/`).
+
+Survey window: **2026-06-15 to 2026-06-22**. Hardware budget: RTX 5060 Ti, 16 GB VRAM.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / augmentation | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| build_wan_video | WAN 2.2 14B | Partial | Bernini-R (WAN 2.2 IC reference) | https://github.com/neuregex/ComfyUI-BerniniR | Low | **Tier 1** — new R2V/V2V mode; ComfyUI v0.25.0 native Jun 16 |
+| build_wan22_t2v | WAN 2.2 14B T2V | Partial | Bernini-R | https://github.com/neuregex/ComfyUI-BerniniR | Low | **Tier 1** — same checkpoint, unified T2V+I2V+V2V+R2V |
+| build_wan_animate_video | WAN 2.1 14B | Partial | SCAIL-2 (skeleton-free motion transfer) | https://github.com/zai-org/SCAIL-2 | Medium | **Tier 2** — new capability class; native v0.25.0 Jun 16 |
+| build_sam3_segment | SAM 3.0 | No | SAM 3.1 (Comfy-Org sam3.1_multiplex) | https://huggingface.co/Comfy-Org/sam3.1 | Low | **Tier 2** — drop-in checkpoint upgrade; Mar 27 release |
+| build_sam3_mask | SAM 3.0 | No | SAM 3.1 | https://huggingface.co/Comfy-Org/sam3.1 | Low | **Tier 2** — same as above |
+| build_sam3_extract | SAM 3.0 | No | SAM 3.1 | https://huggingface.co/Comfy-Org/sam3.1 | Low | **Tier 2** — same as above |
+| build_rembg_birefnet | BiRefNet (custom node) | Partial | BiRefNet native core (ComfyUI v0.21.0+) | https://blog.comfy.org/p/new-open-source-models-now-in-comfyui | Low | **Tier 2** — no new model, but removes 3rd-party node dependency |
+| build_depth_map_v3 | Depth Anything 3 | Partial | MoGe-2 (depth + normals unified) | https://github.com/zade23/ComfyUI-MoGe2 | Low | **Tier 2** — metric depth + normals in one pass; 6–8 GB |
+| build_normal_map | Standalone normal estimator | Partial | MoGe-2 | https://github.com/zade23/ComfyUI-MoGe2 | Low | **Tier 2** — consolidates with build_depth_map_v3 |
+| build_pulid_flux | PuLID for Flux 1 | Partial | ComfyUI-PuLID-Flux2 v0.6.2 (Klein support) | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Low | **Tier 2** — FLUX.2/Klein auto-detect; original workflow discontinued |
+| build_txt2img | Flux / SDXL | Partial | Ideogram 4.0 (new backbone candidate) | https://huggingface.co/Comfy-Org/Ideogram-4 | Medium | **Tier 2** — 9.3B DiT; fp8 ~13 GB; non-commercial license |
+| build_colorize | DDColor | Partial | ColorFLUX (CVPR 2026) | https://arxiv.org/abs/2603.28162 | Medium | **Tier 3** — weights not yet public; monitor post-CVPR |
+| build_ddcolor | DDColor | Partial | ColorFLUX | https://arxiv.org/abs/2603.28162 | Medium | **Tier 3** — same; DDColor outperformed on all benchmarks |
+| build_hunyuan_3d_mesh | HunyuanDiT 3D v2 | Partial | Hunyuan3D 3.0 (shape-only on 16 GB) | https://docs.comfy.org/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0 | Medium | **Tier 3** — shape ~11.5 GB OK; textured ~24.5 GB over budget |
+| build_hunyuan_3d_textured | HunyuanDiT 3D v2 | Partial | Hunyuan3D 3.0 | https://docs.comfy.org/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0 | High | **Tier 3** — textured pipeline OVER 16 GB budget |
+| build_rembg_v3 | RMBG-2.0 | Yes | V-RMBG 3.0 is video-only / commercial | https://www.prnewswire.com/news-releases/bria-launches-v-rmbg-3-0-state-of-the-art-video-background-removal-model-302796516.html | High | **Tier 3** — not a still-image upgrade; no ComfyUI node |
+| build_img2img | SDXL / Flux | Yes | — | — | — | Verified stable |
+| build_inpaint | SDXL / Fooocus | Yes | — | — | — | Verified stable |
+| build_inpaint_fooocus | Fooocus SDXL | Yes | — | — | — | Verified stable |
+| build_outpaint | SDXL | Yes | — | — | — | Verified stable |
+| build_controlnet_gen | ControlNet preprocessors | Yes | — | — | — | No new model in window |
+| build_generate_anything | Flux | Yes | — | — | — | Verified stable |
+| build_style_transfer | SDXL / Flux | Yes | — | — | — | No new model in window |
+| build_klein_* (all 16) | Klein 4B/9B + Qwen-3 CLIP | Yes | — | — | — | No new BFL/Klein weights in window |
+| build_lumina2_txt2img | Lumina 2 | Yes | — | — | — | No update found |
+| build_qwen_edit | Qwen-Image-Edit-2511 | Yes | — | — | — | No update found |
+| build_iclight | IC-Light | Yes | — | — | — | IC-Light V2 predates window |
+| build_ltx_video | LTX Video 2.3 | Yes | — | — | — | LTX Unified Trainer (Jun 17) is training tooling only |
+| build_hunyuan_video | HunyuanVideo 1.5 8.3B | Yes | — | — | — | No new release; CFG-1 speedup via ComfyUI v0.25.0 |
+| build_framepack_video | FramePack-F1 | Yes | — | — | — | No new release found |
+| build_mochi_video | Mochi | Yes | — | — | — | No update found |
+| build_cogvideo_video | CogVideoX | Yes | — | — | — | No update found |
+| build_wan_video_blockswap | WAN 2.2 blockswap | Yes | — | — | — | No new WAN weights in window |
+| build_wan_video_blockswap_t2v | WAN 2.2 blockswap T2V | Yes | — | — | — | No update |
+| build_wan_flf | WAN first-last-frame | Yes | — | — | — | No update |
+| build_seedvr2_video_upscale | SeedVR2 3B fp8 | Yes | — | — | — | No new weights in window |
+| build_seedv2r | SeedVR temporal consistency | Yes | — | — | — | No update |
+| build_video_upscale | 4x-UltraSharp | Yes | — | — | — | No new upscaler model |
+| build_video_reactor | ReActor on video | Yes | — | — | — | No update |
+| build_wavespeed_upscale | SeedVR2 / WaveSpeed | Yes | — | — | — | No new weights |
+| build_upscale | Upscale models | Yes | — | — | — | No update |
+| build_upscale_blend | Dual upscaler blend | Yes | — | — | — | No update |
+| build_faceswap | ReActor inswapper_128 | Yes | — | — | — | ReActor last updated May 12 (outside window) |
+| build_faceswap_model | ReActor | Yes | — | — | — | No update |
+| build_faceswap_mtb | MTB face swap | Yes | — | — | — | No update found |
+| build_face_restore | CodeFormer | Yes | — | — | — | CodeFormer++ (Oct 2025) has no ComfyUI node yet |
+| build_photo_restore | Upscale + CodeFormer | Yes | — | — | — | Verified stable |
+| build_detail_hallucinate | Upscale + detail SR | Yes | — | — | — | No update |
+| build_photobooth | Iterative Klein | Yes | — | — | — | No update |
+| build_faceid_img2img | IP-Adapter FaceID | Yes | — | — | — | No June 2026 update found |
+| build_save_face_model | ReActor face model | Yes | — | — | — | No update |
+| build_supir | SUPIR + SDXL | Yes | — | — | — | No new SUPIR release found |
+| build_color_match | Color match | Yes | — | — | — | No update |
+| build_klein_color_match | Klein color match | Yes | — | — | — | No update |
+| build_lut | LUT color grading | Yes | — | — | — | No update |
+| build_rembg | Basic rembg | Yes | — | — | — | Verified stable |
+| build_layer_blend | LaMa / blend | Yes | — | — | — | No update |
+| build_magic_eraser | SAM3 + LaMa | Yes | — | — | — | Will benefit from SAM 3.1 upgrade |
+| build_lama_remove | LaMa | Yes | — | — | — | No new LaMa release |
+| build_frame_assembly | VHS VideoCombine | Yes | — | — | — | ComfyUI v0.25.0 10-bit video I/O improvement |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+### 1. Bernini-R — Reference-conditioned WAN 2.2 video (ByteDance)
+
+**Replaces / augments:** `build_wan_video`, `build_wan22_t2v`
+
+ComfyUI v0.25.0 shipped June 16, 2026 with native support for Bernini-R. ByteDance's model sits on top of the WAN 2.2-T2V-A14B backbone and adds in-context reference (IC) conditioning via source-id RoPE + APG. A single checkpoint handles T2V, I2V, V2V (video editing), and R2V (reference-to-video) — capabilities none of the current WAN builders expose.
+
+- **New builder needed:** `build_bernini_video`
+- **Weights:** `Comfy-Org/Bernini-R` on HuggingFace; GGUF at `neuregex/Bernini-R-GGUF`
+- **Node pack:** `ComfyUI-BerniniR` (neuregex) or ComfyUI v0.25.0+ native nodes
+- **VRAM:** Q5/Q8 GGUF fits 16 GB RTX 5060 Ti at 720p. fp8 needs 24 GB — not viable locally without GGUF.
+- **Risk:** Low — identical weight structure to WAN 2.2; Comfy-Org repackaged; ComfyUI core support
+
+---
+
+## Tier 2 — Additive new builders / upgrades (needs install or checkpoint swap)
+
+### 2. SCAIL-2 — Skeleton-free character motion transfer (zai-org)
+
+**Augments:** `build_wan_animate_video`; does **not** replace `build_video_reactor`
+
+Released June 13, native ComfyUI v0.25.0 support June 16. Transfers motion from a driving video to a reference character without skeleton/pose maps. Covers cross-identity character replacement and animal-driving scenarios.
+
+- **New builder:** `build_scail2_animate` (distinct from face-swap family)
+- **Weights:** `realrebelai/SCAIL-2_GGUF` on HuggingFace; WAN 2.1 14B backbone
+- **VRAM:** GGUF Q-series required on 16 GB (bf16 peaks 47 GB on Apple Silicon; community confirms Q5 viable on RTX)
+- **Risk:** Medium — new model family; no ComfyUI-Org first-party repackage yet
+
+### 3. SAM 3.1 — Segment Anything Model 3.1 (Meta / Comfy-Org)
+
+**Replaces:** SAM 3.0 checkpoint in `build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract`
+
+Released March 27. Comfy-Org repackaged as `sam3.1_multiplex_fp16.safetensors`. Adds shared-memory multi-object multiplexing for faster joint tracking without accuracy loss. Native core nodes: `SAM3_Detect`, `SAM3_VideoTrack`, `SAM3_TrackToMask`, `SAM3_TrackPreview`.
+
+- **Action:** Update checkpoint path from SAM 3.0 → `sam3.1_multiplex_fp16.safetensors`
+- **VRAM:** 8–10 GB still image (safe on 16 GB). 18–25 GB for multi-object video tracking — **skip video tracking on 16 GB**.
+- **Risk:** Low
+
+### 4. BiRefNet native ComfyUI core (v0.21.0+)
+
+**Simplifies:** `build_rembg_birefnet`
+
+ComfyUI v0.21.0 (May 11) added BiRefNet as a first-class core model. Remove the third-party `ComfyUI_BiRefNet_ll` / `viperyl/ComfyUI-BiRefNet` custom node dependency and use native nodes. Supports BiRefNet-general, BiRefNet-lite, BiRefNet-HR, BiRefNet-Portrait. Apache 2.0 weights via Comfy-Org.
+
+- **Action:** Switch `build_rembg_birefnet` to ComfyUI native BiRefNet nodes
+- **VRAM:** 2–4 GB (general); 6–8 GB (HR)
+- **Risk:** Low
+
+### 5. MoGe-2 — Microsoft monocular geometry (unified depth + normals)
+
+**Consolidates:** `build_depth_map_v3` + `build_normal_map`
+
+ComfyUI-MoGe2 node (zade23) available since early 2026; ComfyUI v0.22.0 (May 20) added MoGe v1 native support. MoGe-2 yields metric-scale depth map, normal map, point cloud, and camera FOV in a single forward pass. Outperforms Depth Anything 3 on per-image metric accuracy. DA3 still preferable for video depth consistency across arbitrary viewpoints.
+
+- **Node:** https://github.com/zade23/ComfyUI-MoGe2 ; HF model: `Ruicheng/moge-2-vitl-normal`
+- **VRAM:** 6–8 GB ViT-L backbone
+- **Risk:** Low
+
+### 6. ComfyUI-PuLID-Flux2 v0.6.2 (iFayens)
+
+**Replaces:** Any FLUX.1-era PuLID node powering `build_pulid_flux`
+
+The original PuLID-for-FLUX ComfyUI workflow on Civitai was formally discontinued. `ComfyUI-PuLID-Flux2` is the active 2026 continuation, adding FLUX.2 Klein 4B/9B and Dev 32B support, auto model detection, InsightFace AntelopeV2 + EVA-CLIP, improved face recognition, TeaCache/WaveSpeed compatibility.
+
+- **VRAM:** Klein 9B + PuLID overhead ~17–18 GB — tight; weight streaming recommended
+- **Risk:** Low
+
+### 7. Ideogram 4.0 — New txt2img backbone candidate (ideogram-ai)
+
+**Augments:** `build_txt2img` if adopted as a backbone
+
+Released June 3 (just outside window). 9.3B single-stream DiT with day-0 ComfyUI support (`Comfy-Org/Ideogram-4`). Class-leading text rendering, structured JSON bounding-box layout control, native transparency. Turbo LoRA `ostris/ideogram_4_turbotime_lora` (June 17 — in window) reduces inference to 2–4 steps.
+
+- **New builder if adopted:** `build_ideogram4_txt2img`
+- **VRAM:** fp8 ~13 GB; nf4 ~10 GB — both fit 16 GB. GGUF at `leejet/ideogram-4-GGUF`.
+- **Risk:** Medium — non-commercial license (verify for production); no inpainting/ControlNet ecosystem yet
+- **License note:** Non-commercial for weights; commercial use needs separate agreement with Ideogram AI
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Reason not ready | Watch for |
+|---|---|---|
+| **Wan 2.7** (Alibaba, 14B) | Not new in window (Mar/Apr 2026); no Comfy-Org HuggingFace repackage | `Comfy-Org/Wan_2.7_ComfyUI_Repackaged` on HuggingFace |
+| **Wan 3.0** (Alibaba, 60B) | Weights not released; 60B needs 24 GB+ locally | `github.com/Wan-Video` for new repo; 14B variant when available |
+| **ColorFLUX** (CVPR 2026) | Weights not yet public; FLUX-based, needs quant for 16 GB | Post-CVPR code + weights release |
+| **Netflix VOID** | 40 GB+ VRAM — over budget; CogVideoX-based | Cloud offload support or GGUF variant |
+| **Hunyuan3D 3.1** | API-only on Tencent global platform; 3.0 textured pipeline 24.5 GB | Open-source 3.1 weights; use shape-only (11.5 GB) from 3.0 |
+| **HunyuanWorld-Mirror 2.0** | 3D reconstruction (not generation); VRAM unconfirmed | ComfyUI node maturation; VRAM spec |
+| **V-RMBG 3.0** (Bria) | Video-only, commercial API, no ComfyUI node | Bria still-image RMBG-3.0 announcement |
+| **BitPoet/Ideogram4-Inpaint-LoRA** | WIP (step 4000 of training); small dataset | Author training completion |
+| **ostris/ideogram_4_turbotime_lora** | Depends on Ideogram 4 backbone being added first | Backbone decision |
+| **MakeupMirror** (arXiv 2606.20094, Jun 18) | Academic paper; no ComfyUI node | Code/weights release |
+| **ComfyUI-Flux2Klein-Enhancer** | Consistency tool for Klein; stability unconfirmed | Community adoption signal |
+| **CodeFormer++** (arXiv Oct 2025) | No ComfyUI node; academic only | Community node implementation |
+| **Grok Imagine Video 1.5** (xAI) | Closed API, not open weights | N/A — proprietary |
+
+---
+
+## No-finds (verified)
+
+The following were explicitly researched and confirmed to have **no new release in the June 15–22, 2026 window**:
+
+- `build_img2img` — SDXL/Flux backbone unchanged
+- `build_inpaint` / `build_inpaint_fooocus` / `build_outpaint` — Fooocus/SDXL unchanged
+- `build_controlnet_gen` — No new ControlNet model or preprocessor in window
+- `build_generate_anything` — Flux backbone unchanged
+- `build_style_transfer` — No new style reference model
+- `build_klein_*` (all 16 methods) — No new BFL/Klein checkpoint released
+- `build_lumina2_txt2img` — No Lumina 2 update (last major update Feb 2025)
+- `build_qwen_edit` — Qwen-Image-Edit-2511 (Dec 2025) is latest; no June 2026 update
+- `build_iclight` — IC-Light V2 predates window; no new release
+- `build_ltx_video` — LTX-2.3 inference unchanged; LTX Unified Trainer (Jun 17) is training tooling only
+- `build_hunyuan_video` — HunyuanVideo 1.5 (8.3B) unchanged; passive CFG-1 speedup via ComfyUI v0.25.0
+- `build_framepack_video` — No FramePack-F1 successor confirmed
+- `build_mochi_video` — No update
+- `build_cogvideo_video` — No update
+- `build_wan_video_blockswap` / `build_wan_video_blockswap_t2v` / `build_wan_flf` — No WAN weights in window
+- `build_seedvr2_video_upscale` / `build_seedv2r` — No new SeedVR2 weights (last: FlashVSR+ Feb 2026)
+- `build_video_upscale` / `build_upscale` / `build_upscale_blend` / `build_wavespeed_upscale` — No new upscaler models
+- `build_faceswap` / `build_faceswap_model` / `build_faceswap_mtb` — ReActor last updated May 12 (outside window)
+- `build_face_restore` — CodeFormer v1.4 / GFPGAN v1.4 unchanged in window
+- `build_photo_restore` / `build_detail_hallucinate` / `build_photobooth` — No update
+- `build_faceid_img2img` — IP-Adapter FaceID unchanged in window
+- `build_save_face_model` — No update
+- `build_supir` — No new SUPIR release
+- `build_color_match` / `build_klein_color_match` — No update
+- `build_lut` — No update
+- `build_rembg` — No update
+- `build_layer_blend` / `build_magic_eraser` / `build_lama_remove` — No new LaMa or inpainting backbone
+- `build_frame_assembly` — Stable; ComfyUI v0.25.0 adds 10-bit video I/O
+- `build_video_reactor` — No ReActor update in window
+- `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured` — No new open-weight release (3.0 predates window)
+
+---
+
+## Platform note: ComfyUI v0.25.0 / v0.25.1 (June 16–18, 2026)
+
+Both Bernini-R and SCAIL-2 landed natively in ComfyUI v0.25.0 (June 16). Additional improvements relevant to Spellcaster:
+
+- Native 10-bit video I/O — benefits `build_frame_assembly` and `build_video_upscale`
+- `--high-ram` dynamic VRAM management — benefits all blockswap workflows
+- CFG-1 DualModelGuider optimisation — passive speedup for `build_hunyuan_video`
+- Depth Anything 3 native support (v0.25.0)
+- Kling V3-Turbo partner node (v0.25.1)
+
+**Recommend updating ComfyUI to ≥ v0.25.1 before implementing any Tier 1/2 items.**
+
+---
+
+*Generated by the Spellcaster daily SOTA review agent. Implementation requires local node-pack installs on the ComfyUI host machine — see `tools/export_comfyui_workflows.py` for the nightly workflow snapshot exporter.*


### PR DESCRIPTION
## Summary

Daily SOTA survey for the 75 `build_*` methods in `workflows.py`. ISO week **2026-W26** (June 15–22 window). First run — no prior punch list baseline.

| Tier | Count | Items |
|---|---|---|
| **Tier 1** — drop-in supersessions | 1 | Bernini-R (WAN 2.2 IC reference model) |
| **Tier 2** — additive builders / upgrades | 6 | SCAIL-2, SAM 3.1, BiRefNet native core, MoGe-2, PuLID-Flux2 v0.6.2, Ideogram 4.0 |
| **Tier 3** — monitor / not wire-ready | 8 | Wan 2.7, ColorFLUX, Netflix VOID, Hunyuan3D 3.1, V-RMBG 3.0, HunyuanWorld-Mirror 2.0, Wan 3.0, BitPoet Ideogram inpaint LoRA |
| **No-finds** (verified stable) | 43+ methods | All Klein/Flux, LTX, HunyuanVideo, FramePack, SeedVR2, ReActor, CodeFormer, SUPIR, DDColor, RMBG-2.0, etc. |

## Top findings

### 🔴 Tier 1 — Bernini-R (ship soon)
ByteDance's in-context reference conditioning model on WAN 2.2-T2V-A14B. ComfyUI v0.25.0 landed native support on **June 16, 2026**. Adds T2V+I2V+**V2V+R2V** from one checkpoint — V2V and reference-to-video modes have no current Spellcaster equivalent. GGUF Q5/Q8 (`neuregex/Bernini-R-GGUF`) fits 16 GB RTX 5060 Ti at 720p.
→ New builder needed: `build_bernini_video`

### 🟡 Tier 2 highlights
- **SCAIL-2** — skeleton-free motion transfer, ComfyUI v0.25.0 native. New capability class (no pose maps); GGUF required on 16 GB. Suggested: `build_scail2_animate`.
- **SAM 3.1** — drop-in checkpoint swap (`Comfy-Org/sam3.1` → `sam3.1_multiplex_fp16.safetensors`). Multi-object multiplexing. Safe at 8–10 GB for still images.
- **BiRefNet native core** — ComfyUI v0.21.0 adds first-class support; removes custom node dependency in `build_rembg_birefnet`.
- **MoGe-2** — consolidates `build_depth_map_v3` + `build_normal_map` into one pass. 6–8 GB ViT-L.
- **ComfyUI-PuLID-Flux2 v0.6.2** — first PuLID for FLUX.2/Klein; original workflow discontinued.
- **Ideogram 4.0** — new 9.3B backbone candidate (fp8 ~13 GB); non-commercial license, verify before production.

### ⚪ Platform: ComfyUI v0.25.0/0.25.1 (June 16–18)
Update ComfyUI before implementing any Tier 1/2 items. Brings: 10-bit video I/O, `--high-ram` VRAM flag, CFG-1 DualModelGuider speedup (HunyuanVideo), and native Depth Anything 3 + Bernini-R + SCAIL-2 nodes.

## Files
- `_dev_docs/upgrade_research/2026-W26.md` — full findings table + tier writeups
- `_dev_docs/upgrade_research/2026-W26.json` — 17 structured records (one per method × candidate)

## Do not merge
Leave open for human review. Implementation requires local node-pack installs on the ComfyUI host machine.

> **Note:** The local `03:30` nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically after any local changes are applied.

🤖 Generated by the Spellcaster daily SOTA review agent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YXx68gRqrqm8yv2WQSYxmA)_