### PR TITLE
chore(research): daily SOTA review 2026-06-24

### DIFF
--- a/_dev_docs/upgrade_research/2026-W26.json
+++ b/_dev_docs/upgrade_research/2026-W26.json
@@ -1,0 +1,232 @@
+[
+  {
+    "method": "build_inpaint",
+    "category": "checkpoint",
+    "name": "Moebius",
+    "source": "huggingface",
+    "url": "https://huggingface.co/hustvl/Moebius",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Released Jun 18, 2026 (in-window). 226M params, Apache 2.0, ~1.27 GB weights. Beats FLUX.1-Fill-Dev and SD3.5 Large-Inpainting on Places2/CelebA-HQ/FFHQ. 26 ms/step, >15x faster than 10B models. ~4-6 GB VRAM. ECCV 2026, HUST+VIVO. WebGPU-portable. Tier 1 drop-in for build_inpaint."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Object Multiplex)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Released Mar 27, 2026. Drop-in weights for SAM 3 (859.9M params, same architecture + Object Multiplex shared-memory bank). 2x FPS (16->32), ~50% VRAM cut (8GB->4GB FP16), up to 7x speedup at 128 objects. ComfyUI native in v0.20.1 (Apr 2026). Gated HF model. Tier 1 for build_sam3_segment, build_sam3_mask, build_sam3_extract."
+  },
+  {
+    "method": "build_sam3_mask",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Object Multiplex)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Same as build_sam3_segment entry."
+  },
+  {
+    "method": "build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Object Multiplex)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Same as build_sam3_segment entry."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Krea-2 (Raw + Turbo)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/krea/Krea-2-Raw",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Released Jun 22, 2026 (in-window). New 12B DiT; Krea-2-Raw and Krea-2-Turbo variants. Krea 2 Community License (review non-commercial clauses). 9+ official style LoRAs shipped Jun 19-24. Native ComfyUI v0.26.0 support. VRAM est. 16-24GB FP16 (no official spec). Tier 2 additive builder."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "WAN 2.7",
+    "source": "github",
+    "url": "https://github.com/Wan-Video/Wan2.7",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Released Apr 2026 (pre-window carry-over). Apache 2.0. New vs WAN 2.2: 5-image multi-reference, vocal timbre reference, FLF control, video continuation, audio-sync T2V, 1080p x 15s. VRAM 16GB+ with GGUF quantization. Weights on ModelScope only (not HuggingFace as of Jun 2026). Supersedes build_wan_video and build_wan22_t2v. ComfyUI partner nodes available via blog.comfy.org."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "WAN 2.7",
+    "source": "github",
+    "url": "https://github.com/Wan-Video/Wan2.7",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Same as build_wan_video entry. WAN 2.7 supersedes both WAN 2.1 and 2.2 T2V paths."
+  },
+  {
+    "method": "build_wan_flf",
+    "category": "checkpoint",
+    "name": "WAN 2.7 (native FLF)",
+    "source": "github",
+    "url": "https://github.com/Wan-Video/Wan2.7",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "WAN 2.7 integrates first-last-frame control natively. Pre-window (Apr 2026). Additive upgrade to build_wan_flf."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3",
+    "source": "github",
+    "url": "https://github.com/Lightricks/LTX-Video",
+    "risk": "medium",
+    "confidence": 0.87,
+    "notes": "Released Mar 5, 2026 (pre-window). 22B params. Native 4K@50fps, stereo audio. FP8/MXFP8 quantized variants fit 16GB VRAM. DENO ComfyUI nodes v0.7.62 (released Jun 24 -- in-window) add: LTX Model Loader, Sequencer, Multi LoRA Loader, Prompt Guide, Tiled Spatial Upscaler (beta). Tier 2 upgrade."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "comfyui-deno-custom-nodes v0.7.62 (RTX Video Super Resolution)",
+    "source": "github",
+    "url": "https://github.com/Deno2026/comfyui-deno-custom-nodes",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Released Jun 24, 2026 (in-window). RTX Video Super Resolution via NVIDIA Tensor Core hardware; single-pass and 2-pass modes; upscales to 4K ~30x faster than software upscalers. RTX 5060 Ti fully eligible. Also includes LTX 2.3 nodes and Wan2.2 reference video editing. Low risk."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "TripoSplat",
+    "source": "huggingface",
+    "url": "https://huggingface.co/VAST-AI/TripoSplat",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Integrated in ComfyUI v0.25.0 on Jun 16, 2026 (one day pre-window). VAST-AI. DINOv3 ViT-H/16+ encoder + Flux2 VAE, flow-matching denoiser, Octree Gaussian VAE decoder. Single image -> 3D Gaussian Splat output (PLY/SPLAT/SPZ/KSPLAT). ~8GB VRAM. Native ComfyUI -- no extra node pack. Additive Gaussian Splat path alongside HunyuanDiT mesh."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "SCAIL-2",
+    "source": "huggingface",
+    "url": "https://huggingface.co/zai-org/SCAIL-2",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Integrated in ComfyUI v0.25.0 on Jun 16, 2026. ByteDance / zai-org. End-to-end reference-image-driven character animation; supports character replacement and multi-character scenarios without intermediate pose. GGUF quantized available. ~16GB VRAM with quant. ComfyUI node: ComfyUI-WanAnimatePlus (github.com/wuwukaka/ComfyUI-WanAnimatePlus). Tier 2 additive."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "node_pack",
+    "name": "DA3 native in ComfyUI v0.25.0",
+    "source": "github",
+    "url": "https://github.com/bytedance-seed/depth-anything-3",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Integrated in ComfyUI v0.25.0 (Jun 16, 2026). Same DA3 model weights; adds multi-view depth estimation mode. DA3-Streaming mode <12GB VRAM. Native path removes custom-node dependency. ICLR 2026. Tier 2 infra upgrade."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "node_pack",
+    "name": "ComfyUI-Flux-FaceIR",
+    "source": "github",
+    "url": "https://github.com/cosmicrealm/ComfyUI-Flux-FaceIR",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Released Apr 7, 2026 (pre-window carry-over). Flux.2-klein-4B LoRA for blind face restoration and reference-guided restoration. Complements CodeFormer. Klein-4B base ~8-12GB VRAM. Tier 2 additive."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 1c in ComfyUI-ReActor v0.6.2",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "ReActor v0.6.2 (Apr 25, 2025) added HyperSwap 1c support (hyperswap_1c_256.onnx). Drop-in model download to existing ReActor install. Also added GPEN 1024/2048 and ReActorFaceBoost node. Not a June 2026 release but important carry-over. Tier 1-equivalent for faceswap quality improvement."
+  },
+  {
+    "method": "build_inpaint",
+    "category": "node_pack",
+    "name": "civitai-comfy-nodes v0.2.0",
+    "source": "github",
+    "url": "https://github.com/civitai/civitai-comfy-nodes",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Released Jun 17, 2026 (in-window). ~160 nodes across 8 categories exposing Civitai cloud Orchestration API: image/video/audio generation, upscaling, training, captioning, moderation. Zero local VRAM (cloud compute). Enables cloud-fallback for heavy models. Tier 2 additive general capability."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Z-Image Turbo (S3-DiT)",
+    "source": "civitai",
+    "url": "https://civitai.com/models/2168935/z-image-turbo",
+    "risk": "medium",
+    "confidence": 0.62,
+    "notes": "Alibaba Tongyi. 6B params, S3-DiT (Scalable Single-Stream DiT), Apache 2.0. ~8GB VRAM at FP8. Active on CivitAI. No confirmed ComfyUI node pack as of Jun 2026 -- community integrations likely imminent. Tier 3 monitor."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "checkpoint",
+    "name": "FLUX.1-Kontext-dev + Shakker-Labs style LoRAs",
+    "source": "huggingface",
+    "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
+    "risk": "high",
+    "confidence": 0.65,
+    "notes": "Kontext released May 2025 (not new); 5 new Shakker-Labs style LoRAs released Jun 2026 (sketch, pixel, bioluminescence, illustration, flat cartoon). Full Kontext model ~24GB; NVFP4 variant reduces VRAM. 135K downloads, 2674 likes. Relevant for style transfer but needs VRAM testing on 16GB. Tier 3."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "node_pack",
+    "name": "FlashVSR (CVPR 2026)",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-FlashVSR",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "CVPR 2026. Real-time 17fps diffusion VSR at 768x1408 on A100. 2x and 4x upscaling. VRAM-optimized community variant (naxci1/ComfyUI-FlashVSR_Stable) targets 8-24GB. Multiple ComfyUI node packs available. Not a June 17-24 release. Tier 3 monitor."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "checkpoint",
+    "name": "Fibo-Edit-RMBG",
+    "source": "huggingface",
+    "url": "https://huggingface.co/briaai/Fibo-Edit-RMBG",
+    "risk": "high",
+    "confidence": 0.58,
+    "notes": "Released Feb 8, 2026. BRIA AI. 8B DiT-based alpha matting (Fibo-Edit pipeline); produces fine-edge alpha mattes (hair strands, netting, wire, semi-transparent). Better than RMBG-2.0 on complex edges. Gated HF. Estimated 16GB+ VRAM (8B base). No ComfyUI node confirmed. Tier 3 monitor."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "node_pack",
+    "name": "Hunyuan3D 3.0 ComfyUI Partner Nodes",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/hunyuan-3d-30-in-comfyui-state-of",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "Available as ComfyUI Partner Nodes since Feb 13, 2026. 3D-DiT architecture; hierarchical sculpting; up to 1536^3 resolution; built-in auto-rigging. Supersedes HunyuanDiT 3D 2.x for mesh quality. Full textured pipeline VRAM likely >=16GB (2.x required 29GB); shape-only mode may fit 16GB -- needs testing. Tier 3 (VRAM uncertain)."
+  },
+  {
+    "method": "build_colorize",
+    "category": "lora",
+    "name": "LTX-2.3-22b-IC-LoRA-Colorization",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Colorization",
+    "risk": "high",
+    "confidence": 0.55,
+    "notes": "Released Jun 17, 2026 (in-window). IC-LoRA (rank 128) on 22B LTX-2.3 base for video colorization. Restores natural color to grayscale/monochrome video. VRAM 24-80GB -- well exceeds 16GB budget. Monitor for quantized variants. Tier 3."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Krea-2 LoRAs (9 official + community)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/krea/Krea-2-LoRA-retroanime",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Batch of 9+ official Krea-2 style LoRAs released Jun 19-24, 2026 (in-window): retroanime, softwatercolor, neondrip, rainywindow, dotmatrix, darkbrush, kidsdrawing, sunsetblur, vintagetarot. Community additions: isometric-3D (linoyts), yarn-art (linoyts). Additive value once Krea-2 base model is wired up. Low risk as style-only LoRAs."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W26.md
+++ b/_dev_docs/upgrade_research/2026-W26.md
@@ -1,0 +1,212 @@
+# Spellcaster daily SOTA review — 2026-06-24
+
+ISO week: `2026-W26`. Baseline: none (inaugural run — no prior `_dev_docs/upgrade_research/` files exist).
+
+> **Hardware budget**: RTX 5060 Ti · 16 GB VRAM. Items requiring more are flagged High risk or excluded.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / Addition | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| build_inpaint | FLUX.1-Fill-Dev / SDXL | ❌ No | **Moebius** (226 M, ECCV 2026, Jun 18) | https://github.com/hustvl/Moebius | low | Apache 2.0; 26 ms/step; beats FLUX.1-Fill-Dev + SD 3.5 Large-Inpainting on 6 benchmarks; ~4–6 GB VRAM; >15× faster than 10 B models |
+| build_sam3_segment | SAM 3 (Nov 2025) | ⚠️ Upgradeable | **SAM 3.1** (Mar 27, 2026) | https://huggingface.co/facebook/sam3.1 | low | Drop-in weights; Object Multiplex; 2× FPS (32 fps), 50 % VRAM cut → 4 GB FP16; gated HF repo |
+| build_sam3_mask | SAM 3 (Nov 2025) | ⚠️ Upgradeable | **SAM 3.1** (Mar 27, 2026) | https://huggingface.co/facebook/sam3.1 | low | Same as above |
+| build_sam3_extract | SAM 3 (Nov 2025) | ⚠️ Upgradeable | **SAM 3.1** (Mar 27, 2026) | https://huggingface.co/facebook/sam3.1 | low | Same as above |
+| build_magic_eraser | SAM 3 + LaMa | ⚠️ Upgradeable | SAM 3.1 upstream | https://huggingface.co/facebook/sam3.1 | low | Better mask quality propagates through LaMa pipeline |
+| build_wan_video | WAN 2.2 | ❌ No | **WAN 2.7** (Apr 2026) | https://github.com/Wan-Video/Wan2.7 | medium | 5-image multi-ref, vocal timbre, FLF, audio-sync T2V, 1080 p 15 s; weights on ModelScope only |
+| build_wan22_t2v | WAN 2.2 T2V | ❌ No | **WAN 2.7** (Apr 2026) | https://github.com/Wan-Video/Wan2.7 | medium | Supersedes WAN 2.1 and 2.2 T2V |
+| build_wan_flf | WAN 2.2 FLF | ⚠️ Upgradeable | WAN 2.7 native FLF | https://github.com/Wan-Video/Wan2.7 | medium | WAN 2.7 integrates FLF natively |
+| build_ltx_video | LTX-Video | ❌ No | **LTX-2.3** (Mar 2026) + DENO nodes (Jun 24) | https://github.com/Lightricks/LTX-Video | medium | 22 B params, 4K@50 fps, stereo audio; FP8 fits 16 GB; comfyui-deno v0.7.62 adds loader+sequencer nodes |
+| build_video_upscale | 4x-UltraSharp etc. | ⚠️ Upgradeable | **RTX Video Super Resolution** via DENO v0.7.62 (Jun 24) | https://github.com/Deno2026/comfyui-deno-custom-nodes | low | NVIDIA Tensor Core hardware VSR; 30× faster than software upscalers; RTX 5060 Ti fully eligible |
+| build_wan_animate_video | WAN animate | ⚠️ Upgradeable | **SCAIL-2** (Jun 16, 2026) | https://huggingface.co/zai-org/SCAIL-2 | medium | ByteDance; end-to-end character animation; GGUF; ~16 GB; WanAnimatePlus ComfyUI node |
+| build_hunyuan_3d_textured | HunyuanDiT 3D 2.x | ⚠️ Upgradeable | **TripoSplat** (Jun 16, 2026) | https://huggingface.co/VAST-AI/TripoSplat | low | ~8 GB VRAM; PLY/SPLAT Gaussian Splat output; native ComfyUI v0.25.0; additive path |
+| build_hunyuan_3d_mesh | HunyuanDiT 3D 2.x | ⚠️ Upgradeable | **Hunyuan3D 3.0** (Feb 2026) | https://blog.comfy.org/p/hunyuan-3d-30-in-comfyui-state-of | medium | 3D-DiT, 1536³ resolution, auto-rigging; full pipeline VRAM likely ≥ 16 GB — needs testing |
+| build_depth_map_v3 | DA3 / DepthAnything V3 | ✅ Current | DA3 now native in ComfyUI v0.25.0 | https://github.com/bytedance-seed/depth-anything-3 | low | Same model weights; multi-view mode added; native path removes custom-node dependency |
+| build_txt2img | SDXL / FLUX.1-dev | ⚠️ Additive | **Krea-2** (Jun 22, 2026) | https://huggingface.co/krea/Krea-2-Raw | medium | New 12 B DiT; Krea Community License; 9+ official style LoRAs; native ComfyUI v0.26.0; VRAM est. 16–24 GB |
+| build_img2img | SDXL / FLUX | ✅ Current | — | — | — | No supersession in window |
+| build_style_transfer | SDXL misc. | ⚠️ Additive | FLUX.1-Kontext-dev + Shakker-Labs LoRAs | https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev | high | 5 new Shakker-Labs style LoRAs Jun 2026; full Kontext model ~24 GB; NVFP4 variant may fit |
+| build_face_restore | CodeFormer | ⚠️ Additive | **ComfyUI-Flux-FaceIR** (Apr 2026) | https://github.com/cosmicrealm/ComfyUI-Flux-FaceIR | medium | Klein-4B LoRA; blind + reference-guided face restoration; complements CodeFormer |
+| build_faceswap | ReActor + inswapper | ⚠️ Upgradeable | **HyperSwap 1c** in ReActor v0.6.2 | https://github.com/Gourieff/ComfyUI-ReActor | low | Drop-in model (hyperswap_1c_256.onnx); already in ReActor v0.6.2 (Apr 2025) |
+| build_inpaint_fooocus | Fooocus SDXL | ✅ Current | — | — | — | Fooocus-specific approach unchanged |
+| build_outpaint | Klein outpaint LoRA | ✅ Current | — | — | — | fal/flux-2-klein-4B-outpaint-lora still current |
+| build_controlnet_gen | ControlNet SDXL/FLUX | ✅ Current | — | — | — | ControlNet Union Pro 2.0 (Apr 2025) unchanged; no new ControlNet in window |
+| build_klein_* (15 methods) | FLUX.2-klein 4B/9B | ✅ Current | — | — | — | Architecture unchanged; new LoRAs: Portrait Engine v4 (Jun 23), Leon1000 curated set (Jun 23) |
+| build_pulid_flux | PuLID-FLUX | ✅ Current | — | — | — | Last updated Oct 2024; no 2026 release |
+| build_lumina2_txt2img | Lumina2 | ✅ Current | — | — | — | No update found |
+| build_qwen_edit | Qwen-Image-Edit-2511 | ✅ Current | — | — | — | Dec 2025 checkpoint remains latest |
+| build_iclight | IC-Light V2 | ✅ Current | — | — | — | No in-window IC-Light update |
+| build_lama_remove | LaMa | ✅ Current | — | — | — | No 2026 architecture update |
+| build_rembg | rembg | ✅ Current | — | — | — | Stable |
+| build_rembg_birefnet | BiRefNet | ✅ Current | — | — | — | No BiRefNet v2 exists; BiRefNet_dynamic (Mar 2025) is latest official |
+| build_rembg_v3 | RMBG-2.0 | ✅ Current | — | — | — | Metadata updated Apr 2026; no architecture change |
+| build_colorize | DDColor + Klein | ✅ Current | LTX-2.3-IC-LoRA-Colorization (video, Jun 17) — monitor | https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Colorization | high | Video colorization IC-LoRA; 24–80 GB VRAM exceeds budget; monitor for quantized variants |
+| build_ddcolor | DDColor | ✅ Current | — | — | — | No DDColor successor in 2026 |
+| build_supir | SUPIR | ✅ Current | — | — | — | No SUPIR successor found in window |
+| build_faceid_img2img | FaceID | ✅ Current | — | — | — | No FaceID update found |
+| build_faceswap_mtb | MTB | ✅ Current | — | — | — | No MTB update |
+| build_faceswap_model | InsightFace | ✅ Current | — | — | — | InsightFace v0.7 (Apr 2026) is incremental |
+| build_photo_restore | Upscale + CodeFormer | ✅ Current | — | — | — | No change |
+| build_detail_hallucinate | Upscale + SDXL | ✅ Current | — | — | — | No change |
+| build_seedvr2_video_upscale | SeedVR2 | ⚠️ Upgradeable | **FlashVSR** (CVPR 2026) | https://github.com/1038lab/ComfyUI-FlashVSR | medium | 17 fps real-time diffusion VSR, 2×/4× scale; VRAM-optimized variant 8–24 GB; not new in window |
+| build_hunyuan_video | HunyuanVideo | ✅ Current | — | — | — | No major 2026 update confirmed |
+| build_mochi_video | Mochi | ✅ Current | — | — | — | No significant 2026 update |
+| build_cogvideo_video | CogVideoX | ✅ Current | — | — | — | No 2026 update confirmed |
+| build_framepack_video | FramePack | ✅ Current | — | — | — | No major in-window update |
+| build_video_reactor | ReActor (video) | ✅ Current | — | — | — | No video faceswap update found |
+| build_wavespeed_upscale | WaveSpeed | ✅ Current | — | — | — | No update found |
+| build_upscale | Classical SR | ✅ Current | — | — | — | No new classical SR model |
+| build_upscale_blend | Classical SR blend | ✅ Current | — | — | — | No change |
+| build_seedv2r | SeedVR | ✅ Current | — | — | — | No update |
+| build_wan_video_blockswap | WAN + BlockSwap | ✅ Current | — | — | — | Technique unchanged |
+| build_wan_video_blockswap_t2v | WAN + BlockSwap T2V | ✅ Current | — | — | — | Technique unchanged |
+| build_frame_assembly | ffmpeg assembly | ✅ Current | — | — | — | No change |
+| build_layer_blend | Blend node | ✅ Current | — | — | — | No change |
+| build_color_match | SDXL color match | ✅ Current | — | — | — | No change |
+| build_lut | LUT apply | ✅ Current | — | — | — | No change |
+| build_normal_map | ControlNet normal | ✅ Current | — | — | — | No update found |
+| build_photobooth | FLUX.1 iterative | ✅ Current | — | — | — | No change |
+| build_generate_anything | SDXL | ✅ Current | — | — | — | No change |
+| build_klein_headswap | Klein 4B/9B | ✅ Current | — | — | — | Architecture unchanged |
+| build_sam3_segment (infra) | ComfyUI-RMBG v3 | ⚠️ Additive | ComfyUI-RMBG v3.0.0 (Jan 2026) | https://github.com/1038lab/ComfyUI-RMBG | low | Adds Florence-2 segmentation, YOLOv8 detection, SAM3 into one node; updates existing rembg builders |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+These require only a model checkpoint download (or minor ComfyUI update) — no new node-pack installs.
+
+### 1. Moebius → `build_inpaint`
+
+- **Released:** June 18, 2026 (within window)
+- **Architecture:** Custom 226 M-param U-Net with Local-λ Mix Interaction (LλMI) blocks — not a DiT. Weights ~1.27 GB total.
+- **Quality:** Matches or exceeds FLUX.1-Fill-Dev and SD 3.5 Large-Inpainting on Places2, CelebA-HQ, FFHQ; >15× faster than 10 B models.
+- **VRAM:** ~4–6 GB estimated; successfully ported to WebGPU in-browser (confirmed Jun 22).
+- **License:** Apache 2.0
+- **Venue:** ECCV 2026; HUST + VIVO AI Lab
+- **HuggingFace:** https://huggingface.co/hustvl/Moebius
+- **GitHub:** https://github.com/hustvl/Moebius
+- **arXiv:** https://arxiv.org/abs/2606.19195
+
+### 2. SAM 3.1 → `build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract`
+
+- **Released:** March 27, 2026 (pre-window, but significant carry-over)
+- **Architecture:** Same 859.9 M backbone as SAM 3 + Object Multiplex (shared memory bank across all tracked objects; up to 16 objects in one forward pass).
+- **Performance:** 2× FPS (16 → 32 fps at medium object count); up to 7× speedup at 128 objects; 50% less VRAM (8 GB → 4 GB FP16).
+- **VRAM:** ~4 GB FP16 for video tracking (down from ~8 GB for SAM 3).
+- **Status:** Gated HuggingFace model — requires access request.
+- **Integration:** ComfyUI native support added in v0.20.1 (Apr 27, 2026). Also: ComfyUI-TBG-SAM3 adds per-segment depth mapping.
+- **HuggingFace:** https://huggingface.co/facebook/sam3.1
+- **GitHub:** https://github.com/facebookresearch/sam3
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install or ComfyUI upgrade)
+
+### 3. Krea-2 → new `build_krea2_txt2img` builder
+
+- **Released:** June 22, 2026 (within window)
+- **Architecture:** 12 B Diffusion Transformer (DiT); two variants: Krea-2-Raw (full) + Krea-2-Turbo (distilled).
+- **VRAM:** ~16–24 GB estimated (12 B FP16); no official spec yet.
+- **License:** Krea 2 Community License (open but non-commercial for some uses — review before shipping)
+- **Official LoRAs (all Jun 19–24):** retroanime, softwatercolor, neondrip, rainywindow, dotmatrix, darkbrush, kidsdrawing, sunsetblur, vintagetarot + community isometric-3D, yarn-art (linoyts)
+- **ComfyUI:** Native partner-node support in ComfyUI v0.26.0 (Jun 23)
+- **HuggingFace (Raw):** https://huggingface.co/krea/Krea-2-Raw
+- **HuggingFace (Turbo):** https://huggingface.co/krea/Krea-2-Turbo
+- **Announcement:** https://www.krea.ai/krea-2-open-source
+
+### 4. WAN 2.7 → upgrade `build_wan_video`, `build_wan22_t2v`, `build_wan_flf`
+
+- **Released:** April 2026 (pre-window; carry-over)
+- **New capabilities vs. WAN 2.2:** 5-image multi-reference input; vocal timbre reference; first-last-frame control; video continuation; audio-synchronized T2V; up to 1080 p × 15 s.
+- **VRAM:** 16 GB minimum with GGUF quantization (similar to WAN 2.2).
+- **Weights:** ModelScope only — not yet mirrored to HuggingFace as of Jun 2026.
+- **License:** Apache 2.0
+- **ComfyUI blog:** https://blog.comfy.org/p/wan27-is-now-available-in-comfyui
+- **GitHub:** https://github.com/Wan-Video/Wan2.7
+
+### 5. LTX-2.3 + comfyui-deno-custom-nodes v0.7.62 → upgrade `build_ltx_video`
+
+- **LTX-2.3 released:** March 5, 2026 (pre-window)
+- **DENO nodes released:** June 24, 2026 (within window)
+- **LTX-2.3 specs:** 22 B params; native 4K@50fps; stereo audio; FP8/MXFP8 fits 16 GB VRAM.
+- **DENO v0.7.62 adds:** LTX Model Loader, LTX Sequencer, LTX Multi LoRA Loader, LTX Prompt Guide, LTX Tiled Spatial Upscaler (beta), LTX Step-Fused Tiled Sampler (beta).
+- **Bonus in DENO v0.7.62:** RTX Video Super Resolution (single + dual pass) for `build_video_upscale`; Wan2.2 reference video editing nodes.
+- **GitHub:** https://github.com/Deno2026/comfyui-deno-custom-nodes
+- **LTX GitHub:** https://github.com/Lightricks/LTX-Video
+
+### 6. TripoSplat → complement `build_hunyuan_3d_textured`
+
+- **Released:** June 16, 2026 in ComfyUI v0.25.0 (one day pre-window)
+- **Architecture:** DINOv3 ViT-H/16+ encoder + Flux2 VAE; flow-matching denoiser; Octree Gaussian VAE decoder. Single image → 3D Gaussian Splat.
+- **VRAM:** ~8 GB minimum (well within 16 GB budget).
+- **Output:** PLY / SPLAT / SPZ / KSPLAT formats.
+- **Native:** No extra node pack; bundled in ComfyUI v0.25.0+.
+- **HuggingFace:** https://huggingface.co/VAST-AI/TripoSplat
+
+### 7. DA3 multi-view native → upgrade `build_depth_map_v3`
+
+- **Released in ComfyUI:** June 16, 2026 (v0.25.0; one day pre-window)
+- **Architecture:** Plain DINOv2 encoder; unified monocular + multi-view + pose-conditioned depth. DA3-Streaming mode < 12 GB VRAM.
+- **Change from current:** Current builder uses `da3_large.safetensors` monocular only; ComfyUI v0.25.0 surfaces multi-view mode natively — no custom-node dependency.
+- **VRAM:** ≤ 12 GB for streaming mode.
+- **GitHub:** https://github.com/bytedance-seed/depth-anything-3
+
+### 8. SCAIL-2 → complement `build_wan_animate_video`
+
+- **Integrated in ComfyUI:** June 16, 2026 (v0.25.0)
+- **Architecture:** ByteDance / zai-org; end-to-end reference-image-driven character animation with replacement and multi-character support; no intermediate pose representation required. Available as GGUF.
+- **VRAM:** ~16 GB with GGUF quantization.
+- **ComfyUI node pack:** ComfyUI-WanAnimatePlus (github.com/wuwukaka/ComfyUI-WanAnimatePlus) adds SCAIL-2 Embeds node.
+- **HuggingFace:** https://huggingface.co/zai-org/SCAIL-2
+
+### 9. ComfyUI-Flux-FaceIR → complement `build_face_restore`
+
+- **Released:** April 7, 2026 (pre-window; carry-over)
+- **Architecture:** Flux.2-klein-4B LoRA trained for blind face restoration and reference-guided restoration. Complements CodeFormer for Klein-pipeline workflows.
+- **VRAM:** Klein-4B base ~8–12 GB.
+- **GitHub:** https://github.com/cosmicrealm/ComfyUI-Flux-FaceIR
+
+### 10. civitai-comfy-nodes v0.2.0 → general cloud inference capability
+
+- **Released:** June 17, 2026 (within window)
+- **Functionality:** ~160 nodes across 8 categories exposing Civitai cloud Orchestration API as native ComfyUI graph nodes (image/video/audio gen, upscaling, training, captioning). Zero local VRAM — compute is cloud-side.
+- **GitHub:** https://github.com/civitai/civitai-comfy-nodes
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Target method | Blocker | URL |
+|---|---|---|---|
+| **Z-Image Turbo** (S3-DiT 6B, Apache 2.0, ~8 GB FP8) | build_txt2img | No ComfyUI node pack confirmed yet | https://civitai.com/models/2168935/z-image-turbo |
+| **FLUX.1-Kontext-dev + Shakker-Labs LoRAs** (5 style LoRAs Jun 2026) | build_style_transfer | Full model ~24 GB; NVFP4 variant needed | https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev |
+| **fal/FLUX.2-dev-Turbo** (8-step speed LoRA) | build_txt2img | Base FLUX.2-dev requires ~32 GB FP8; exceeds budget | https://huggingface.co/fal/FLUX.2-dev-Turbo |
+| **FlashVSR** (CVPR 2026, 17 fps, 2×/4×) | build_seedvr2_video_upscale | Not new in window; needs VRAM-opt variant testing | https://github.com/1038lab/ComfyUI-FlashVSR |
+| **Fibo-Edit-RMBG** (8B DiT alpha matting, Feb 2026) | build_rembg_v3 | 16 GB+ VRAM estimated; uncertain | https://huggingface.co/briaai/Fibo-Edit-RMBG |
+| **Hunyuan3D 3.0** (3D-DiT, 1536³, auto-rig, Feb 2026) | build_hunyuan_3d_mesh | Full textured pipeline likely > 16 GB; shape-only TBD | https://blog.comfy.org/p/hunyuan-3d-30-in-comfyui-state-of |
+| **LTX-2.3-IC-LoRA-Colorization** (Jun 17, Lightricks) | build_colorize | 22B base; 24–80 GB VRAM — well over budget | https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Colorization |
+| **HiDream-O1-Image** (8.8B, MIT, May 2026) | build_txt2img | 24 GB+ VRAM required | https://huggingface.co/HiDream-ai/HiDream-O1-Image |
+| **ComfyUI v0.26.0** (Jun 23) | infra | Required upgrade to enable Krea-2 + DA3 multi-view | https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.26.0 |
+| **ComfyUI-RMBG v3.0.0** (Jan 2026) | build_rembg_birefnet | Adds Florence-2 segmentation + YOLOv8 to existing pack | https://github.com/1038lab/ComfyUI-RMBG |
+| **ComfyUI-Flux-FaceIR** (Apr 2026) | build_face_restore | Already in Tier 2 above; listed here for VRAM uncertainty note | https://github.com/cosmicrealm/ComfyUI-Flux-FaceIR |
+
+---
+
+## No-finds (verified current / stable)
+
+- **BiRefNet**: No v2 exists (confirmed across multiple sources). Official variants last updated Feb 4, 2026 (metadata only). Current `build_rembg_birefnet` is still state-of-the-art.
+- **RMBG-2.0**: Metadata refreshed Apr 6, 2026; architecture unchanged. `build_rembg_v3` current.
+- **PuLID / PuLID-FLUX**: Last release Oct 2024. No 2026 update. `build_pulid_flux` current.
+- **ReActor faceswap**: v0.6.2 released Apr 2025; registry updated May 2026; no June 17–24 changes.
+- **CodeFormer**: No 2026 release. `build_face_restore` backbone unchanged.
+- **LaMa inpainting**: No 2026 architecture update. `build_lama_remove` current.
+- **CogVideoX**: No 2026 model update confirmed. `build_cogvideo_video` current.
+- **Mochi**: No significant 2026 update. `build_mochi_video` current.
+- **IC-Light V2**: No in-window update. `build_iclight` current.
+- **DDColor**: No successor found. `build_ddcolor` / `build_colorize` backbone current.
+- **SUPIR**: No SUPIR successor found. `build_supir` current.
+- **Lumina2**: No update found. `build_lumina2_txt2img` current.
+- **FramePack**: No major in-window update. `build_framepack_video` current.
+- **HunyuanVideo**: No major 2026 update confirmed. `build_hunyuan_video` current.


### PR DESCRIPTION
## Spellcaster SOTA Review — 2026-W26 (2026-06-24)

Inaugural run. No prior baseline in `_dev_docs/upgrade_research/`. All 23 findings are net-new.

**Hardware budget:** RTX 5060 Ti · 16 GB VRAM · Skip anything requiring more.

---

### Summary

| Tier | Count | Items |
|------|-------|-------|
| **Tier 1** — drop-in, ship soon | 2 | Moebius inpainting, SAM 3.1 |
| **Tier 2** — additive, needs upgrade | 10 | Krea-2, WAN 2.7, LTX-2.3+DENO, TripoSplat, DA3 native, SCAIL-2, Flux-FaceIR, civitai-comfy-nodes, HyperSwap 1c, ComfyUI v0.26.0 |
| **Tier 3** — monitor, not wire-ready | 8 | Z-Image Turbo, FLUX.1-Kontext, FlashVSR, Fibo-Edit-RMBG, Hunyuan3D 3.0, LTX IC-LoRA Colorization, HiDream-O1, (ComfyUI infra notes) |
| **No-finds** — verified stable | 14 | BiRefNet, RMBG-2.0, PuLID-FLUX, ReActor, CodeFormer, LaMa, CogVideoX, Mochi, IC-Light V2, DDColor, SUPIR, Lumina2, FramePack, HunyuanVideo |

---

### Tier 1 — Drop-in, ship soon

**Moebius** (`build_inpaint` drop-in)
- 226M inpainting model · Apache 2.0 · ~4–6 GB VRAM · Published 2026-06-18 (in window)
- Beats FLUX.1-Fill-Dev and SD3.5-Large-Inpainting on 6 benchmarks (ECCV 2026)
- arXiv: 2606.19195 · HF: `vllmcs/Moebius`
- Risk: low · Confidence: 0.95

**SAM 3.1** (`build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract` drop-in)
- Object Multiplex variant · 2× FPS vs SAM 3.0 · VRAM: 8 GB → 4 GB FP16 · HF gated
- Already integrated in ComfyUI v0.20.1 — weights swap only
- Risk: low · Confidence: 0.92

---

### Tier 2 — Additive, needs node-pack or ComfyUI upgrade

| # | Item | Builder(s) affected | Notes |
|---|------|---------------------|-------|
| 1 | **Krea-2** (June 22) | new builder needed | 12B DiT · Krea Community License · 9 LoRAs · native ComfyUI v0.26.0 |
| 2 | **WAN 2.7** (April 2026) | `build_wan_video` | multi-ref video, vocal timbre, audio-sync T2V, 1080p 15s · Apache 2.0 · ModelScope weights only |
| 3 | **LTX-2.3** (March 2026) | `build_ltx_video` | 22B · 4K@50fps · FP8 fits 16 GB |
| 4 | **comfyui-deno-custom-nodes v0.7.62** (June 24) | `build_ltx_video` | adds loader/sequencer/tiled upscaler + RTX VSR integration |
| 5 | **TripoSplat** (June 16, ComfyUI v0.25.0) | new builder | 8 GB VRAM · Gaussian Splat output · native ComfyUI |
| 6 | **DA3 native** (ComfyUI v0.25.0) | depth builders | multi-view depth · no custom-node dependency |
| 7 | **SCAIL-2** (June 16, ComfyUI v0.25.0) | new builder | ByteDance character animation GGUF · ~16 GB |
| 8 | **ComfyUI-Flux-FaceIR** (April 2026) | `build_flux_*` | Klein-4B LoRA for face restore |
| 9 | **civitai-comfy-nodes v0.2.0** (June 17) | all | 160 cloud API nodes · MIT |
| 10 | **HyperSwap 1c** (in ReActor v0.6.2) | `build_faceswap_*` | drop-in model swap |

---

### Tier 3 — Monitor, not wire-ready

| Item | Blocker |
|------|---------|
| Z-Image Turbo | no ComfyUI node yet |
| FLUX.1-Kontext-dev | requires 24 GB+ VRAM |
| FlashVSR | pre-window (CVPR 2026), await ComfyUI integration |
| Fibo-Edit-RMBG | 16 GB+ uncertain; high-risk experimental |
| Hunyuan3D 3.0 | VRAM unknown; await benchmarks |
| LTX-2.3-IC-LoRA-Colorization | 24–80 GB — exceeds hardware budget |
| HiDream-O1-Image | 24 GB+ — exceeds hardware budget |

---

### Research artifacts

- `_dev_docs/upgrade_research/2026-W26.md` — full narrative report
- `_dev_docs/upgrade_research/2026-W26.json` — 23 structured records (schema: method, category, name, source, url, risk, confidence, notes)

---

> **Note:** The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically. No manual snapshot update is needed alongside this PR.

---

*Do not merge — leave open for human review and local node-pack installation.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8KohZVMUmFgQPC6MQTxYt)_