### PR TITLE
chore(research): daily SOTA review 2026-07-03

### DIFF
--- a/_dev_docs/upgrade_research/2026-W27.json
+++ b/_dev_docs/upgrade_research/2026-W27.json
@@ -1,0 +1,282 @@
+[
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Krea 2 Turbo FP8 (12B DiT, Qwen3-VL encoder)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/krea/Krea-2-Turbo",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "Biggest model release this cycle. Needs new backbone in architectures.py + new build_krea2_txt2img and build_krea2_img2img. ComfyUI 0.26+ required. vladmandic uint4 quant also on HF (krea/Krea-2-Raw for LoRA training target). Tier 3 — significant arch work needed."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "FLUX.2-dev INT8 tensorwise",
+    "source": "huggingface",
+    "url": "https://huggingface.co/LAXMAYDAY/FLUX.2-dev-int8-tensorwise",
+    "risk": "low",
+    "confidence": 0.7,
+    "notes": "Created July 3, 2026. Drop-in VRAM-saver for FLUX.2-dev path. Zero downloads/likes — treat as provisional. No code change needed; model weight swap only. Monitor for adoption."
+  },
+  {
+    "method": "build_txt2img,build_img2img,build_inpaint,build_klein_img2img,build_klein_inpaint",
+    "category": "checkpoint",
+    "name": "FLUX.2-small-decoder (fast VAE decode for all FLUX.2/Klein)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
+    "risk": "low",
+    "confidence": 0.9,
+    "notes": "Released April 6, 2026; 196K downloads. Faster VAE decode at slight quality tradeoff. Add vae_fast=True flag to load_model_stack(). TIER 1 — ship soon."
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "IC-Light V2 (Flux-based, 16-channel VAE)",
+    "source": "github",
+    "url": "https://github.com/lllyasviel/IC-Light/discussions/98",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Announced January 29, 2026. Flux architecture dramatically improves photoreal relighting vs SD1.5 v1. Foreground-conditional model available. fal.ai has deployed endpoint. Needs build_iclight_v2 + ComfyUI-IC-Light-Native node. Keep build_iclight (SD1.5) for stylized cases. TIER 2."
+  },
+  {
+    "method": "build_kontext_img_edit",
+    "category": "checkpoint",
+    "name": "FLUX.1 Kontext dev (reference-image instruction editing)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Architecture already registered as flux_kontext in architectures.py. Missing: build_kontext_img_edit builder surfacing FluxKontextImageScale + reference latent injection. worksimpli/FLUX.1-Kontext-img-edit confirms the node pattern. Low risk — no arch changes needed. TIER 2."
+  },
+  {
+    "method": "build_klein_img2img_ref,build_klein_headswap,build_klein_virtual_tryon",
+    "category": "checkpoint",
+    "name": "FLUX.2-Klein-9B-KV (2.5x faster multi-reference via KV cache)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv",
+    "risk": "medium",
+    "confidence": 0.9,
+    "notes": "Released March 9, 2026; 10.8K downloads; FP8 variant also on HF. Needs Flux2KleinKVPipeline new arch key in architectures.py and separate loader path. vladmandic uint4 quants created July 1, 2026. TIER 3 — 1-2 weeks."
+  },
+  {
+    "method": "build_supir,build_upscale",
+    "category": "node_pack",
+    "name": "PiD — Pixel Diffusion Decoder (NVIDIA, CVPR 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/nvidia/PiD",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Paper arXiv 2605.23902; HF checkpoint June 2, 2026. Generative VAE decode: 8 denoising steps in pixel space, 4x (512→2048) or 8x output. ComfyUI-PiD node available. 2K fits 16 GB (~13 GB peak); 4K will OOM. New build_pid_decode builder; best as quality-upgrade step after build_supir. TIER 2."
+  },
+  {
+    "method": "build_sam3_segment,build_sam3_mask,build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1 Multiplex (Meta, native ComfyUI PR #13408)",
+    "source": "github",
+    "url": "https://ai.meta.com/blog/segment-anything-model-3/",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Released March 27, 2026. Checkpoint: sam3.1_multiplex_fp16.safetensors. New SAM3_Detect, SAM3_VideoTrack, SAM3_TrackToMask nodes natively in ComfyUI. Update default checkpoint name in builders. TIER 1 — ship soon."
+  },
+  {
+    "method": "build_face_restore,build_photo_restore,build_klein_face_detail",
+    "category": "lora",
+    "name": "IConFace — reference-aware face restoration LoRA on Klein-base-4B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/zhangjinyang/IConFace",
+    "risk": "medium",
+    "confidence": 0.9,
+    "notes": "Paper arXiv 2605.02814, May 4, 2026. iconface_lora.safetensors, LoRA rank 16. Two modes: blind restoration and reference-aware (1-3 ref images). ComfyUI node: github.com/cosmicrealm/ComfyUI-Flux-FaceIR. Reference-aware mode unique — no equivalent in current stack. New build_klein_face_restore builder. TIER 2."
+  },
+  {
+    "method": "build_faceswap,build_faceswap_model",
+    "category": "checkpoint",
+    "name": "HyperSwap 256 ONNX models (FaceFusion Labs, in ReActor)",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "256px vs 128px for inswapper. hyperswap_1a/1b/1c_256.onnx in ComfyUI/models/hyperswap/. Issue #183 (broken) filed — stability uncertain. Document as swap_model option; no code change. Recommend 1b variant. TIER 2."
+  },
+  {
+    "method": "build_faceswap,build_faceswap_model",
+    "category": "checkpoint",
+    "name": "ReSwapper 128/256 (somanchiu, open-licensed, in ReActor)",
+    "source": "github",
+    "url": "https://github.com/somanchiu/ReSwapper",
+    "risk": "low",
+    "confidence": 0.8,
+    "notes": "Open-source reproduction of inswapper architecture. reswapper_128.onnx / reswapper_256.onnx. Weaker identity similarity than inswapper_128 but open-licensed. Drop-in swap_model param value. TIER 1."
+  },
+  {
+    "method": "build_face_restore,build_photo_restore",
+    "category": "checkpoint",
+    "name": "GPEN-BFR-512 / GPEN-BFR-1024 (in ReActor May 2026)",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "ReActor May 12, 2026 update. Drop GPEN-BFR-512.onnx / GPEN-BFR-1024.onnx in models folder. Better face similarity than CodeFormer in many cases. Already usable via model_name param — no code change needed. Document in docstrings. TIER 1."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 (Lightricks, full architecture replacement of 0.9.x)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "LTX-2 released Jan 6, 2026; LTX-2.3 March 5, 2026 (Apache 2.0). Joint audio+video, built-in spatial/temporal latent upscalers, up to 4K/50FPS/20s. Kijai FP8 comfy weights: huggingface.co/Kijai/LTX2.3_comfy. GGUF Q4 also available. New build_ltx2_video builder; keep build_ltx_video for 0.9.x compat. TIER 2."
+  },
+  {
+    "method": "build_wan_video,build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "WAN 2.7 (Alibaba, 14B MoE, audio-driven, multi-person)",
+    "source": "github",
+    "url": "https://github.com/Wan-Video/Wan2.7",
+    "risk": "medium",
+    "confidence": 0.9,
+    "notes": "Cloud release April 22, 2026; open weights May 20, 2026 (Apache 2.0, Wan-AI/Wan2.7-T2V-14B on ModelScope). Up to 5 reference persons, vocal timbre input, audio-driven. FP8/GGUF Q4 for 16 GB. ComfyUI partner nodes are cloud API — local needs manual weight pull. New build_wan27_video builder. TIER 3 — 2-4 weeks."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "lora",
+    "name": "WAN 2.2 Lightning 4-step distillation",
+    "source": "huggingface",
+    "url": "https://huggingface.co/lightx2v/Wan2.2-Lightning",
+    "risk": "low",
+    "confidence": 0.9,
+    "notes": "4-step distilled WAN 2.2 variant. Same VRAM as base WAN 2.2. Existing WAN 2.2 ComfyUI nodes work. Add lightning=True / steps=4 + checkpoint name to build_wan22_t2v. TIER 1."
+  },
+  {
+    "method": "build_hunyuan_video",
+    "category": "checkpoint",
+    "name": "HunyuanVideo 1.5 (8.3B params, 14 GB VRAM, fits RTX 5060 Ti cleanly)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tencent/HunyuanVideo-1.5",
+    "risk": "medium",
+    "confidence": 0.9,
+    "notes": "Released November 21, 2025. 8.3B params down from 13B. 14 GB VRAM — fits 16 GB without quantization. Repacks: 3loso3/ and LawrenceBoudreau/ on HF. SOTA visual quality at release. Node compat check recommended before flagging as Tier 1. TIER 1 (pending local verification)."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "checkpoint",
+    "name": "SeedVR2 v2.5 (ICLR 2026, 60% VRAM reduction, 3B/7B variants)",
+    "source": "github",
+    "url": "https://github.com/IceClear/SeedVR2",
+    "risk": "medium",
+    "confidence": 0.9,
+    "notes": "ICLR 2026 accepted. 60% VRAM reduction vs v1. FP8 and GGUF Q4/Q8 quantizations. Breaking node-layout change — workflows must be recreated. ComfyUI node: github.com/numz/ComfyUI-SeedVR2_VideoUpscaler. TIER 3 — breaking change requires workflow rebuild."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "RealRestorer (StepFun, 9 degradation types, DiT-based)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Paper arXiv 2603.25502, March 26, 2026. Handles blur, rain, reflection, low-light, denoising, haze, moire, flare, compression. Based on Step1X-Edit DiT + Flux-VAE. Fixed 1024×1024. No ComfyUI node exists yet — would need to write one. New build_realrestorer builder. TIER 3."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "BFS-Best-Face-Swap Head V5 LoRA (Qwen-Image-Edit-2511 + Klein)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/chfm/BFS-Best-Face-Swap",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Created June 8, 2026. Head V5 on Qwen-2511 is recommended tier. Multiple LoRA variants: Face V1, Head V1-V5. Better lighting/tone consistency than ONNX swapper approach. Generative (not pixel-faithful) — different tradeoff than current build_klein_headswap. Validate quality before wiring. TIER 3."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "checkpoint",
+    "name": "FlashVSR v1.1 (CVPR 2026, streaming-capable diffusion upscaler)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1",
+    "risk": "low",
+    "confidence": 0.9,
+    "notes": "v1.1 with temporal stability improvements; CVPR 2026 accepted. One-step diffusion with locality-constrained sparse attention; streaming per-frame mode for low VRAM. ComfyUI nodes: ComfyUI_FlashVSR, ComfyUI-FlashVSR_Ultra_Fast, WaveSpeed node. New build_flashvsr_upscale builder. TIER 2."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX Video Super Resolution (ComfyUI official partner node)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.9,
+    "notes": "NVIDIA GDC announcement late June 2026 (within 7-day window). Tensor-core acceleration; 30x faster than diffusion upscalers; perfect for RTX 5060 Ti; zero VRAM overhead for upscale step. Clarity/artifact correction only — no detail synthesis. New build_rtx_upscale builder or fast-mode flag on build_video_upscale. TIER 2."
+  },
+  {
+    "method": "build_wan22_s2v",
+    "category": "checkpoint",
+    "name": "WAN 2.2 Sound/Speech-to-Video (WanSoundImageToVideo node)",
+    "source": "github",
+    "url": "https://docs.comfy.org/tutorials/video/wan/wan2-2-s2v",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "Native ComfyUI support; WanSoundImageToVideo node. wan2.2_s2v_14B_fp8_scaled.safetensors at 12-14 GB VRAM. New modality: audio-driven talking-head video from static image + audio clip. New build_wan22_s2v builder. TIER 2."
+  },
+  {
+    "method": "build_skyreels_v3",
+    "category": "checkpoint",
+    "name": "SkyReels-V3 R2V-14B / V2V-14B (WanPipeline-based, multi-subject ref)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Skywork/SkyReels-V3-R2V-14B",
+    "risk": "medium",
+    "confidence": 0.8,
+    "notes": "Released January 29, 2026 (Apache 2.0). R2V (Reference-to-Video, 1-4 ref images) and V2V at 14B fit 16 GB via GGUF. A2V at 19B is borderline. VACE_SkyReels_V3_R2V_Merge GGUF (902 downloads) compatible with WAN BlockSwap infrastructure. New build_skyreels_v3 builder. TIER 3."
+  },
+  {
+    "method": "build_facefusion",
+    "category": "node_pack",
+    "name": "FaceFusion 3.7.0 (HyperSwap-based, multi-frame-aware)",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Released June 30, 2026 (within 7-day window). v3.7.0 adds multi-frame-aware processors, auto face-selector, CoreML perf. Uses HyperSwap 256 as default swapper. Unofficial ComfyUI node: github.com/huygiatrng/Facefusion_comfyui. New build_facefusion builder (separate from build_faceswap). TIER 3."
+  },
+  {
+    "method": "build_canonswap_video",
+    "category": "checkpoint",
+    "name": "CanonSwap — video face swap via canonical space modulation (paper)",
+    "source": "huggingface",
+    "url": "https://hf.co/papers/2507.02691",
+    "risk": "high",
+    "confidence": 0.95,
+    "notes": "Paper published July 3, 2026 (today). Temporal consistency via canonical space decoupling. Project: luoxyhappy.github.io/CanonSwap/. No weights, no ComfyUI node. Would be first video face swap builder in Spellcaster. Watch for weights release in 4-8 weeks. TIER 3."
+  },
+  {
+    "method": "build_topaz_upscale",
+    "category": "node_pack",
+    "name": "Topaz Astra 2 + Bloom (official ComfyUI partner nodes)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/topazs-flagship-upscale-models-in",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Official ComfyUI partner integration. Astra 2 tuned for GenAI video; Bloom for 8K image + face enhancement. Requires Topaz Video AI license (paid). New build_topaz_upscale builder. TIER 3 — requires license."
+  },
+  {
+    "method": "build_sama_matte",
+    "category": "checkpoint",
+    "name": "SAMA — Segment and Matte Anything (Walmart Tech, paper only)",
+    "source": "huggingface",
+    "url": "https://hf.co/papers/2601.12147",
+    "risk": "medium",
+    "confidence": 0.45,
+    "notes": "Paper January 17, 2026. Simultaneous segmentation mask + alpha matte from text prompt, no trimap. No public weights, no ComfyUI node. Would enable new build_sama_matte builder. Monitor for weights release. TIER 3 — paper only."
+  },
+  {
+    "method": "build_depth_map_v3,build_sam3_segment,build_normal_map",
+    "category": "checkpoint",
+    "name": "Vision Banana (Google DeepMind — closed source, not locally usable)",
+    "source": "github",
+    "url": "https://vision-banana.github.io/",
+    "risk": "high",
+    "confidence": 0.08,
+    "notes": "Paper arXiv 2604.20329, April 22, 2026. Single model beats SAM 3 on segmentation, DA3 on metric depth. Closed source — Google API/AI Studio only. No local weights. Not actionable. Watch for open weights. TIER 3 — blocked."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W27.md
+++ b/_dev_docs/upgrade_research/2026-W27.md
@@ -1,0 +1,253 @@
+# Spellcaster daily SOTA review — 2026-07-03
+
+ISO week: `2026-W27`. Baseline: N/A — first run (no prior file in `_dev_docs/upgrade_research/`).
+
+Survey window: **June 26 – July 3, 2026** (strict 7 days), plus high-priority pre-window items not yet in the codebase.
+Hardware constraint: RTX 5060 Ti, 16 GB VRAM — items requiring more are excluded from Tier 1/2 and flagged ❌ VRAM.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / upgrade | Source URL | Risk | Notes |
+|--------|-----------------|-------------|----------------------|-----------|------|-------|
+| build_txt2img (FLUX.2 path) | FLUX.2-dev FP16 | Partial | FLUX.2-dev INT8 tensorwise | https://huggingface.co/LAXMAYDAY/FLUX.2-dev-int8-tensorwise | Low | Drop-in quant; 0 downloads, provisional |
+| build_txt2img / build_img2img | No Krea 2 backbone | — | Krea 2 Turbo FP8 (12B DiT, Qwen3-VL) | https://huggingface.co/krea/Krea-2-Turbo | Medium | Biggest model release this cycle; ComfyUI 0.26+ |
+| build_iclight | IC-Light SD1.5 | No | IC-Light V2 (Flux-based, 16-ch VAE) | https://github.com/lllyasviel/IC-Light/discussions/98 | Medium | V2 dramatically better for photoreal relighting |
+| build_kontext_img_edit | N/A (builder missing) | — | FLUX.1 Kontext ref-image editing | https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev | Low | Arch registered; only builder function missing |
+| build_klein_img2img_ref / build_klein_headswap / build_klein_virtual_tryon | FLUX.2-Klein-9B | Partial | FLUX.2-Klein-9B-KV (2.5× faster) | https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv | Medium | Needs Flux2KleinKVPipeline arch key |
+| build_supir | SUPIR (SDXL-based) | Partial | PiD generative decoder (NVIDIA) | https://huggingface.co/nvidia/PiD | Medium | Additive; 2K fits 16 GB; generative decode paradigm |
+| build_sam3_segment / build_sam3_mask / build_sam3_extract | SAM 3.0 | Partial | SAM 3.1 Multiplex | https://ai.meta.com/blog/segment-anything-model-3/ | Low | Checkpoint name update; faster multi-object tracking |
+| build_face_restore | CodeFormer | Partial | IConFace LoRA on Klein-base-4B | https://huggingface.co/zhangjinyang/IConFace | Low-Med | Reference-aware restoration; Klein path only |
+| build_photo_restore | Upscale + CodeFormer | Partial | IConFace reference-aware mode | https://huggingface.co/zhangjinyang/IConFace | Low-Med | Unique capability: pass clean ref photo |
+| build_faceswap / build_faceswap_model | inswapper_128.onnx | Partial | HyperSwap 256 (256px ONNX) | https://github.com/Gourieff/ComfyUI-ReActor | Medium | In ReActor; stability issue #183 still unclear |
+| build_faceswap | inswapper_128.onnx | Partial | ReSwapper 128/256 (open-licensed) | https://github.com/somanchiu/ReSwapper | Low | Weaker than inswapper but open-licensed; in ReActor |
+| build_ltx_video | LTX 0.9.x | No | LTX-2.3 (full arch replacement) | https://huggingface.co/Lightricks/LTX-2.3 | Medium | Joint audio+video, 4K, 50 FPS; new node graph |
+| build_wan22_t2v | WAN 2.2 | Partial | WAN 2.7 (14B MoE, multi-person + audio) | https://github.com/Wan-Video/Wan2.7 | Medium | Weights on ModelScope; Lightning variant for speed |
+| build_wan_video (all WAN 1.x builders) | WAN 1.x | Partial | WAN 2.7 | https://github.com/Wan-Video/Wan2.7 | Medium | Multi-reference persons, vocal timbre, audio-driven |
+| build_hunyuan_video | HunyuanVideo 13B | Partial | HunyuanVideo 1.5 (8.3B, 14 GB) | https://huggingface.co/tencent/HunyuanVideo-1.5 | Low-Med | Fits RTX 5060 Ti without quantization |
+| build_seedvr2_video_upscale | SeedVR2 v1 | No | SeedVR2 v2.5 (ICLR2026, 60% less VRAM) | https://github.com/IceClear/SeedVR2 | Medium | Breaking node change; 3B/7B variants |
+| build_supir (restore path) | SUPIR single-style | Partial | RealRestorer (9 degradation types, DiT) | https://huggingface.co/RealRestorer/RealRestorer | Medium | No ComfyUI node yet; 1024px fixed |
+| build_klein_headswap | Klein + identity transfer | Partial | BFS-Best-Face-Swap Head V5 LoRA | https://huggingface.co/chfm/BFS-Best-Face-Swap | Medium | Generative approach; better lighting/tone |
+| build_video_upscale | 4x-UltraSharp ESRGAN | Partial | FlashVSR v1.1 (CVPR 2026 diffusion) | https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1 | Low | Streaming-capable; low VRAM; ComfyUI nodes ready |
+| build_video_upscale (fast path) | — | — | NVIDIA RTX VSR (tensor core) | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | Low | 30× faster than diffusion; preview/proxy quality |
+| build_pulid_flux | PuLID Flux | Yes | — | — | — | No updates in window |
+| build_faceid_img2img | InstantID | Yes | — | — | — | Maintenance only (Jun 12 compat update) |
+| build_cogvideo_video | CogVideoX 1.5 | Yes | — | — | — | No new architecture in 2026 Q2 |
+| build_mochi_video | Mochi | Yes | — | — | — | No updates |
+| build_framepack_video | FramePack | Yes | — | — | — | Node updates only; checkpoint unchanged |
+| build_rembg_v3 | RMBG-2.0 | Yes | — | — | — | V-RMBG 3.0 is video-only, API-only |
+| build_depth_map_v3 | DA3 large | Yes | — | — | — | No V4 exists yet |
+| build_normal_map | — | Yes | — | — | — | No updates |
+| build_ddcolor | DDColor artistic | Yes | — | — | — | No updates |
+| build_colorize | Klein/Flux2 | Yes | — | — | — | No updates |
+| build_hunyuan_3d_mesh / build_hunyuan_3d_textured | HunyuanDiT 3D 2.x | Yes (for 16 GB) | Hunyuan3D 3.x | — | ❌ VRAM | 3.x likely >16 GB; no confirmed open weights |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+These require no new ComfyUI node packs — only model file swaps or parameter documentation updates.
+
+### 1. FLUX.2-small-decoder — faster VAE decode for all FLUX.2/Klein builders
+- **Source:** https://huggingface.co/black-forest-labs/FLUX.2-small-decoder
+- **Released:** April 6, 2026 — 196K downloads, 153 likes (high adoption)
+- **What changes:** Replace `vae_name` with `FLUX.2-small-decoder` in `composites.py`'s FLUX.2 path for a fast-decode option. Encoding is unchanged; decoding is faster at a slight quality tradeoff.
+- **Affected builders:** All FLUX.2-dev and FLUX.2-Klein builders
+- **Action:** Add a `vae_fast=True` flag to `load_model_stack()` that swaps the VAE. The existing `flux2-vae` remains the quality default.
+- **Risk:** Low
+
+### 2. SAM 3.1 Multiplex checkpoint — faster multi-object tracking
+- **Source:** https://ai.meta.com/blog/segment-anything-model-3/
+- **Released:** March 27, 2026 — official ComfyUI PR #13408 merged
+- **What changes:** `sam3.1_multiplex_fp16.safetensors` replaces `sam3` checkpoint. New `SAM3_Detect`, `SAM3_VideoTrack`, `SAM3_TrackToMask` ComfyUI nodes available natively.
+- **Affected builders:** `build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract`
+- **Action:** Update the default checkpoint name in those builders. Check if any hardcoded path references `sam3` (vs `sam3.1_multiplex_fp16`).
+- **Risk:** Low
+
+### 3. GPEN-BFR-512 / GPEN-BFR-1024 in ReActor (May 2026 update)
+- **Source:** https://github.com/Gourieff/ComfyUI-ReActor
+- **Released:** May 12, 2026 — in ReActor already
+- **What changes:** Drop `GPEN-BFR-512.onnx` / `GPEN-BFR-1024.onnx` into ReActor models folder. Already usable via `build_face_restore`'s `model_name` parameter with no code change. GPEN reportedly produces better face similarity than CodeFormer in many cases.
+- **Affected builders:** `build_face_restore`, `build_photo_restore`
+- **Action:** Document these as available alternatives in the builder's parameter docstring and any UI option lists.
+- **Risk:** Low
+
+### 4. ReSwapper 128/256 — open-licensed face swap option
+- **Source:** https://github.com/somanchiu/ReSwapper
+- **Released:** In ReActor as of May 2026 — available as ONNX
+- **What changes:** Add `reswapper_128.onnx` / `reswapper_256.onnx` as valid values for `build_faceswap`'s `swap_model` parameter. Quality is below inswapper_128 but open-licensed, useful for users concerned about inswapper's legal provenance.
+- **Affected builders:** `build_faceswap`, `build_faceswap_model`
+- **Action:** Document in parameter docstrings / UI dropdown. No code change needed if ReActor is already updated.
+- **Risk:** Low
+
+### 5. WAN 2.2 Lightning 4-step distillation — speed option for build_wan22_t2v
+- **Source:** https://huggingface.co/lightx2v/Wan2.2-Lightning
+- **Released:** 4-step variants updated April 2026; same WAN 2.2 ComfyUI nodes work
+- **What changes:** Pass `Wan2.2-Lightning` checkpoint variant; reduce steps to 4. Additive speed mode within existing `build_wan22_t2v`.
+- **Affected builders:** `build_wan22_t2v`
+- **Action:** Add `lightning=True` or expose `steps=4` + checkpoint name in the builder docs/UI.
+- **Risk:** Low
+
+### 6. HunyuanVideo 1.5 checkpoint — fits 16 GB without quantization
+- **Source:** https://huggingface.co/tencent/HunyuanVideo-1.5
+- **Released:** November 21, 2025 — 8.3B params (down from 13B), 14 GB VRAM confirmed
+- **What changes:** HunyuanVideo 1.5 is a superior checkpoint swap; node graph compatibility likely maintained. Repacks available (`3loso3/` and `LawrenceBoudreau/` on HF).
+- **Affected builders:** `build_hunyuan_video`
+- **Action:** Update default checkpoint reference; verify node compatibility with a local test.
+- **Risk:** Low-Medium (node graph may need minor verification)
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install)
+
+These require new builder functions and at least one new ComfyUI node pack on the local ComfyUI instance.
+
+### 1. build_kontext_img_edit — FLUX.1 Kontext reference-image editing
+- **Source:** https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev
+- **Architecture:** Already registered in `architectures.py` as `flux_kontext`; SageAttention, PAG, SLG, TeaCache, CFGZeroStar wired
+- **Gap:** No `build_kontext_img_edit(source_image, ref_image, instruction_text, ...)` builder exists. The reference-image conditioning path (`FluxKontextImageScale` + reference latent injection) is not surfaced; users fall back to `build_img2img` at low denoise which is functionally weaker.
+- **ComfyUI:** Official workflow exists; `FluxKontextImageScale` node in standard ComfyUI Kontext workflow
+- **Action:** Write the builder; no arch changes required; add `FluxKontextImageScale` to `node_factory.py`
+- **Risk:** Low
+
+### 2. build_ltx2_video — LTX-2.3 (supersedes LTX 0.9.x)
+- **Source:** https://huggingface.co/Lightricks/LTX-2.3 / https://huggingface.co/Kijai/LTX2.3_comfy (FP8 comfy weights)
+- **Released:** LTX-2 January 6 2026; LTX-2.3 March 5 2026 (Apache 2.0)
+- **Why upgrade:** Full architectural replacement. Joint audio+video in single forward pass, built-in spatial/temporal latent upscalers, up to 4K/50 FPS/20s. 0.9.x is now legacy.
+- **VRAM:** FP8 and GGUF Q4 confirmed sub-16 GB; Kijai's `LTX2.3_comfy` repo provides FP8
+- **Action:** New `build_ltx2_video` builder; update `ComfyUI-LTXVideo` node pack; keep `build_ltx_video` for 0.9.x backward compatibility
+- **Risk:** Medium (new node graph, not drop-in for old `build_ltx_video`)
+
+### 3. build_wan22_s2v — WAN 2.2 Sound/Speech-to-Video
+- **Source:** https://docs.comfy.org/tutorials/video/wan/wan2-2-s2v
+- **Released:** Native ComfyUI support; `WanSoundImageToVideo` node; `wan2.2_s2v_14B_fp8_scaled.safetensors` at ~12-14 GB VRAM
+- **Why add:** Entirely new modality — audio-driven talking-head video from static image + audio clip. Not in current stack.
+- **Action:** New `build_wan22_s2v(image_filename, audio_filename, prompt_text, ...)` builder using `WanSoundImageToVideo` node
+- **Risk:** Low-Medium
+
+### 4. build_flashvsr_upscale — FlashVSR v1.1 video upscaling
+- **Source:** https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1 / https://github.com/OpenImagingLab/FlashVSR
+- **Released:** v1.1 with temporal stability focus; CVPR 2026 accepted
+- **Why add:** Fills gap between heavy SeedVR2 and trivial ESRGAN. One-step diffusion with locality-constrained sparse attention; streaming per-frame mode for low VRAM.
+- **ComfyUI:** Multiple nodes — `ComfyUI_FlashVSR`, `ComfyUI-FlashVSR_Ultra_Fast`, WaveSpeed node
+- **Action:** New `build_flashvsr_upscale` builder; install `ComfyUI_FlashVSR`
+- **Risk:** Low
+
+### 5. build_rtx_upscale — NVIDIA RTX Video Super Resolution
+- **Source:** https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI
+- **Released:** NVIDIA GDC announcement late June 2026 — within the 7-day window
+- **Why add:** 30× faster than diffusion upscalers; tensor-core acceleration on RTX 5060 Ti; zero VRAM overhead for the upscale step; ideal for proxy/preview or as a fast pre-pass before SeedVR2.
+- **Limitation:** Clarity/artifact correction only — no detail synthesis/hallucination
+- **Action:** New `build_rtx_upscale` builder or add as a fast-mode flag on `build_video_upscale`; install via ComfyUI Manager search "RTX"
+- **Risk:** Low
+
+### 6. build_klein_face_restore — IConFace reference-aware face restoration on Klein
+- **Source:** https://huggingface.co/zhangjinyang/IConFace / https://github.com/cosmicrealm/ComfyUI-Flux-FaceIR
+- **Released:** May 4, 2026 — `iconface_lora.safetensors` (LoRA rank 16 on Klein-base-4B)
+- **Why add:** Reference-aware restoration mode — pass 1-3 clean reference photos to guide restoration of a degraded face. This is a unique capability CodeFormer lacks entirely. Mode 1 (no reference) also outperforms CodeFormer blind.
+- **Integration:** `build_klein_face_detail` is the most natural integration point; `ComfyUI-Flux-FaceIR` node is the dependency
+- **VRAM:** Klein-base-4B + LoRA fits easily in 16 GB
+- **Action:** New `build_klein_face_restore(image_filename, ref_filenames, ...)` builder using `ComfyUI-Flux-FaceIR`
+- **Risk:** Low-Medium
+
+### 7. build_iclight_v2 — IC-Light V2 (Flux-based relighting)
+- **Source:** https://github.com/lllyasviel/IC-Light/discussions/98 / https://aichief.com/ai-image-tools/ic-light-v2/
+- **Released:** Announced January 29, 2026; foreground-conditional model available
+- **Why add:** Flux architecture + 16-channel VAE dramatically improves relighting quality for oil paintings, anime, and photorealistic inputs vs SD1.5 IC-Light. The current `build_iclight` is hardwired to the SD1.5 pipeline.
+- **ComfyUI:** `ComfyUI-IC-Light-Native` or compatible Flux-sampling node; `ComfyUI-Conditioning-Rebalance` for Krea2EditRebalance-style editing
+- **VRAM:** Flux FP8 ~12 GB; fits 16 GB
+- **Action:** New `build_iclight_v2` builder; keep `build_iclight` (SD1.5) for non-photorealistic cases
+- **Risk:** Medium (new builder + new node pack)
+
+### 8. build_pid_decode — PiD Pixel Diffusion generative decoder
+- **Source:** https://huggingface.co/nvidia/PiD / https://github.com/tsolful/ComfyUI-PiD
+- **Paper:** arXiv 2605.23902, published May 22, 2026; HF checkpoint June 2, 2026
+- **Why add:** Replaces the single-pass VAE decode with ~8 denoising steps in pixel space, conditioned on the source latent. Produces 4× (512→2048) or 8× (512→4096) outputs in one step. Supports FLUX, FLUX.2, SD3, SDXL checkpoints. DMD2-distilled 1-2-step variant also available.
+- **VRAM:** 512→2K: ~13 GB peak on RTX 5090; expected similar on 5060 Ti — 16 GB has ~3 GB headroom. 4K will OOM or require tiling.
+- **Action:** New `build_pid_decode` builder; best used as a quality-upgrade step after `build_supir`'s main restoration pass; install `ComfyUI-PiD`
+- **Risk:** Medium (new paradigm — may hallucinate texture compared to reconstruction upscalers)
+
+### 9. HyperSwap 256 as swap_model option in build_faceswap
+- **Source:** https://github.com/Gourieff/ComfyUI-ReActor/issues/143 (HyperSwap in ReActor)
+- **Why add:** HyperSwap 256px ONNX models (`hyperswap_1a_256.onnx`, `1b`, `1c`) offer higher resolution than inswapper_128. Developed by FaceFusion Labs. Already supported in ReActor.
+- **Caveat:** GitHub issue #183 ("Hyperswap broken") was filed; uncertain if resolved. Quality varies per variant (1a/1b/1c have different trade-offs).
+- **Action:** Document as available `swap_model` values; no code change needed if ReActor is updated. Recommend `hyperswap_1b_256.onnx` as the default option to expose.
+- **Risk:** Medium (stability uncertainty)
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Status | Blocker | ETA |
+|------|--------|---------|-----|
+| **Krea 2 (12B DiT)** | Weights live; ComfyUI 0.26 support confirmed | New backbone: architectures.py entry, new builders, `Krea2Pipeline` in node_factory | 2-4 weeks |
+| **FLUX.2-Klein-9B-KV** | Weights on HF (10.8K downloads); FP8 available | `Flux2KleinKVPipeline` separate diffusers class; new arch key needed | 1-2 weeks |
+| **WAN 2.7** | Open weights (Apache 2.0); 14B MoE fits 16 GB FP8 | Weights on ModelScope (not HF); ComfyUI partner nodes are cloud API | 2-4 weeks (HF mirror expected) |
+| **SeedVR2 v2.5** | ICLR 2026 accepted; 60% VRAM reduction; 3B/7B GGUF | Breaking node-layout change; workflows must be recreated | 1-2 weeks |
+| **RealRestorer (StepFun)** | HF weights available; 9 degradation types | No ComfyUI node exists; need to write one | 2-4 weeks |
+| **SkyReels-V3 R2V/V2V** | 14B fits 16 GB (GGUF); WanPipeline-based | Partially compatible with WAN nodes; R2V conditioning needs new nodes | 2-4 weeks |
+| **BFS-Best-Face-Swap Klein LoRA Head V5** | LoRA on HF (170+ downloads); generative approach | Quality vs Klein headswap needs validation on realistic photos | 1 week to validate |
+| **FaceFusion 3.7.0** | Active; v3.7.0 released June 30, 2026 | Unofficial ComfyUI node; separate pipeline from ReActor | 2-4 weeks |
+| **Topaz Astra 2 + Bloom** | Official ComfyUI partner nodes | Requires Topaz Video AI license (paid) | On-demand |
+| **CanonSwap (paper Jul 3, 2026)** | Paper published today | No weights, no node, no code | 4-8 weeks |
+| **SAMA segment+matte** | Paper Jan 2026 | No public weights, no ComfyUI node | Unknown |
+| **WAN 2.2 BlockSwap + VACE** | Already in stack (build_wan_video_blockswap) | Check if VACE_SkyReels_V3_R2V_Merge GGUF is compatible | 1 week |
+
+---
+
+## No-finds (verified)
+
+The following were searched and confirmed to have no novel release in the past 7 days:
+
+| Builder | Searched for | Verdict |
+|---------|-------------|---------|
+| build_pulid_flux | PuLID Flux 2, PuLID updates | Nothing new; `build_pulid_flux` is current |
+| build_faceid_img2img | InstantID v2, InstantID updates | Maintenance-only update June 12, 2026; no new model |
+| build_cogvideo_video | CogVideoX 2.0, CogVideoX June 2026 | No new architecture; stuck at CogVideoX 1.5 (Nov 2024) |
+| build_mochi_video | Mochi v2, Mochi updates | No updates |
+| build_framepack_video | FramePack v2, FramePack model | Node updates only (first+last-frame, bucket fixes Apr 2026); upstream checkpoint unchanged |
+| build_ddcolor | DDColor v2, colorization models | Nothing new |
+| build_colorize | Klein colorize, new colorization | Nothing new; Klein path remains valid |
+| build_depth_map_v3 | Depth Anything V4, DA3 successor | DA3 is ICLR 2026 Oral (current); no V4 |
+| build_normal_map | Normal map estimation updates | Nothing new |
+| build_rembg_v3 | RMBG-3.0, BiRefNet v2 | V-RMBG 3.0 is video + API-only (Bria); RMBG-2.0 remains current for images |
+| build_hunyuan_3d_mesh / build_hunyuan_3d_textured | Hunyuan3D 3.x | Released but ❌ VRAM (>16 GB); no confirmed open weights |
+| build_lama_remove | LaMa v2, improved inpainting | Nothing new |
+| build_inpaint_fooocus | Fooocus inpainting update | Nothing new |
+| build_lumina2_txt2img | Lumina 3, Lumina updates | Latest is Lumina-Image 2.0; no new release |
+| — | WAN 3.0 | Marketing term for WAN 2.6/2.7; not a separate release |
+| — | Vision Banana (Google DeepMind) | Closed source, Google API only; benchmarks beat SAM 3 + DA3 but inaccessible locally |
+| — | FLUX.2-dev INT8 tensorwise | 0 downloads / 0 likes; unproven; monitor for adoption before recommending |
+| — | GFPGAN v2 | Does not exist; GFPGAN appears unmaintained since 2022 |
+
+---
+
+## Sources
+
+- Krea 2: https://www.krea.ai/krea-2-open-source / https://blog.comfy.org/p/krea-2-open-source-models-are-now
+- FLUX.2-small-decoder: https://huggingface.co/black-forest-labs/FLUX.2-small-decoder
+- FLUX.2-Klein-9B-KV: https://huggingface.co/black-forest-labs/FLUX.2-klein-9b-kv / https://www.kombitz.com/2026/03/20/how-to-use-flux-2-klein-9b-kv-image-edit-gguf-in-comfyui/
+- FLUX.1 Kontext: https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev / https://comfyui-wiki.com/en/tutorial/advanced/image/flux/flux-1-kontext
+- IC-Light V2: https://github.com/lllyasviel/IC-Light/discussions/98 / https://aichief.com/ai-image-tools/ic-light-v2/
+- PiD: https://arxiv.org/abs/2605.23902 / https://huggingface.co/nvidia/PiD / https://github.com/tsolful/ComfyUI-PiD
+- SAM 3.1: https://ai.meta.com/blog/segment-anything-model-3/ / https://www.runcomfy.com/comfyui-workflows/sam-3-1-comfyui-workflow-native-segmentation-and-video-tracking
+- IConFace: https://huggingface.co/zhangjinyang/IConFace / https://github.com/cosmicrealm/ComfyUI-Flux-FaceIR / https://hf.co/papers/2605.02814
+- BFS-Best-Face-Swap: https://huggingface.co/chfm/BFS-Best-Face-Swap / https://huggingface.co/PcZerokey/BFS-Best-Face-Swap
+- HyperSwap: https://github.com/Gourieff/ComfyUI-ReActor/issues/143
+- ReSwapper: https://github.com/somanchiu/ReSwapper
+- ReActor May 2026: https://github.com/Gourieff/ComfyUI-ReActor
+- LTX-2.3: https://huggingface.co/Lightricks/LTX-2.3 / https://huggingface.co/Kijai/LTX2.3_comfy / https://huggingface.co/unsloth/LTX-2.3-GGUF
+- WAN 2.7: https://docs.comfy.org/tutorials/partner-nodes/wan/wan2-7
+- WAN 2.2 S2V: https://docs.comfy.org/tutorials/video/wan/wan2-2-s2v
+- WAN 2.2 Lightning: https://huggingface.co/lightx2v/Wan2.2-Lightning
+- HunyuanVideo 1.5: https://huggingface.co/tencent/HunyuanVideo-1.5
+- SeedVR2 v2.5: https://github.com/IceClear/SeedVR2 / https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler
+- SkyReels-V3: https://huggingface.co/Skywork/SkyReels-V3-R2V-14B / https://github.com/SkyworkAI/SkyReels-V3
+- FlashVSR v1.1: https://huggingface.co/JunhaoZhuang/FlashVSR-v1.1 / https://github.com/OpenImagingLab/FlashVSR
+- NVIDIA RTX VSR: https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI / https://blogs.nvidia.com/blog/rtx-ai-garage-flux-ltx-video-comfyui-gdc/
+- Topaz Astra 2: https://blog.comfy.org/p/topazs-flagship-upscale-models-in
+- RealRestorer: https://huggingface.co/RealRestorer/RealRestorer / https://arxiv.org/abs/2603.25502
+- CanonSwap: https://hf.co/papers/2507.02691 / https://luoxyhappy.github.io/CanonSwap/
+- FaceFusion 3.7.0: https://github.com/facefusion/facefusion
+- Vision Banana: https://vision-banana.github.io/ / https://hf.co/papers/2604.20329


### PR DESCRIPTION
## Summary

Daily SOTA survey for `2026-W27` (June 26 – July 3, 2026). Hardware constraint: RTX 5060 Ti, 16 GB VRAM.
First run — no prior baseline in `_dev_docs/upgrade_research/`.

---

## Findings at a glance

| Tier | Count | Items |
|------|-------|-------|
| **Tier 1** — Drop-in supersessions (ship soon) | 6 | FLUX.2-small-decoder, SAM 3.1 Multiplex, GPEN-BFR-512/1024, ReSwapper 128/256, WAN 2.2 Lightning, HunyuanVideo 1.5 |
| **Tier 2** — Additive new builders (needs node-pack install) | 9 | build_kontext_img_edit, build_ltx2_video, build_wan22_s2v, build_flashvsr_upscale, build_rtx_upscale, build_klein_face_restore (IConFace), build_iclight_v2, build_pid_decode, HyperSwap 256 option |
| **Tier 3** — Monitor / not wire-ready | 11 | Krea 2, FLUX.2-Klein-9B-KV, WAN 2.7, SeedVR2 v2.5, RealRestorer, SkyReels-V3, BFS Head LoRA, FaceFusion 3.7, Topaz Astra 2, CanonSwap (paper only), SAMA (paper only) |
| **No-finds** | 13 | PuLID Flux, InstantID, GFPGAN v2 (doesn't exist), CogVideoX 2.0 (doesn't exist), FramePack v2 (node update only), Mochi, DDColor, DA V4, Hunyuan3D 3.x (❌ VRAM), WAN 3.0 (marketing alias), Vision Banana (closed source), V-RMBG 3.0 (video/API-only), FLUX.2-dev INT8 (0 adoption) |

---

## Highlights

**Biggest release:** Krea 2 Turbo FP8 (12B DiT, Qwen3-VL encoder) — open weights since June 22, ComfyUI 0.26 native support, fits 16 GB. New backbone needing `architectures.py` entry + new builders. Community LoRA and ControlNet adapters landing this week.

**Fastest win:** `build_kontext_img_edit` — the `flux_kontext` architecture is already registered in `architectures.py`; only the builder function is missing. The `FluxKontextImageScale` node + reference latent injection pattern is well-documented.

**Best quality uplift for faces:** IConFace (`zhangjinyang/IConFace`) — reference-aware face restoration LoRA on Klein-base-4B. Pass 1-3 clean reference photos to guide restoration. Unique capability not present anywhere else in the stack. ComfyUI-Flux-FaceIR node available.

**LTX is superseded:** LTX-2.3 is a full architectural replacement of the 0.9.x line — joint audio+video, 4K/50 FPS, built-in latent upscalers. Kijai FP8 comfy weights available. `build_ltx_video` (0.9.x) should remain for backward compat but `build_ltx2_video` is the new default.

**New paper watch (July 3, today):** CanonSwap — video face swap via canonical space modulation. No weights yet, but if/when released it would be Spellcaster's first video face swap builder.

---

## Files

- `_dev_docs/upgrade_research/2026-W27.md` — full findings report with Tier 1/2/3/no-find breakdown
- `_dev_docs/upgrade_research/2026-W27.json` — 27 structured records (one per candidate), machine-readable

---

> **Note:** The local `03:30` nightly export at `tools/export_comfyui_workflows.py` will refresh ComfyUI workflow snapshots automatically — no action needed here for that.

> **Do not merge** — leave open for human review. Implementation upgrades require local node-pack installs that can only happen on the user's machine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EW4C4LSeYUxtQufdsrKViJ)_