### PR TITLE
chore(research): daily SOTA review 2026-06-28

### DIFF
--- a/_dev_docs/upgrade_research/2026-W26.json
+++ b/_dev_docs/upgrade_research/2026-W26.json
@@ -1,0 +1,522 @@
+[
+  {
+    "method": "build_inpaint",
+    "category": "checkpoint",
+    "name": "Moebius 0.22B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/hustvl/Moebius",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "ECCV 2026. 0.22B matches FLUX.1-Fill-Dev (11.9B) on 6 benchmarks; 26ms/step; Apache 2.0. No ComfyUI node yet as of 2026-06-28 — community port expected within days. Will replace FLUX.1-Fill-Dev in build_inpaint."
+  },
+  {
+    "method": "build_magic_eraser",
+    "category": "checkpoint",
+    "name": "Moebius 0.22B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/hustvl/Moebius",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Same model as build_inpaint entry. One model covers erase and inpaint workflows."
+  },
+  {
+    "method": "build_lama_remove",
+    "category": "checkpoint",
+    "name": "Moebius 0.22B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/hustvl/Moebius",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Moebius outperforms LaMa on object removal. Await ComfyUI node before wiring."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Released 2026-05-22. Adds native Klein 4B/9B/Dev auto-detection, improved face recognition, fewer artifacts. Drop-in node update; same workflow graph."
+  },
+  {
+    "method": "build_faceid_img2img",
+    "category": "node_pack",
+    "name": "balazik/ComfyUI-PuLID-Flux (migration from discontinued Enhanced fork)",
+    "source": "github",
+    "url": "https://github.com/balazik/ComfyUI-PuLID-Flux",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "ComfyUI-PuLID-Flux-Enhanced (sipie800) formally discontinued; last update 2026-02-12. Must migrate to maintained fork. No model weight changes needed."
+  },
+  {
+    "method": "build_photobooth",
+    "category": "node_pack",
+    "name": "balazik/ComfyUI-PuLID-Flux (migration from discontinued Enhanced fork)",
+    "source": "github",
+    "url": "https://github.com/balazik/ComfyUI-PuLID-Flux",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "Same migration as build_faceid_img2img — Enhanced fork discontinued."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "medium",
+    "confidence": 0.96,
+    "notes": "Released 2026-03-27. Accepts text prompts and image exemplars (open-vocabulary). 7x faster multi-object tracking vs SAM 2. Weights gated on Meta HF; Comfy-Org mirror available. Fits 16 GB at FP16."
+  },
+  {
+    "method": "build_sam3_mask",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "medium",
+    "confidence": 0.96,
+    "notes": "Same SAM 3.1 upgrade. Text-driven masking is a major workflow capability gain."
+  },
+  {
+    "method": "build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "medium",
+    "confidence": 0.96,
+    "notes": "Text noun-phrase prompts replace the point/box flow. Same upgrade as segment/mask."
+  },
+  {
+    "method": "build_klein_sam3_inpaint",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (upstream dependency)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "SAM 3.1 text prompts make the segment step easier; upgrade the SAM upstream dep."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 (22B)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Released 2026-03-05. Complete architecture change: 22B DiT, audio+video, 4K/50fps, new VAE. FP8 or GGUF Q4 (unsloth/LTX-2.3-GGUF) required for 16 GB VRAM. Builder must be rewritten for new node structure. ComfyUI v0.26.0 (2026-06-23) adds native LTX2 Context Windows node."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "node_pack",
+    "name": "Deno2026 custom nodes v0.7.64 — LTX-2.3 tiled upscaler",
+    "source": "github",
+    "url": "https://github.com/Deno2026/comfyui-deno-custom-nodes",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Released 2026-06-26 (in reporting window). Contains LTX-2.3 tiled spatial upscaler/loader and reference video editing helpers. Complements LTX-2.3 model upgrade."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "node_pack",
+    "name": "SeedVR2 v2.5 (GGUF, 4-node modular)",
+    "source": "github",
+    "url": "https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Released 2026-11-07. Breaking change: 4-node modular system replaces single node. 60% VRAM reduction; 7B now runs on 8 GB with GGUF Q4. Old workflows must be rebuilt. Improved temporal consistency."
+  },
+  {
+    "method": "build_seedv2r",
+    "category": "checkpoint",
+    "name": "SeedVR2 3B / 7B (ICLR 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ByteDance-Seed/SeedVR2-3B",
+    "risk": "medium",
+    "confidence": 0.97,
+    "notes": "Paper 2026-06-05; ICLR 2026 accepted 2026-01-27. One-step diffusion (adversarial post-training) replaces multi-step SeedVR. 3B fits 16 GB; 7B needs BF16 variant (SassyDiffusion/SeedVR2-7B_BF16). Direct successor to build_seedv2r."
+  },
+  {
+    "method": "build_hunyuan_video",
+    "category": "checkpoint",
+    "name": "HunyuanVideo-1.5 (8.3B)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tencent/HunyuanVideo-1.5",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Released 2025-11-21; I2V step-distilled 2025-12-05. 8.3B vs original 13B; 1.87x speedup via SSTA attention; I2V in 8-12 steps. Better 16 GB headroom than original HunyuanVideo."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "FlashVSR v1.1",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-FlashVSR",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "arXiv 2510.12747, CVPR 2026. One-step diffusion VSR; Tiny Long low-VRAM mode; tiling available. Multiple ports — prefer 1038lab or naxci1/ComfyUI-FlashVSR_Stable (VRAM-optimized). Caution: ports missing locality-constrained sparse attention show quality degradation."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX Video Super Resolution Node",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Last updated 2026-03-22. TensorRT-accelerated 4K upscaling on RTX 5060 Ti. 30x faster than ESRGAN. Two-pass (denoise + upscale) available. Deno2026 v0.7.64 (2026-06-26) includes enhanced 4-mode wrapper."
+  },
+  {
+    "method": "build_wavespeed_upscale",
+    "category": "node_pack",
+    "name": "FlashVSR v1.1",
+    "source": "github",
+    "url": "https://github.com/OpenImagingLab/FlashVSR",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Local alternative to WaveSpeed cloud inference. Same quality warning re: sparse attention implementation."
+  },
+  {
+    "method": "build_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX VSR Node",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Hardware-accelerated image upscaling on RTX 5060 Ti. 30x faster than software ESRGAN."
+  },
+  {
+    "method": "build_upscale_blend",
+    "category": "node_pack",
+    "name": "NVIDIA RTX VSR Node",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Can replace one of the two ESRGAN legs in the blend with hardware-accelerated VSR."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Wan2.7 (14B, GGUF+blockswap)",
+    "source": "github",
+    "url": "https://comfyui.org/en/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Released 2026-04-22 on ModelScope (not HF). Adds native audio, 5-image multi-reference, built-in FLF. Requires GGUF Q4 + blockswap for 16 GB VRAM at 720p (~10-15 min). Community GGUF quantizations on HF."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "Wan2.7 (14B, GGUF+blockswap)",
+    "source": "github",
+    "url": "https://comfyui.org/en/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Same Wan2.7 upgrade. T2V benefits from new audio conditioner."
+  },
+  {
+    "method": "build_wan_flf",
+    "category": "checkpoint",
+    "name": "Wan2.7 (14B, native FLF)",
+    "source": "github",
+    "url": "https://comfyui.org/en/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "FLF now native in Wan2.7 — may allow simplification of build_wan_flf builder."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "Wan2.7 (14B)",
+    "source": "github",
+    "url": "https://comfyui.org/en/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "5-image multi-reference improves animation consistency."
+  },
+  {
+    "method": "build_wan_video_blockswap",
+    "category": "checkpoint",
+    "name": "Wan2.7 + blockswap",
+    "source": "github",
+    "url": "https://comfyui.org/en/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Blockswap + GGUF combination still needed for 16 GB VRAM."
+  },
+  {
+    "method": "build_wan_video_blockswap_t2v",
+    "category": "checkpoint",
+    "name": "Wan2.7 + blockswap",
+    "source": "github",
+    "url": "https://comfyui.org/en/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Same as build_wan_video_blockswap."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 256 (1a/1b/1c variants)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0/tree/main",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Already in ReActor v0.6.2 (2025-04-25); adoption peaking June 2026. 2x face output resolution vs inswapper_128. Download into ComfyUI/models/hyperswap/. Inswapper retains higher identity similarity — test 1a/1b/1c for best tradeoff."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "ReActor v0.6.x — Restore Face Advanced",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "New Restore Face Advanced node applies CodeFormer only to swapped faces. ReActorSetWeight (0-100% swap strength), ReActorMaskHelper, ReActorImageDuplicator nodes added. No longer requires InsightFace C++ build tools."
+  },
+  {
+    "method": "build_faceswap_mtb",
+    "category": "node_pack",
+    "name": "ComfyUI-Faceless (FaceFusion in ComfyUI)",
+    "source": "github",
+    "url": "https://github.com/jeffy5/comfyui-faceless-node",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Last updated 2026-04-03. Brings FaceFusion pipeline (including HyperSwap) into ComfyUI natively. Evaluate as alternative to MTB face swap nodes."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "node_pack",
+    "name": "facerestore_advanced",
+    "source": "github",
+    "url": "https://github.com/flickleafy/facerestore_advanced",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "Drop-in replacement for facerestore_cf node. Same CodeFormer/GFPGAN models with 15+ quality metrics, automatic fallback, caching. Test fallback logic in batch workflows before production use."
+  },
+  {
+    "method": "build_photo_restore",
+    "category": "node_pack",
+    "name": "facerestore_advanced",
+    "source": "github",
+    "url": "https://github.com/flickleafy/facerestore_advanced",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "Better quality gating via 15+ metrics improves the CodeFormer post-processing step in photo restore pipeline."
+  },
+  {
+    "method": "build_klein_face_detail",
+    "category": "node_pack",
+    "name": "ComfyUI v0.23.0 — MediaPipe Face Detection (native)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/14009",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Released 2026-06-01. Dependency-free 478-point FaceMesh, BlazeFace detectors, FaceBlendshapes — all in ComfyUI core as safetensors. Zero install cost. Replaces less precise YOLO/RetinaFace detectors."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "node_pack",
+    "name": "ComfyUI v0.23.0 — MediaPipe Face Detection (native)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/14009",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "More accurate face detection masks upstream of CodeFormer/GFPGAN. In ComfyUI core."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "node_pack",
+    "name": "GHOST 2.0 + Ghost2_Comfyui",
+    "source": "github",
+    "url": "https://github.com/Holasyb918/Ghost2_Comfyui",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Paper 2025-02-25. Full head swap (Aligner + Blender modules). ComfyUI node unofficial but available. Alternative to Klein Flux2 for one-shot scenarios. Fits 16 GB."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "checkpoint",
+    "name": "BEN2",
+    "source": "huggingface",
+    "url": "https://huggingface.co/PramaLLC/BEN2",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Confidence-Guided Matting pipeline; better hair/fine-edge matting. 1.13 GB; 1080p in ~6s. Already in ComfyUI-RMBG alongside RMBG-2.0. Add as selectable model if not already present."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "BiRefNet v2 variants (matting/portrait/2K)",
+    "source": "github",
+    "url": "https://fal.ai/models/fal-ai/birefnet/v2",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "Specialized fine-tunes of BiRefNet: General Light 2K, Matting, Portrait. Current BiRefNet-general remains good default; add variants for hair/portrait use cases."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "node_pack",
+    "name": "LBM Depth/Normal (ComfyUI-LBM v1.1.0)",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-LBM",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "ICCV 2025 Highlight (arXiv 2503.07535). Single-step depth+normal output via Latent Bridge Matching. Node released 2025-05-22. Faster single-step alternative to DSINE/BAE if current normal_map is slow."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 3.0 (shape-only)",
+    "source": "github",
+    "url": "https://docs.comfy.org/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0",
+    "risk": "high",
+    "confidence": 0.82,
+    "notes": "ComfyUI Partner Nodes integration 2026-02-13. Text/image/sketch-to-3D. Shape-only generation likely fits 16 GB (6-10 GB range based on prior versions). Full texture pipeline likely exceeds 16 GB. Test Hunyuan3D-2GP (GPU-poor fork) first."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 3.0 (texture — VRAM risk)",
+    "source": "github",
+    "url": "https://docs.comfy.org/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0",
+    "risk": "high",
+    "confidence": 0.82,
+    "notes": "Full texture pipeline of Hunyuan3D 3.0 historically needed ~29 GB. VRAM specs for 3.0 not yet fully documented. Likely exceeds 16 GB budget without offloading. Monitor for quantized variant."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "NVIDIA PixelDiT 1300M",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Released in ComfyUI v0.23.0 (2026-06-01). CVPR 2026 Best Paper Finalist. 1.3B BF16, single-stage pixel-space DiT (no VAE), 1024px. New backbone option — not Flux quality but fast and VAE-free."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Microsoft Lens 3.8B",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/14077",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Released in ComfyUI v0.23.0 (2026-06-01). 3.8B dual-stream MMDiT, GPT-OSS-20B text features + FLUX.2 VAE, nvfp4. No access gate. Lens Turbo (distilled) also available."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-Edit 20B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Open-sourced June 2026. Dedicated editing MMDiT: bilingual text editing in-image, semantic+appearance editing, preserves font/size/style. 20B needs FP8/Q8 on 16 GB; may need CPU offload. ComfyUI nodes: lrzjason/Comfyui-QwenEditUtils."
+  },
+  {
+    "method": "build_cogvideo_video",
+    "category": "checkpoint",
+    "name": "CogVideoX1.5",
+    "source": "github",
+    "url": "https://github.com/kijai/ComfyUI-CogVideoXWrapper",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "CogVideoX1.5-5B with higher resolution I2V; GGUF+SageAttention+tiled encoding via kijai wrapper. ComfyUI changelog notes CogVideoX inclusion in May 2026 update. Upgrade if builder targets base CogVideoX."
+  },
+  {
+    "method": "build_video_reactor",
+    "category": "checkpoint",
+    "name": "HyperSwap 256 (via ReActor v0.6.2)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0/tree/main",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Same HyperSwap upgrade path as build_faceswap. 2x face resolution on per-frame video swap."
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "PIXLRelight (Tier 3 watch)",
+    "source": "github",
+    "url": "https://github.com/mlfarinha/pixlrelight",
+    "risk": "high",
+    "confidence": 0.72,
+    "notes": "Paper 2026-05-18. Physically-based feed-forward relighter; <100ms inference. No ComfyUI node. Standalone script only. Watch for community port. More physically grounded than IC-Light v2."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "RealRestorer (Tier 3 watch)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "Paper arXiv 2603.25502 (March 2026). Generalizable restoration on large-scale editing models. No ComfyUI node yet. SUPIR remains best-packaged option. Monitor for community wrapper."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "AnyDepth (lightweight alternative)",
+    "source": "github",
+    "url": "https://github.com/AIGeeksGroup/AnyDepth",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "arXiv 2601.02760 (2026-01-06). DINOv3 encoder + Simple Depth Transformer; 85-89% fewer params vs DPT. DA3 is still current; AnyDepth is useful as fast preview mode only. Not a quality replacement."
+  },
+  {
+    "method": "build_mochi_video",
+    "category": "checkpoint",
+    "name": "(no update found — consider deprecating)",
+    "source": "github",
+    "url": "https://github.com/genmoai/mochi",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Mochi 1 still at 480p preview (Oct 2024). No update in 8+ months. WAN and LTX have advanced significantly. Recommend evaluating whether build_mochi_video should be maintained or deprecated."
+  },
+  {
+    "method": "build_framepack_video",
+    "category": "checkpoint",
+    "name": "(no update found)",
+    "source": "github",
+    "url": "https://github.com/lllyasviel/FramePack",
+    "risk": "low",
+    "confidence": 0.70,
+    "notes": "No release since FramePack-F1/P1 in 2025. Monitor lllyasviel/FramePack/releases directly."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "checkpoint",
+    "name": "FLUX.2 Dev multi-reference (matured)",
+    "source": "github",
+    "url": "https://blogs.nvidia.com/blog/rtx-ai-garage-flux-2-comfyui/",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "FLUX.2 Dev multi-reference (up to 10 refs) matured in June 2026 with NVIDIA FP8 guide reducing VRAM 40%. RTX 5060 Ti confirmed compatible. Useful for style transfer without extra LoRAs."
+  },
+  {
+    "method": "build_detail_hallucinate",
+    "category": "node_pack",
+    "name": "ComfyUI v0.23.0 — MediaPipe Face Detection (native)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/14009",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Native face detection improves face-targeting in detail hallucination pipeline."
+  },
+  {
+    "method": "build_save_face_model",
+    "category": "node_pack",
+    "name": "ReActor v0.6.x — FACE_MODEL_NAME output",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Minor: Load Face Model node now outputs FACE_MODEL_NAME string, enabling downstream model routing."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W26.md
+++ b/_dev_docs/upgrade_research/2026-W26.md
@@ -1,0 +1,276 @@
+# Spellcaster daily SOTA review — 2026-06-28
+
+ISO week: `2026-W26`. Baseline: *(first run — no prior punch list)*.
+
+Hardware budget: RTX 5060 Ti, 16 GB VRAM. Items exceeding this are flagged.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / Addition | Source URL | Risk | Notes |
+|--------|-----------------|-------------|----------------------|-----------|------|-------|
+| build_inpaint | FLUX.1-Fill-Dev (11.9B) | No | Moebius 0.22B | https://huggingface.co/hustvl/Moebius | Low | 54× smaller, matches FLUX.1-Fill-Dev on 6 benchmarks; no ComfyUI node yet — expected within days (ECCV 2026) |
+| build_magic_eraser | LaMa + SAM2 | Partial | Moebius 0.22B | https://huggingface.co/hustvl/Moebius | Low | Same Moebius — one model covers inpaint and erase |
+| build_lama_remove | LaMa | Partial | Moebius 0.22B | https://huggingface.co/hustvl/Moebius | Low | Moebius outperforms LaMa on object removal at a fraction of the compute |
+| build_pulid_flux | ComfyUI-PuLID-Flux (older) | No | ComfyUI-PuLID-Flux2 v0.6.2 | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Low | Adds native Klein 4B/9B/Dev auto-detection; fewer artifacts |
+| build_faceid_img2img | ComfyUI-PuLID-Flux-Enhanced (discontinued) | No — fork dead | balazik/ComfyUI-PuLID-Flux | https://github.com/balazik/ComfyUI-PuLID-Flux | Low | Enhanced fork formally discontinued Feb 2026; must migrate |
+| build_photobooth | ComfyUI-PuLID-Flux-Enhanced | No — fork dead | balazik/ComfyUI-PuLID-Flux | https://github.com/balazik/ComfyUI-PuLID-Flux | Low | Same migration as build_faceid_img2img |
+| build_sam3_segment | SAM 2 | No | SAM 3.1 | https://huggingface.co/facebook/sam3.1 | Medium | Text-prompt + exemplar segmentation; 7× faster multi-object tracking; gated HF, mirror at Comfy-Org/sam3.1 |
+| build_sam3_mask | SAM 2 | No | SAM 3.1 | https://huggingface.co/facebook/sam3.1 | Medium | Same upgrade path; text-driven masking is a major workflow capability gain |
+| build_sam3_extract | SAM 2 | No | SAM 3.1 | https://huggingface.co/facebook/sam3.1 | Medium | Text noun-phrase prompts replace point/box flow |
+| build_ltx_video | LTX-Video 0.9.x | No | LTX-2.3 (22B, FP8/GGUF) | https://huggingface.co/Lightricks/LTX-2.3 | Medium | Complete architecture change — audio+video, 4K/50fps, new VAE; FP8/GGUF Q4 fits 16 GB VRAM |
+| build_seedvr2_video_upscale | SeedVR2 pre-v2.5 | No | SeedVR2 v2.5 (GGUF Q4) | https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler | Medium | Breaking: 4-node modular system replaces single node; now 8 GB VRAM viable; must rebuild workflows |
+| build_seedv2r | SeedVR (CVPR 2025) | No | SeedVR2 3B/7B (ICLR 2026) | https://huggingface.co/ByteDance-Seed/SeedVR2-3B | Medium | One-step inference vs multi-step; 3B fits 16 GB comfortably; 7B needs BF16 variant |
+| build_hunyuan_video | HunyuanVideo 13B | Partial | HunyuanVideo-1.5 8.3B | https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5 | Low | 1.87× speedup via SSTA attention; step-distilled I2V in 8–12 steps; better 16 GB headroom |
+| build_video_upscale | 4x-UltraSharp ESRGAN | Partial | FlashVSR v1.1 + NVIDIA RTX VSR | https://github.com/1038lab/ComfyUI-FlashVSR | Medium | Diffusion VSR (CVPR 2026); RTX 5060 Ti native HW acceleration via Comfy-Org/Nvidia_RTX_Nodes_ComfyUI |
+| build_wavespeed_upscale | WaveSpeed API | Partial | FlashVSR v1.1 | https://github.com/OpenImagingLab/FlashVSR | Medium | Local alternative to WaveSpeed cloud; verify locality-constrained sparse attention in chosen port |
+| build_wan_video | Wan2.2 | Partial | Wan2.7 (14B, GGUF+blockswap) | https://comfyui.org/en/wan27-is-now-available-in-comfyui | Medium | Adds audio, 5-image multi-ref, built-in FLF; 16 GB viable with GGUF Q4 + blockswap at 720p |
+| build_wan22_t2v | Wan2.2 | Partial | Wan2.7 | https://comfyui.org/en/wan27-is-now-available-in-comfyui | Medium | Same upgrade path; T2V benefits from new audio conditioner |
+| build_wan_flf | Wan2.2 | Partial | Wan2.7 (native FLF) | https://comfyui.org/en/wan27-is-now-available-in-comfyui | Medium | FLF now native in Wan2.7 — may simplify the builder |
+| build_wan_animate_video | Wan2.2 | Partial | Wan2.7 | https://comfyui.org/en/wan27-is-now-available-in-comfyui | Medium | Wan2.7 5-image multi-reference improves animate consistency |
+| build_wan_video_blockswap | Wan2.2 | Partial | Wan2.7 + blockswap | https://comfyui.org/en/wan27-is-now-available-in-comfyui | Medium | Blockswap + GGUF combo still needed for 16 GB VRAM |
+| build_wan_video_blockswap_t2v | Wan2.2 | Partial | Wan2.7 + blockswap | https://comfyui.org/en/wan27-is-now-available-in-comfyui | Medium | Same |
+| build_faceswap | ReActor (inswapper_128.onnx) | Partial | HyperSwap 256 + ReActor v0.6.2 | https://huggingface.co/facefusion/models-3.3.0/tree/main | Medium | 2× output resolution; 3 variants (1a/1b/1c); already in ReActor v0.6.2; inswapper still higher identity similarity |
+| build_faceswap_mtb | MTB nodes | Partial | ComfyUI-Faceless (FaceFusion) | https://github.com/jeffy5/comfyui-faceless-node | Medium | FaceFusion pipeline in ComfyUI, includes HyperSwap; evaluate as MTB replacement |
+| build_face_restore | CodeFormer (facerestore_cf) | Partial | facerestore_advanced | https://github.com/flickleafy/facerestore_advanced | Medium | Same models + quality assessment, artifact detection, caching; drop-in node replacement |
+| build_photo_restore | ESRGAN + CodeFormer | Partial | facerestore_advanced + ESRGAN | https://github.com/flickleafy/facerestore_advanced | Medium | Better post-restoration quality gating via 15+ metrics |
+| build_klein_face_detail | Klein + ad-hoc face detection | Partial | ComfyUI v0.23.0 MediaPipe native | https://github.com/Comfy-Org/ComfyUI/pull/14009 | Low | 478-point FaceMesh in core ComfyUI — zero install cost, more precise face detection |
+| build_rembg_v3 | RMBG-2.0 | Partial | RMBG-2.0 + BEN2 selectable | https://huggingface.co/PramaLLC/BEN2 | Low | BEN2 uses Confidence-Guided Matting for better hair; 1.13 GB; add as selectable model |
+| build_rembg_birefnet | BiRefNet-general | Partial | BiRefNet v2 variants (matting/portrait/2K) | https://fal.ai/models/fal-ai/birefnet/v2 | Low | Specialized fine-tunes for hair+portrait; BiRefNet-general remains good default |
+| build_normal_map | DSINE / BAE | Partial | LBM Depth/Normal | https://github.com/1038lab/ComfyUI-LBM | Low | Single-step inference (ICCV 2025 Highlight); simultaneous depth+normal output |
+| build_hunyuan_3d_mesh | Hunyuan3D 2.x | Partial | Hunyuan3D 3.0 (shape-only) | https://docs.comfy.org/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0 | High | Shape-only likely fits 16 GB; texture gen likely exceeds VRAM; Partner Nodes API needed |
+| build_hunyuan_3d_textured | Hunyuan3D 2.x | No | Hunyuan3D 3.0 (texture VRAM risk) | https://docs.comfy.org/tutorials/partner-nodes/hunyuan3d/hunyuan3d-3-0 | High | Full texture pipeline likely needs >16 GB; test with Hunyuan3D-2GP (6-8 GB fork) first |
+| build_txt2img | SDXL / Flux.1 Dev | Stable + options | PixelDiT 1300M, Microsoft Lens 3.8B | https://huggingface.co/Comfy-Org/PixelDiT | Low | Two new native backbones in ComfyUI v0.23.0; not replacements but diversity options |
+| build_qwen_edit | Qwen 2.5 VL edit | Partial | Qwen-Image-Edit 20B (FP8) | https://huggingface.co/Qwen/Qwen-Image-Edit | Medium | Dedicated editing MMDiT; in-image text editing, bilingual; 20B needs FP8/Q8 on 16 GB |
+| build_cogvideo_video | CogVideoX 5B | Partial | CogVideoX1.5 | https://github.com/kijai/ComfyUI-CogVideoXWrapper | Low | Higher resolution I2V variant; GGUF+SageAttention available |
+| build_iclight | IC-Light v1/v2 | Stable | PIXLRelight (watch) | https://github.com/mlfarinha/pixlrelight | High | Physically-based relighting; no ComfyUI node yet; watch for port |
+| build_depth_map_v3 | da3_large.safetensors | Still current | AnyDepth (lightweight alt) | https://github.com/AIGeeksGroup/AnyDepth | Low | DA3 is current; AnyDepth (Jan 2026) is 85% smaller for fast preview mode only |
+| build_supir | SUPIR | Stable | RealRestorer (watch) | https://huggingface.co/RealRestorer/RealRestorer | Low | No ComfyUI node yet; SUPIR remains best-packaged option |
+| build_klein_headswap | Klein Flux2 headswap | Partial | GHOST 2.0 + Ghost2_Comfyui | https://github.com/Holasyb918/Ghost2_Comfyui | Medium | Full head swap (not just face); ComfyUI node available; evaluate for one-shot use |
+| build_colorize | Klein colorize | Stable | — | — | — | No new colorization model or ComfyUI node found this week |
+| build_ddcolor | DDColor | Stable | — | — | — | No DDColor successor released; no changes |
+| build_outpaint | FLUX.1-Fill-Dev | Stable | — | — | — | No improvements over FLUX.1-Fill-Dev for outpaint found this week |
+| build_inpaint_fooocus | Fooocus inpaint | Stable | — | — | — | Moebius could eventually replace; wait for ComfyUI node |
+| build_style_transfer | FLUX.2 Dev | Stable | FLUX.2 multi-reference mature | https://blogs.nvidia.com/blog/rtx-ai-garage-flux-2-comfyui/ | Low | NVIDIA FP8 guide for FLUX.2 multi-ref on RTX 5060 published Jun 2026; production-ready |
+| build_controlnet_gen | ControlNet preprocessors | Stable | — | — | — | No new ControlNet preprocessor releases found this week |
+| build_generate_anything | SDXL / Flux general | Stable | PixelDiT / Lens as alt | — | Low | Same as build_txt2img; new backbones available |
+| build_img2img | SDXL / Flux.1 Dev | Stable | — | — | — | No new img2img-specific model; FLUX.2 multi-ref matures |
+| build_upscale | ESRGAN variants | Stable | NVIDIA RTX VSR (HW-accel) | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | Low | RTX 5060 Ti HW acceleration; 30× faster than software ESRGAN |
+| build_upscale_blend | ESRGAN variants | Stable | NVIDIA RTX VSR | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | Low | Same |
+| build_mochi_video | Mochi 1 (480p) | Stalled | — | — | — | No update since Oct 2024; still 480p preview; consider deprecating |
+| build_framepack_video | FramePack-F1 | Stable | — | — | — | No release since May 2025; monitor lllyasviel/FramePack/releases |
+| build_lut | LUT processor | Stable | — | — | — | No new neural LUT model found |
+| build_color_match | Color matcher | Stable | — | — | — | No new model; stable |
+| build_klein_color_match | Klein color match | Stable | — | — | — | ComfyUI-Flux2Klein-Enhancer adds color anchoring (experimental) |
+| build_layer_blend | Layer blend | Stable | — | — | — | No new blending model |
+| build_detail_hallucinate | ESRGAN + ControlNet | Stable | MediaPipe face detection | https://github.com/Comfy-Org/ComfyUI/pull/14009 | Low | Native face detection from ComfyUI v0.23.0 improves face-targeting |
+| build_frame_assembly | Frame concat | Stable | — | — | — | No changes needed |
+| build_faceswap_model | InsightFace trainer | Stable | — | — | — | No new training approach found |
+| build_save_face_model | ReActor face saver | Stable | — | — | — | ReActor v0.6.x adds FACE_MODEL_NAME output; minor improvement |
+| build_video_reactor | ReActor on video | Stable | HyperSwap (via ReActor v0.6.2) | https://huggingface.co/facefusion/models-3.3.0 | Medium | Same HyperSwap upgrade path as build_faceswap |
+| build_klein_img2img | Klein 4B/9B | Stable | — | — | — | One Node Klein wrapper (convenience); no weight changes |
+| build_klein_img2img_ref | Klein 4B/9B | Stable | ComfyUI-Flux2Klein-Enhancer | https://github.com/capitan01R/ComfyUI-Flux2Klein-Enhancer | Medium | Multi-reference (up to 8 images) + text conditioning enhancement; experimental |
+| build_klein_inpaint | Klein 4B/9B | Stable | — | — | — | No new inpaint-specific Klein node |
+| build_klein_refine | Klein 4B/9B | Stable | — | — | — | No changes |
+| build_klein_repose | Klein 4B/9B | Stable | One Node POSE mode | https://github.com/yanokusnir-ai/one-node-flux-2-klein | Low | Convenience wrapper with POSE mode; same weights |
+| build_klein_scene_img2img | Klein 4B/9B | Stable | — | — | — | No changes |
+| build_klein_blend | Klein 4B/9B | Stable | — | — | — | No changes |
+| build_klein_detail | Klein 4B/9B | Stable | — | — | — | ComfyUI-Flux2Klein-Enhancer adds spatial attention control |
+| build_klein_virtual_tryon | Klein 4B/9B | Stable | — | — | — | No changes |
+| build_klein_generate_object | Klein 4B/9B | Stable | — | — | — | No changes |
+| build_klein_batch_variations | Klein 4B/9B | Stable | ComfyUI-Flux2Klein-Enhancer | https://github.com/capitan01R/ComfyUI-Flux2Klein-Enhancer | Medium | Adds sectioned prompt encoding and mask-based reference filtering |
+| build_klein_auto_inpaint | Klein 4B/9B | Stable | — | — | — | No changes |
+| build_klein_sam3_inpaint | Klein 4B/9B + SAM 2 | Partial | SAM 3.1 upstream | https://huggingface.co/facebook/sam3.1 | Medium | SAM 3.1 text prompts make the segment step easier; upstream dep |
+| build_sam3_mask | SAM 2 | No | SAM 3.1 | https://huggingface.co/facebook/sam3.1 | Medium | Listed above |
+| build_rembg | RMBG-2.0 | Stable | — | — | — | RMBG-2.0 remains current; no v3 from BRIA |
+| build_iclight | IC-Light | Stable | PIXLRelight (watch) | https://github.com/mlfarinha/pixlrelight | High | Watch |
+| build_lumina2_txt2img | Lumina 2 | Stable | — | — | — | No new Lumina release found this week |
+| build_photobooth | IP-Adapter / PuLID-Enhanced | No — fork dead | balazik/ComfyUI-PuLID-Flux | https://github.com/balazik/ComfyUI-PuLID-Flux | Low | Same migration as build_faceid_img2img |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+Items that can be adopted with minimal risk and directly replace a current component.
+
+### 1. Moebius 0.22B — Drop-in Inpainting Backbone
+**Affects:** `build_inpaint`, `build_magic_eraser`, `build_lama_remove`  
+**Source:** https://huggingface.co/hustvl/Moebius | Paper: https://huggingface.co/papers/2606.19195  
+**Release:** June 18, 2026 (ECCV 2026)  
+A 0.22B model matching FLUX.1-Fill-Dev (11.9B) across 6 benchmarks (Places2, CelebA-HQ, FFHQ). 26 ms/step on a single GPU. Apache 2.0. No ComfyUI node as of June 28, but demo Space exists at `multimodalart/Moebius`; community port expected within days. When the node lands: replace FLUX.1-Fill-Dev in `build_inpaint` and LaMa in `build_lama_remove`. Fits easily in 16 GB VRAM.
+
+### 2. PuLID Flux2 v0.6.2 — Klein Auto-Detection
+**Affects:** `build_pulid_flux`  
+**Source:** https://github.com/iFayens/ComfyUI-PuLID-Flux2 | HF: https://huggingface.co/Fayens/Pulid-Flux2  
+**Release:** May 22, 2026 (v0.6.2)  
+Adds native Klein 4B/9B/Dev auto-detection; improved face recognition; fewer artifacts. Straightforward node update — same workflow graph, better output. No VRAM increase.
+
+### 3. Migrate off ComfyUI-PuLID-Flux-Enhanced (discontinued)
+**Affects:** `build_faceid_img2img`, `build_photobooth`  
+**Destination:** https://github.com/balazik/ComfyUI-PuLID-Flux  
+**Reason:** `sipie800/ComfyUI-PuLID-Flux-Enhanced` formally discontinued; last update Feb 12, 2026. The maintained fork (`balazik/ComfyUI-PuLID-Flux`) is drop-in compatible. No model weight changes needed.
+
+### 4. SAM 3.1 — Text-Prompt Segmentation
+**Affects:** `build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract`, upstream dependency of `build_klein_sam3_inpaint`  
+**Source:** https://huggingface.co/facebook/sam3.1 | Mirror: https://huggingface.co/Comfy-Org/sam3.1  
+**Release:** March 27, 2026  
+Major capability leap: accepts text prompts (short noun phrases) and image exemplars instead of point/box only. SAM 3.1 "Object Multiplex" adds shared-memory multi-object tracking at 7× lower GPU memory per object. Transforms the segment/mask/extract builders from point-driven to text-driven workflows. Weights are gated on Meta HF but Comfy-Org mirror is available. Fits 16 GB at FP16 (~8-10 GB for encoder).
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+Items requiring a new node pack or significant workflow rework, but clearly wire-ready.
+
+### 5. LTX-2.3 22B — Complete LTX Architecture Upgrade
+**Affects:** `build_ltx_video`  
+**Source:** https://huggingface.co/Lightricks/LTX-2.3 | GGUF: https://huggingface.co/unsloth/LTX-2.3-GGUF  
+**Nodes:** https://github.com/Lightricks/ComfyUI-LTXVideo  
+**Release:** March 5, 2026  
+Complete architecture change from LTX-Video 0.9.x: 22B DiT generating synchronized audio+video, up to 4K/50fps, new VAE. FP8 or GGUF Q4 is required for 16 GB VRAM (confirmed working). `build_ltx_video` must be rewritten for the new loader/node structure. Also: ComfyUI v0.26.0 (June 23, 2026) adds a native `LTX2 Context Windows` node for IC-LoRA guide splicing.
+
+### 6. SeedVR2 v2.5 — Video Upscale GGUF Edition (Breaking)
+**Affects:** `build_seedvr2_video_upscale`  
+**Source:** https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler | Weights: https://huggingface.co/numz/SeedVR2_comfyUI  
+**Release:** November 7, 2025  
+Node structure completely redesigned: 4-node modular system replaces single giant node. 60% VRAM reduction (7B now runs on 8 GB with GGUF Q4). Old workflows must be rebuilt. Quality: improved lab color correction, better temporal consistency. High priority given the breaking change — the sooner `build_seedvr2_video_upscale` adopts v2.5, the less technical debt accrues.
+
+### 7. SeedVR2 Paper — build_seedv2r Upgrade
+**Affects:** `build_seedv2r`  
+**Source:** https://huggingface.co/ByteDance-Seed/SeedVR2-3B | 7B: https://huggingface.co/ByteDance-Seed/SeedVR2-7B  
+**Paper:** https://huggingface.co/papers/2506.05301 (June 5, 2026, ICLR 2026 accepted)  
+The paper codifies the full SeedVR2 architecture (one-step adversarial post-training + adaptive window attention + feature matching loss). 3B model fits 16 GB comfortably. 7B needs BF16 variant (`SassyDiffusion/SeedVR2-7B_BF16`). Community v2.5 workflow already established on RunComfy.
+
+### 8. Wan2.7 14B — Upgrade for All WAN Builders
+**Affects:** `build_wan_video`, `build_wan22_t2v`, `build_wan_flf`, `build_wan_animate_video`, `build_wan_video_blockswap`, `build_wan_video_blockswap_t2v`  
+**Source:** https://comfyui.org/en/wan27-is-now-available-in-comfyui | Weights: ModelScope (not HF)  
+**Release:** April 22, 2026  
+Adds native audio, 5-image multi-reference, built-in FLF generation. 14B — needs GGUF Q4 + blockswap for 16 GB VRAM at 720p (~10-15 min inference). Community GGUF quantizations available on HF. Wan2.7 integrates FLF natively which may allow simplification of `build_wan_flf`.
+
+### 9. HunyuanVideo-1.5 8.3B — Consumer-Friendly Upgrade
+**Affects:** `build_hunyuan_video`  
+**Source:** https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5 | HF: https://huggingface.co/tencent/HunyuanVideo-1.5  
+**Release:** November 21, 2025 (I2V distilled: December 5, 2025)  
+8.3B vs original 13B — better 16 GB headroom, 1.87× speedup. Step-distilled I2V generates in 8–12 steps (75% time reduction). Better choice than original HunyuanVideo for the RTX 5060 Ti budget.
+
+### 10. FlashVSR v1.1 — Diffusion-Based Video Super-Resolution
+**Affects:** `build_video_upscale`, `build_wavespeed_upscale`  
+**Source:** https://github.com/1038lab/ComfyUI-FlashVSR | Stable fork: https://github.com/naxci1/ComfyUI-FlashVSR_Stable  
+**Paper:** arXiv:2510.12747 (CVPR 2026)  
+One-step real-time VSR using locality-constrained sparse attention. Multiple ComfyUI ports exist. "Tiny Long" low-VRAM mode and tiling available. Caution: ports lacking the locality-constrained sparse attention show quality degradation — use 1038lab (mainstream) or naxci1 (VRAM-optimized) variants.
+
+### 11. NVIDIA RTX VSR Node — Hardware-Accelerated Upscaling
+**Affects:** `build_video_upscale`, `build_upscale`, `build_upscale_blend`  
+**Source:** https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI  
+**Last updated:** March 22, 2026  
+TensorRT-accelerated 4K upscaling on RTX 5060 Ti. 30× faster than ESRGAN. Two-pass (denoise + upscale) available. Deno2026 custom nodes v0.7.64 (June 26, 2026) includes enhanced wrapper with 4 effect modes. Zero-cost given existing RTX hardware.
+
+### 12. HyperSwap 256 — Higher Resolution Face Swap
+**Affects:** `build_faceswap`, `build_video_reactor`  
+**Source:** https://huggingface.co/facefusion/models-3.3.0/tree/main  
+**Nodes:** Already in ReActor v0.6.2 (released April 25, 2025); adoption peaking June 2026  
+Three 256px variants (1a/1b/1c) vs inswapper's 128px. 2× output face resolution. Download models into `ComfyUI/models/hyperswap/` — no node change needed. Note: inswapper retains higher identity similarity; HyperSwap trades some fidelity for resolution. Test 1a/1b/1c variants to find the right tradeoff.
+
+### 13. ReActor v0.6.x — Restore Face Advanced Node
+**Affects:** `build_faceswap`, `build_face_restore`, `build_video_reactor`  
+**Source:** https://github.com/Gourieff/ComfyUI-ReActor  
+**Release:** v0.6.0 May 21, 2025; v0.6.2 April 25, 2025  
+New nodes: `Restore Face Advanced` (apply restoration only to swapped faces — directly improves `build_faceswap` CodeFormer post-processing), `ReActorSetWeight` (0–100% face swap strength), `ReActorMaskHelper`, `ReActorImageDuplicator`. No longer requires InsightFace C++ build tools.
+
+### 14. ComfyUI v0.23.0 — MediaPipe Face Detection Native
+**Affects:** `build_klein_face_detail`, `build_face_restore`, `build_photo_restore`, `build_detail_hallucinate`  
+**Source:** https://github.com/Comfy-Org/ComfyUI/pull/14009  
+**Release:** June 1, 2026  
+Dependency-free 478-point FaceMesh (3D landmarks), BlazeFace detectors, FaceBlendshapes, ComfyUI nodes — all distributed as safetensors. Zero install cost (in ComfyUI core). Provides more accurate face detection masks than YOLO/RetinaFace.
+
+### 15. BEN2 — Better Hair/Edge Background Removal
+**Affects:** `build_rembg_v3`  
+**Source:** https://huggingface.co/PramaLLC/BEN2 | https://github.com/PramaLLC/BEN2  
+Confidence-Guided Matting pipeline; refiner network targets low-confidence pixels. 1.13 GB model, 1080p in ~6 seconds. Already supported in ComfyUI-RMBG alongside RMBG-2.0. Add as selectable model if not already present.
+
+### 16. Deno2026 Custom Nodes v0.7.64 (June 26, 2026 — in window)
+**Affects:** `build_video_upscale`, `build_ltx_video`, `build_upscale`, `build_upscale_blend`  
+**Source:** https://github.com/Deno2026/comfyui-deno-custom-nodes  
+**Release:** June 26, 2026  
+In-window release. Contains: RTX VSR enhanced wrapper (4 modes, Low–Ultra quality), LTX-2.3 tiled spatial upscaler/loader, video comparison nodes, LTX-2.3 reference utilities. Low adoption risk.
+
+### 17. GHOST 2.0 + Ghost2_Comfyui Node
+**Affects:** `build_klein_headswap`  
+**Source:** https://github.com/ai-forever/ghost-2.0 | ComfyUI: https://github.com/Holasyb918/Ghost2_Comfyui  
+**Paper:** https://huggingface.co/papers/2502.18417 (Feb 2025)  
+Full head swap (not just face): Aligner module for reenactment + Blender for seamless integration with skin color transfer. ComfyUI node is unofficial but available. Alternative to Klein Flux2 for one-shot head swap scenarios. Fits 16 GB.
+
+### 18. facerestore_advanced Node
+**Affects:** `build_face_restore`, `build_photo_restore`  
+**Source:** https://github.com/flickleafy/facerestore_advanced  
+Drop-in replacement for `facerestore_cf` node. Same CodeFormer/GFPGAN models; adds 15+ quality metrics (SSIM, artifact detection, skin texture), automatic model fallback, CodeFormer fidelity control. Medium confidence (0.72) — test fallback logic in batch workflows first.
+
+### 19. CogVideoX1.5 — Higher Resolution I2V
+**Affects:** `build_cogvideo_video`  
+**Source:** https://github.com/kijai/ComfyUI-CogVideoXWrapper  
+CogVideoX1.5-5B with higher resolution + I2V variant; GGUF, tiled encoding, SageAttention support via kijai wrapper. Low-risk upgrade if builder targets base CogVideoX.
+
+### 20. Qwen-Image-Edit 20B — Open-Sourced (June 2026)
+**Affects:** `build_qwen_edit`  
+**Source:** https://huggingface.co/Qwen/Qwen-Image-Edit | Nodes: https://github.com/lrzjason/Comfyui-QwenEditUtils  
+**Release:** June 2026  
+Dedicated editing MMDiT: bilingual text editing in-image, semantic + appearance editing, preserves font/size/style. 20B at FP8 is tight on 16 GB — may need CPU offload. Lighter alternative: Qwen-Image-2.0 7B (Feb 2026) runs comfortably.
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+| Item | Affects | Blocker | URL |
+|------|---------|---------|-----|
+| PIXLRelight (May 2026) | build_iclight | No ComfyUI node; runs standalone | https://github.com/mlfarinha/pixlrelight |
+| EditCrafter (Apr 2026, CVPRW) | build_img2img, build_qwen_edit | Research code only | https://github.com/EditCrafter/EditCrafter |
+| SpectrumKSampler v0605 | All DiT builders | Currently tuned for Anima DiT only; errors on SDXL/Flux | https://github.com/sorryhyun/ComfyUI-Spectrum-KSampler |
+| RealRestorer (Mar 2026) | build_supir | No ComfyUI node yet | https://huggingface.co/RealRestorer/RealRestorer |
+| NTIRE 2026 face restoration teams | build_face_restore, build_detail_hallucinate | Weights not yet all public; research prototype | https://huggingface.co/papers/2604.10532 |
+| One-Shot Video Head Swap (Ji et al., Jun 2025) | build_klein_headswap | Paper only; no weights/node | https://huggingface.co/papers/2506.16852 |
+| ComfyUI-Flux2Klein-Enhancer | build_klein_img2img_ref, build_klein_color_match | Experimental (197 commits, no stable tags) | https://github.com/capitan01R/ComfyUI-Flux2Klein-Enhancer |
+| AnyDepth (Jan 2026) | build_depth_map_v3 | DA3 still current; AnyDepth is a faster/lighter alternative only | https://github.com/AIGeeksGroup/AnyDepth |
+| Hunyuan3D 3.1 (rumored) | build_hunyuan_3d_* | Unconfirmed open weights; VRAM unknown | vset3d.com (low confidence) |
+| SeeDance 2.5 (Jun 23, 2026) | None (API-only) | No local weights; ByteDance cloud only | https://blog.comfy.org |
+| HappyHorse 1.1 (Jun 23, 2026) | None (API-only) | Alibaba Cloud API only | https://technode.com/2026/06/23 |
+| One Node FLUX.2 Klein (Jun 18, 2026) | Klein family (convenience) | Convenience wrapper; not a model upgrade | https://github.com/yanokusnir-ai/one-node-flux-2-klein |
+| LBM Depth/Normal (May 2025, mature) | build_normal_map | Lower priority — current setup functional | https://github.com/1038lab/ComfyUI-LBM |
+| BiRefNet v2 matting/portrait/2K | build_rembg_birefnet | Fine-tune variants; current general model adequate | https://fal.ai/models/fal-ai/birefnet/v2 |
+
+---
+
+## No-finds (verified)
+
+The following builders were checked and no new relevant models, node packs, or LoRAs were found for the June 21–28, 2026 window:
+
+| Builder | Verdict |
+|---------|---------|
+| build_mochi_video | Stalled — Mochi 1 still at 480p preview (Oct 2024); no update. Consider deprecating. |
+| build_framepack_video | No release since FramePack-F1 / FramePack-P1 (2025). Monitor lllyasviel/FramePack/releases. |
+| build_colorize | No new colorization model. DDColor remains current. |
+| build_ddcolor | No update to DDColor weights. |
+| build_lut | No new neural LUT model. |
+| build_color_match | No update. |
+| build_outpaint | No improvements over FLUX.1-Fill-Dev found. |
+| build_inpaint_fooocus | Stable; Moebius may eventually replace but await ComfyUI node. |
+| build_controlnet_gen | No new ControlNet preprocessors released this week. |
+| build_layer_blend | No new blending model. |
+| build_depth_map_v3 | da3_large.safetensors is current (DA3, ICLR 2026 Oral); no new checkpoint. |
+| build_supir | No update to SUPIR model weights. |
+| build_lumina2_txt2img | No new Lumina 2 release found. |
+| build_iclight | IC-Light stable; PIXLRelight is a future upgrade path (Tier 3). |
+| build_klein_img2img | Klein weights unchanged; One Node wrapper is a convenience tool only. |
+| build_klein_inpaint | No changes. |
+| build_klein_refine | No changes. |
+| build_klein_virtual_tryon | No changes. |
+| build_klein_generate_object | No changes. |
+| build_klein_auto_inpaint | No changes. |
+| build_rembg | RMBG-2.0 current; no BRIA v3. |
+| build_faceswap_model | No new training approach found. |
+| build_save_face_model | Minor: ReActor v0.6.x adds FACE_MODEL_NAME output. |
+| build_2d_to_sbs / build_2d_to_sbs_extreme | Not listed in target builders; no changes noted. |
+
+---
+
+*Report generated by automated SOTA review agent. No implementation upgrades were made — all changes require local node-pack installs. The nightly ComfyUI workflow snapshot export at `tools/export_comfyui_workflows.py` will refresh workflow JSON snapshots automatically after local installs.*


### PR DESCRIPTION
## Summary

First daily SOTA review — ISO week `2026-W26`. Adds `_dev_docs/upgrade_research/2026-W26.md` and `2026-W26.json`. No prior punch list (first run).

Hardware budget: RTX 5060 Ti, 16 GB VRAM.

---

## Findings at a glance

| Tier | Count | Description |
|------|-------|-------------|
| Tier 1 — drop-in supersessions | 4 | Ship these soon |
| Tier 2 — additive new builders | 20 | Needs node-pack install |
| Tier 3 — monitor / not wire-ready | 14 | Research prototypes or API-only |
| No-finds (verified stable) | 24 | No action needed |

---

## Tier 1 — Drop-in supersessions (ship soon)

| Item | Builder(s) | Notes |
|------|-----------|-------|
| **Moebius 0.22B** (ECCV 2026, Jun 18) | `build_inpaint`, `build_magic_eraser`, `build_lama_remove` | 54× smaller than FLUX.1-Fill-Dev; matches it on 6 benchmarks. No ComfyUI node yet — expected within days |
| **ComfyUI-PuLID-Flux2 v0.6.2** (May 22) | `build_pulid_flux` | Native Klein 4B/9B/Dev auto-detection; fewer artifacts. Drop-in node update |
| **Migrate off PuLID-Flux-Enhanced** (discontinued Feb 2026) | `build_faceid_img2img`, `build_photobooth` | Fork is dead — migrate to `balazik/ComfyUI-PuLID-Flux` |
| **SAM 3.1** (Mar 27, 2026) | `build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract`, `build_klein_sam3_inpaint` (upstream) | Text-prompt segmentation, 7× faster multi-object tracking. Weights at `Comfy-Org/sam3.1` mirror |

## Tier 2 — Additive new builders (node-pack install required)

Key items (see full MD for all 20):

- **LTX-2.3 22B** — complete rework of `build_ltx_video`; audio+video+4K; FP8/GGUF Q4 fits 16 GB
- **SeedVR2 v2.5** — `build_seedvr2_video_upscale` must be rebuilt (breaking node change; now 8 GB VRAM viable)
- **SeedVR2 3B/7B** (ICLR 2026) — `build_seedv2r` direct successor; one-step inference
- **Wan2.7 14B** — all WAN builders; adds audio + 5-image multi-ref + native FLF; needs GGUF+blockswap on 16 GB
- **HunyuanVideo-1.5** — `build_hunyuan_video`; 8.3B, 1.87× speedup, better 16 GB headroom
- **FlashVSR v1.1** (CVPR 2026) — `build_video_upscale`; one-step diffusion VSR
- **NVIDIA RTX VSR Node** — `build_video_upscale`/`build_upscale`; 30× faster than ESRGAN on RTX 5060 Ti
- **HyperSwap 256** — `build_faceswap`; 2× face resolution; already in ReActor v0.6.2
- **SAM 3.1 text prompts** — see Tier 1 for builds_sam3_*
- **ComfyUI v0.23.0 MediaPipe** — native 478-point FaceMesh in core; improves `build_klein_face_detail`, `build_face_restore`
- **Qwen-Image-Edit 20B** (Jun 2026 open-source) — `build_qwen_edit`; FP8 needed on 16 GB

## Tier 3 — Monitor / not wire-ready

PIXLRelight (no ComfyUI node), EditCrafter (research code), SpectrumKSampler (DiT-only), RealRestorer (no node), NTIRE 2026 face restoration teams, SeeDance 2.5 / HappyHorse 1.1 (cloud-only API). Full list in the MD.

## Notable no-finds

- **Mochi 1** — stalled at 480p preview since Oct 2024. Consider deprecating `build_mochi_video`.
- **FramePack** — no release since 2025. Monitor lllyasviel/FramePack/releases.
- **DDColor, SUPIR, LaMa, DA3** — no updates; current weights remain current.

---

> **DO NOT MERGE** — leave open for human review.
>
> The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically after any local node-pack installs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQbBrfnQtnMuWDGbBb7iAW)_