### PR TITLE
chore(research): daily SOTA review 2026-07-11

### DIFF
--- a/_dev_docs/upgrade_research/2026-W28.json
+++ b/_dev_docs/upgrade_research/2026-W28.json
@@ -1,0 +1,432 @@
+[
+  {
+    "method": "build_sam3_segment",
+    "category": "node_pack",
+    "name": "SAM 3.1 Multiplex — Native ComfyUI Integration",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/13408",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Merged into ComfyUI core in the Jul 4–11 window. Native SAM3_Detect / SAM3_VideoTrack / SAM3_TrackToMask nodes. Multiplex shared-memory tracker, bit-packed masks, text + point conditioned. Weights: huggingface.co/Comfy-Org/sam3.1. VRAM ~8–10 GB. Tier 1."
+  },
+  {
+    "method": "build_sam3_mask",
+    "category": "node_pack",
+    "name": "SAM 3.1 Multiplex — Native ComfyUI Integration",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/13408",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Same as build_sam3_segment. Tier 1."
+  },
+  {
+    "method": "build_sam3_extract",
+    "category": "node_pack",
+    "name": "SAM 3.1 Multiplex — Native ComfyUI Integration",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/13408",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Same as build_sam3_segment. Tier 1."
+  },
+  {
+    "method": "build_klein_sam3_inpaint",
+    "category": "node_pack",
+    "name": "SAM 3.1 Multiplex — Native ComfyUI Integration",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/13408",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "SAM 3.1 improves the segmentation step within the Klein inpaint pipeline. Tier 1."
+  },
+  {
+    "method": "build_magic_eraser",
+    "category": "node_pack",
+    "name": "SAM 3.1 Multiplex — Native ComfyUI Integration",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/13408",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "SAM 3.1 improves the segmentation step in the magic eraser pipeline. Tier 1."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "node_pack",
+    "name": "SeedVR2 v2.5 — modular node redesign",
+    "source": "github",
+    "url": "https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Same 7B model weights; new 4-node modular architecture. BlockSwap CPU offload and GGUF Q4_K_M quantization reduce VRAM to 8 GB. Now in ComfyUI Manager. ICLR 2026 accepted (ByteDance Seed). Tier 1."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 1c_256 (FaceFusion Labs)",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/issues/143",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "Drop-in replacement for inswapper_128.onnx. 256px face resolution vs 128px. Place in ComfyUI/models/hyperswap/. Already supported by ComfyUI-ReActor. Became FaceFusion 3.7.0 default (Jun 30). VRAM minimal (ONNX ~200 MB). Tier 1."
+  },
+  {
+    "method": "build_video_reactor",
+    "category": "checkpoint",
+    "name": "HyperSwap 1c_256 (FaceFusion Labs)",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/issues/143",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "Same as build_faceswap — improved face resolution across video frames. Tier 1."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 (22B, Apache 2.0, FP8 fits 16 GB)",
+    "source": "huggingface",
+    "url": "https://ltx.io/model/ltx-2-3",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Native ComfyUI v0.27.0 support (Jun 30). 4K, up to 50 FPS, synchronized audio in single pass. FP8 quantized variant at huggingface.co/Lightricks/LTX-Video. Context Windows prevent OOM on longer sequences. Also ships IC-LoRA Pixel Spatial Upscaler (2×/4× latent upscaling). VRAM ~16 GB (FP8). Tier 1."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "node_pack",
+    "name": "ComfyUI-RMBG v3.0.0",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-RMBG",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Multi-model bundle: RMBG-2.0, BEN, BEN2 (Confidence Guided Matting, hair + 4K), BiRefNet-general, BiRefNet-HR (2048px), SDMatte, SAM3, GroundingDINO. BEN2 outperforms BiRefNet-general on hair edges. Released Jan 1 2026. VRAM ~6–8 GB. Tier 1."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "node_pack",
+    "name": "ComfyUI-RMBG v3.0.0",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-RMBG",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Same as build_rembg_birefnet. BEN2 beats RMBG-2.0 on hair edges. Multi-model selector exposes all variants in one node. Tier 1."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Krea 2 Turbo (12.9B DiT, 8-step distilled)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/Krea-2",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "12.9B DiT trained from scratch. Turbo (distilled) ~12 GB; RAW (50-step) ~24 GB (skip). Ships 9 style LoRAs under Krea 2 Community License. ComfyUI v0.27.1 (Jul 8) added Advanced Krea 2 Model Merging node. Tier 2 — new builder recommended: build_krea2_txt2img."
+  },
+  {
+    "method": "build_img2img",
+    "category": "checkpoint",
+    "name": "Krea 2 Turbo (12.9B DiT, 8-step distilled)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/Krea-2",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Same as build_txt2img. Tier 2."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "checkpoint",
+    "name": "FlashVSR (CVPR 2026, OpenImagingLab / Alibaba)",
+    "source": "github",
+    "url": "https://github.com/OpenImagingLab/FlashVSR",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "One-step diffusion video SR; 12× faster than prior diffusion VSR; ~17 FPS at 768×1408 on A100. 4 community ComfyUI ports: smthemex/ComfyUI_FlashVSR, 1038lab/ComfyUI-FlashVSR, naxci1/ComfyUI-FlashVSR_Stable. VRAM 8–16 GB with LightVAE_W2.1 backbone. VSR-120K training dataset included. Tier 2 — new builder: build_flashvsr_video_upscale."
+  },
+  {
+    "method": "build_faceswap_mtb",
+    "category": "checkpoint",
+    "name": "DreamID-V 1.3B-Faster (ByteDance, ECCV 2026)",
+    "source": "huggingface",
+    "url": "https://github.com/bytedance/DreamID-V",
+    "risk": "medium",
+    "confidence": 0.55,
+    "notes": "DiT-based (Wan) face swap with superior video identity fidelity vs ONNX methods. 1.3B-Faster variant feasible at 16 GB via Goldlionren/ComfyUI_JR_DreamID-V. HF: huggingface.co/XuGuo699/DreamID-V. Slower than ONNX — best for high-quality final renders only. Confidence docked: Jan 2026 release, not strictly this week. Tier 2."
+  },
+  {
+    "method": "build_inpaint",
+    "category": "node_pack",
+    "name": "LanPaint — training-free universal inpainting KSampler",
+    "source": "github",
+    "url": "https://github.com/scraed/LanPaint",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Drop-in KSampler replacement; any checkpoint inpaints without a dedicated inpaint model. Krea 2 inpaint support landed Jul 2 2026. Supports Flux, Klein, Wan 2.2, Qwen-Image, SDXL, SD 1.5. VRAM: inherits from loaded backbone. Tier 2."
+  },
+  {
+    "method": "build_inpaint_fooocus",
+    "category": "node_pack",
+    "name": "LanPaint — training-free universal inpainting KSampler",
+    "source": "github",
+    "url": "https://github.com/scraed/LanPaint",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Same as build_inpaint. Tier 2."
+  },
+  {
+    "method": "build_klein_inpaint",
+    "category": "node_pack",
+    "name": "LanPaint — training-free universal inpainting KSampler",
+    "source": "github",
+    "url": "https://github.com/scraed/LanPaint",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "LanPaint adds training-free inpaint path to Klein backbone without a separate inpaint checkpoint. Tier 2."
+  },
+  {
+    "method": "build_klein_auto_inpaint",
+    "category": "node_pack",
+    "name": "LanPaint — training-free universal inpainting KSampler",
+    "source": "github",
+    "url": "https://github.com/scraed/LanPaint",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "Same benefit for the auto-inpaint path. Tier 2."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "node_pack",
+    "name": "TRELLIS 2 (Microsoft Research)",
+    "source": "github",
+    "url": "https://github.com/visualbruno/ComfyUI-Trellis2",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "4B-param structured-latent diffusion; single or multi-view input; GLB mesh, UV unwrap, PBR textures, quad topology, hole-filling. Open-source + free commercial use. ComfyUI nodes updated Feb 28 2026. VRAM ~12–16 GB. Alternative port: github.com/PozzettiAndrea/ComfyUI-TRELLIS2. Tier 2."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "node_pack",
+    "name": "TRELLIS 2 (Microsoft Research)",
+    "source": "github",
+    "url": "https://github.com/visualbruno/ComfyUI-Trellis2",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "Same as build_hunyuan_3d_mesh. Adds PBR textures, UV unwrap, SmoothNormals. Tier 2."
+  },
+  {
+    "method": "build_supir",
+    "category": "node_pack",
+    "name": "RealRestorer (ComfyUI node available)",
+    "source": "github",
+    "url": "https://github.com/StartHua/Comfyui_RealRestorer",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "Diffusion-model-based unified restoration; broader degradation coverage in one pass vs SUPIR's 5-stage SDXL pipeline. Paper: github.com/yfyang007/RealRestorer (Mar 26 2026). Includes RealIR-Bench benchmark. VRAM ~12–16 GB. Tier 2."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "lora",
+    "name": "QwenStyle LoRA (arXiv 2601.06202)",
+    "source": "github",
+    "url": "https://github.com/witcherofresearch/Qwen-Image-Style-Transfer",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "LoRA + lightning LoRA trained on Qwen-Image-Edit; zero-shot style transfer with better content-preservation and aesthetic quality than prior methods. Drop-in on existing build_qwen_edit backbone. VRAM: ~12–16 GB (same as Qwen-Image base). Tier 2."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "lora",
+    "name": "QwenStyle LoRA (arXiv 2601.06202)",
+    "source": "github",
+    "url": "https://github.com/witcherofresearch/Qwen-Image-Style-Transfer",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Augments build_qwen_edit with style-transfer capability via LoRA. Tier 2."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Anima Base v1 (CircleStone Labs + ComfyUI Org, 2B DiT)",
+    "source": "github",
+    "url": "https://docs.comfy.org/tutorials/image/anima/anima",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "2B-param DiT for anime + illustration; tag + natural-language conditioning. Released May 15 2026; ComfyUI workflows embedded in model card. VRAM: 6 GB — accessible where Klein 4B cannot run. Niche (anime/illustration). Tier 2 — new builder: build_anima_txt2img."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "SurGe — Improved Surface Geometry in Point Maps",
+    "source": "github",
+    "url": "https://github.com/karimknaebel/surge",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "Point-gradient matching loss + Neighborhood Attention Decoder; best average rank across 8 zero-shot monocular geometry benchmarks. Released Jun 1 2026. No ComfyUI node found yet. Outperforms DA3 on local surface geometry. VRAM ~8–12 GB (estimated). Tier 3 — monitor for wrapper."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "RoSE — Monocular Normal Estimation via Shading Sequence (ICLR 2026 Oral)",
+    "source": "github",
+    "url": "https://github.com/LMozart/ICLR2026-RoSE",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "Reformulates normal estimation as shading-sequence prediction using image-to-video backbone. MultiShade dataset + checkpoints released Jun 21 2026. SOTA on real-world object benchmarks. No ComfyUI wrapper found. VRAM ~12 GB (estimated). Tier 3 — monitor for wrapper."
+  },
+  {
+    "method": "build_colorize",
+    "category": "checkpoint",
+    "name": "ColorFLUX — Structure-Color Decoupling for Colorization (CVPR 2026)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2603.28162",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "FLUX-based diffusion with structure-color decoupling. Outperforms DeOldify, CtrlColor, Kontext. Published Mar 30 2026, CVPR 2026 accepted. No standalone ComfyUI node found. VRAM: FLUX standard ~16 GB. Tier 3 — monitor for node."
+  },
+  {
+    "method": "build_ddcolor",
+    "category": "checkpoint",
+    "name": "ColorFLUX — Structure-Color Decoupling for Colorization (CVPR 2026)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2603.28162",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Same as build_colorize. ColorFLUX is the stronger candidate to eventually replace DDColor for old-photo colorization. Tier 3."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "checkpoint",
+    "name": "TeleStyle V2 (Tele-AI, Jun 10 2026)",
+    "source": "github",
+    "url": "https://github.com/Tele-AI/TeleStyleV2",
+    "risk": "medium",
+    "confidence": 0.73,
+    "notes": "Self-distillation data synthesis + distribution-matching-distillation. Supports all 4 reference-pair combinations. Performance on par with Gemini 3 Pro Image style transfer. Paper arXiv 2606.20709 Jun 10 2026. No ComfyUI node yet. VRAM ~12–24 GB estimated. Tier 3."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "node_pack",
+    "name": "DiffBIR v2.1",
+    "source": "github",
+    "url": "https://github.com/XPixelGroup/DiffBIR",
+    "risk": "low",
+    "confidence": 0.55,
+    "notes": "Two-stage blind restoration (regression + diffusion prior); tiled inference for 8 GB VRAM; handles occlusion/accessories better than CodeFormer. ComfyUI node: github.com/jtscmw01/ComfyUI-DiffBIR. NTR team backbone in NTIRE 2026. Not a July 2026 release (v2.1 late 2025) but gaining ComfyUI traction now. Tier 3 — evaluate alongside CodeFormer."
+  },
+  {
+    "method": "build_photo_restore",
+    "category": "node_pack",
+    "name": "DiffBIR v2.1",
+    "source": "github",
+    "url": "https://github.com/XPixelGroup/DiffBIR",
+    "risk": "low",
+    "confidence": 0.55,
+    "notes": "Same as build_face_restore. Tier 3."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Stable Video Infinity (SVI) — ICLR 2026 Oral",
+    "source": "github",
+    "url": "https://github.com/vita-epfl/Stable-Video-Infinity",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Error-Recycling Fine-Tuning on Wan2.2 backbone for infinite-length video without temporal drift. ICLR 2026 Oral. ComfyUI workflow available (branch svi_wan22) but research-code quality. Requires fine-tuned Wan2.2 weights. VRAM ~16 GB. Tier 3 — monitor for polished node."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "Stable Video Infinity (SVI) — ICLR 2026 Oral",
+    "source": "github",
+    "url": "https://github.com/vita-epfl/Stable-Video-Infinity",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Same as build_wan_video. Tier 3."
+  },
+  {
+    "method": "build_wavespeed_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX Video Super Resolution",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "30× faster than competing local upscalers per NVIDIA benchmarks. RTX GPU required — hardware-gated. Minimal VRAM (separate RTX VSR pipeline). Official Comfy-Org node. Tier 3 — ship only if target users have confirmed RTX hardware."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 3.1 / 3.5 Pro",
+    "source": "github",
+    "url": "https://github.com/Tencent-Hunyuan/Hunyuan3D-2",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Jan 23 2026 (3.1 Pro); 3.5 adds 2M+ polygon + 8K PBR textures. Direct successor to Hunyuan3D 2.0. Verify whether the existing build_hunyuan_3d_mesh checkpoint path already resolves to 3.1/3.5 before creating a new builder. VRAM ~12–16 GB. Tier 3."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "controlnet",
+    "name": "Qwen-Image-ControlNet-Union (InstantX, Apache 2.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/InstantX/Qwen-Image-ControlNet-Union",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Union ControlNet for Qwen-Image covering canny, soft-edge, depth, and pose in a single safetensors file. Also: alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union (10.6K downloads). Extends ControlNet to Qwen backbone only — new pipeline needed. VRAM ~10–16 GB. Tier 3."
+  },
+  {
+    "method": "build_klein_img2img",
+    "category": "lora",
+    "name": "Portrait Engine LoRA v4.0 (CivitAI)",
+    "source": "civitai",
+    "url": "https://civitai.com/models/2067704/portrait-engine-flux-flux-2-klein-z-image-detailed-skin-lora",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "Realism-enhancing LoRA for detailed skin texture; compatible with FLUX.2 Klein 4B/9B. Updated ~late Jun 2026 (v4.0). Augments, does not replace. Confidence docked: CivitAI timestamps approximate. VRAM: no overhead on top of Klein base. Tier 3 / additive."
+  },
+  {
+    "method": "build_klein_repose",
+    "category": "lora",
+    "name": "Portrait Engine LoRA v4.0 (CivitAI)",
+    "source": "civitai",
+    "url": "https://civitai.com/models/2067704/portrait-engine-flux-flux-2-klein-z-image-detailed-skin-lora",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "Same LoRA — augments repose portrait quality. Tier 3 / additive."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "checkpoint",
+    "name": "GSwap — 3D-Gaussian Head Swap (TVCG, research only)",
+    "source": "github",
+    "url": "https://ustc3dv.github.io/GSwap/",
+    "risk": "high",
+    "confidence": 0.35,
+    "notes": "Dynamic Neural Gaussian Field for pose/expression-consistent head swap in video. No inference code or ComfyUI wrapper released. TVCG-accepted. Monitor for code drop. Tier 3."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "FaceFusion 3.7.0",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion/releases/tag/3.7.0",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "Released Jun 30 2026. Multi-frame-aware processors, auto face-selector, CoreML fp16 boost. HyperSwap 1a/1b/1c are now the default swapper models. FaceFusion ComfyUI wrapper: huygiatrng/Facefusion_comfyui. Separate from ReActor path. Tier 3 — evaluate as an alternative swapper backend."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Seedream 5.0 Pro (ByteDance, API-only)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/seedream-50-pro",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "Released Jul 8 2026; ComfyUI v0.27.1 partner node same day. Reasoning image model: point/lasso/sketch/color-swap precision editing, layer export, 2K output, 10+ languages. API-only (Volcano Engine / BytePlus / fal). Tier 2 — new builder: build_seedream_edit. VRAM: N/A."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "lora",
+    "name": "LTX-2 IC-LoRA Pixel Spatial Upscaler (2×/4× latent)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/13325",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "IC-LoRA adapters that perform 2× or 4× latent-space video upscaling within LTX-2 pipeline. Added to ComfyUI core v0.27.0. HDR IC-LoRA also available. Not standalone — requires LTX-2 pipeline context. VRAM: same as LTX-2 base (~16 GB FP8). Tier 3 / additive within build_ltx_video pipeline."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W28.md
+++ b/_dev_docs/upgrade_research/2026-W28.md
@@ -1,0 +1,251 @@
+# Spellcaster daily SOTA review — 2026-07-11
+
+ISO week: `2026-W28`. Baseline: *(first run — no prior baseline)*.
+
+Survey window: **July 4–11, 2026** (plus recent-but-relevant releases from late June where ComfyUI wires landed in the window).
+Hardware budget: RTX 5060 Ti, 16 GB VRAM — items requiring more are flagged **>16 GB** and placed in Tier 3 / skipped.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / augmentation | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| build_txt2img | SDXL + Flux | Conditionally | Krea 2 Turbo (12B DiT, open weights) | https://huggingface.co/Comfy-Org/Krea-2 | medium | ComfyUI v0.27.1 (Jul 8) added Advanced Model Merging. Turbo ~12 GB; RAW ~24 GB (skip). |
+| build_img2img | SDXL + Flux | Conditionally | Krea 2 Turbo | https://huggingface.co/Comfy-Org/Krea-2 | medium | Same as build_txt2img. |
+| build_inpaint | Fooocus / SDXL | Yes + additive | LanPaint (training-free KSampler) | https://github.com/scraed/LanPaint | low | Drop-in complement; any checkpoint inpaints without a dedicated inpaint model. |
+| build_outpaint | SDXL | Yes | — | — | — | No novel find this week. |
+| build_inpaint_fooocus | Fooocus | Yes + additive | LanPaint | https://github.com/scraed/LanPaint | low | Same benefit as build_inpaint. |
+| build_controlnet_gen | SDXL / Flux preprocessors | Conditionally | Qwen-Image-ControlNet-Union (InstantX) | https://huggingface.co/InstantX/Qwen-Image-ControlNet-Union | medium | Union model (canny+depth+pose+soft-edge) for Qwen backbone only; extends Qwen path. 10–16 GB. |
+| build_generate_anything | Flux | Yes | — | — | — | No novel find. |
+| build_style_transfer | Flux + IPAdapter | Conditionally | QwenStyle LoRA (Qwen-Image-Edit) | https://github.com/witcherofresearch/Qwen-Image-Style-Transfer | low | Drop-in LoRA on existing Qwen backbone; better content-preservation than current approach. |
+| build_klein_img2img | Klein 4B/9B | Yes + LoRA | Portrait Engine LoRA v4.0 | https://civitai.com/models/2067704/ | low | CivitAI LoRA for detailed skin; updated ~late Jun 2026. Augments, does not replace. |
+| build_klein_img2img_ref | Klein 4B/9B | Yes | — | — | — | No direct novel find. |
+| build_klein_inpaint | Klein 4B/9B | Yes + additive | LanPaint | https://github.com/scraed/LanPaint | low | Adds training-free inpaint path on Klein backbone. |
+| build_klein_refine | Klein 4B/9B | Yes | — | — | — | No novel find. |
+| build_klein_scene_img2img | Klein 4B/9B | Yes | — | — | — | No novel find. |
+| build_klein_blend | Klein 4B/9B | Yes | — | — | — | No novel find. |
+| build_klein_detail | Klein 4B/9B | Yes | — | — | — | No novel find. |
+| build_klein_auto_inpaint | Klein 4B/9B | Yes + additive | LanPaint | https://github.com/scraed/LanPaint | low | Same benefit. |
+| build_klein_sam3_inpaint | Klein + SAM3 | Yes + upgrade | SAM 3.1 Multiplex | https://github.com/Comfy-Org/ComfyUI/pull/13408 | low | SAM 3.1 merged into ComfyUI core in the Jul 4–11 window; faster multi-object tracking. |
+| build_klein_batch_variations | Klein 4B/9B | Yes | — | — | — | No novel find. |
+| build_klein_generate_object | Klein 4B/9B | Yes | — | — | — | No novel find. |
+| build_klein_virtual_tryon | Klein 4B/9B | Yes | — | — | — | No novel find. |
+| build_klein_repose | Klein 4B/9B | Yes + LoRA | Portrait Engine LoRA v4.0 | https://civitai.com/models/2067704/ | low | Augments portrait quality; same backbone. |
+| build_klein_color_match | Klein 4B/9B | Yes | — | — | — | No novel find. |
+| build_klein_headswap | Klein 4B/9B | Yes | GSwap (research only, TVCG) | https://ustc3dv.github.io/GSwap/ | high | 3D-Gaussian head swap; no inference code released. Monitor. |
+| build_klein_face_detail | Klein 4B/9B | Yes | — | — | — | No novel find. |
+| build_pulid_flux | PuLID + Flux | Yes | — | — | — | No novel find. |
+| build_lumina2_txt2img | Lumina 2 | Yes | — | — | — | No novel find. |
+| build_qwen_edit | Qwen-Image-Edit | Yes + additive | QwenStyle LoRA + Qwen ControlNet Union | https://github.com/witcherofresearch/Qwen-Image-Style-Transfer | low | Both additive on same backbone. |
+| build_iclight | IC-Light | Yes | — | — | — | No novel find. |
+| build_layer_blend | Compositing | Yes | — | — | — | No novel find. |
+| build_magic_eraser | SAM3 + LaMa | Yes + upgrade | SAM 3.1 Multiplex | https://github.com/Comfy-Org/ComfyUI/pull/13408 | low | SAM 3.1 improves segmentation step in erase pipeline. |
+| build_lama_remove | LaMa | Yes | — | — | — | No novel find. |
+| build_wan_video | WAN 2.1 | Yes + additive | SVI (ICLR 2026 Oral) infinite-length | https://github.com/vita-epfl/Stable-Video-Infinity | medium | Error-recycling on Wan2.2 backbone; research-code ComfyUI workflow. Monitor. |
+| build_wan22_t2v | WAN 2.2 | Yes + additive | SVI infinite-length | https://github.com/vita-epfl/Stable-Video-Infinity | medium | Same as build_wan_video. |
+| build_wan_flf | WAN 2.x FLF | Yes | — | — | — | No novel find. |
+| build_wan_animate_video | WAN animate | Yes | — | — | — | No novel find. |
+| build_wan_video_blockswap | WAN + BlockSwap | Yes | — | — | — | No novel find. |
+| build_wan_video_blockswap_t2v | WAN + BlockSwap T2V | Yes | — | — | — | No novel find. |
+| build_ltx_video | LTX-Video (prior) | **No** | **LTX-2.3** (22B, FP8 ≤16 GB) | https://ltx.io/model/ltx-2-3 | low | Native ComfyUI v0.27.0 support landed Jun 30. 4K, 50 FPS, audio. **Tier 1 upgrade.** |
+| build_hunyuan_video | HunyuanVideo | Yes | — | — | — | No novel find this week. |
+| build_mochi_video | Mochi | Yes | — | — | — | No novel find. |
+| build_cogvideo_video | CogVideoX | Yes | — | — | — | No novel find. |
+| build_framepack_video | FramePack | Yes | — | — | — | No novel find. |
+| build_frame_assembly | Utility | Yes | — | — | — | No novel find. |
+| build_video_upscale | Real-ESRGAN etc. | Conditionally | FlashVSR (CVPR 2026) | https://github.com/OpenImagingLab/FlashVSR | medium | 4 community ComfyUI ports; 8–16 GB with lighter backbone; 12× faster than prior diffusion VSR. |
+| build_seedvr2_video_upscale | SeedVR2 (prior nodes) | **No** | **SeedVR2 v2.5** (same weights, new nodes) | https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler | low | Modular 4-node redesign, BlockSwap → 8 GB, GGUF Q4 → 8 GB. In ComfyUI Manager. **Tier 1.** |
+| build_video_reactor | ReActor on video | Yes + upgrade | HyperSwap 1c_256 in ReActor | https://github.com/Gourieff/ComfyUI-ReActor/issues/143 | low | 256px face resolution vs 128px inswapper; same ONNX speed. Already supported. |
+| build_wavespeed_upscale | WaveSpeed | Conditionally | NVIDIA RTX Video SR | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | low | RTX GPU required; 30× faster per NVIDIA benchmarks. Hardware-gated — skip if non-RTX. |
+| build_upscale | Real-ESRGAN etc. | Yes | — | — | — | No novel find. |
+| build_upscale_blend | Blended upscalers | Yes | — | — | — | No novel find. |
+| build_seedv2r | SeedVR | Yes | — | — | — | No novel find. |
+| build_faceswap | ReActor + inswapper_128 | **No** | **HyperSwap 1c_256** | https://github.com/Gourieff/ComfyUI-ReActor/issues/143 | low | Drop-in; 256px face resolution. Already supported by ReActor. **Tier 1.** |
+| build_faceswap_model | ReActor training | Yes | — | — | — | No novel find. |
+| build_faceswap_mtb | MTB face swap | Conditionally | DreamID-V 1.3B-Faster | https://github.com/bytedance/DreamID-V | medium | Better video identity fidelity; 16 GB feasible via JR ComfyUI fork. Tier 2. |
+| build_photobooth | Klein iterative | Yes | — | — | — | No novel find. |
+| build_save_face_model | ReActor utility | Yes | — | — | — | No novel find. |
+| build_faceid_img2img | IP-Adapter FaceID | Yes | — | — | — | InsightFace 1.0 (May 26) adds GUI/eval only; no new open-weight swapper. |
+| build_face_restore | CodeFormer | Conditionally | DiffBIR v2.1 | https://github.com/XPixelGroup/DiffBIR | low | ComfyUI node available; 8 GB tiled; handles occlusion/accessories better than CodeFormer. Tier 3. |
+| build_photo_restore | Upscale + CodeFormer | Conditionally | DiffBIR v2.1 | https://github.com/XPixelGroup/DiffBIR | low | Same as build_face_restore. Tier 3. |
+| build_detail_hallucinate | SR + detail | Yes | — | — | — | No novel find. |
+| build_supir | SUPIR (SDXL 5-stage) | Conditionally | RealRestorer | https://github.com/StartHua/Comfyui_RealRestorer | low | Broader degradation coverage, one pass, ComfyUI node available (Mar 2026). Tier 2. |
+| build_color_match | Color matching | Yes | — | — | — | No novel find. |
+| build_klein_color_match | Klein color match | Yes | — | — | — | No novel find. |
+| build_colorize | Klein colorize | Conditionally | ColorFLUX (CVPR 2026) | https://arxiv.org/abs/2603.28162 | medium | No ComfyUI node yet; Flux-based ~16 GB; better structure preservation for old photos. Monitor. |
+| build_ddcolor | DDColor | Conditionally | ColorFLUX (CVPR 2026) | https://arxiv.org/abs/2603.28162 | medium | Same as build_colorize. Monitor. |
+| build_lut | LUT grading | Yes | — | — | — | No novel find. |
+| build_rembg | rembg | Yes | — | — | — | No novel find for base rembg. |
+| build_rembg_birefnet | BiRefNet-general | **No** | **ComfyUI-RMBG v3.0.0** | https://github.com/1038lab/ComfyUI-RMBG | low | Bundles BiRefNet-HR (2048px) + BEN2 (hair + 4K matting). Released Jan 1 2026. **Tier 1.** |
+| build_rembg_v3 | RMBG-2.0 | **No** | **ComfyUI-RMBG v3.0.0** | https://github.com/1038lab/ComfyUI-RMBG | low | Multi-model selector; BEN2 beats RMBG-2.0 on hair edges. **Tier 1.** |
+| build_sam3_segment | SAM 3 | **No** | **SAM 3.1 Multiplex** (native ComfyUI) | https://github.com/Comfy-Org/ComfyUI/pull/13408 | low | Merged into ComfyUI core in the Jul 4–11 window; native SAM3_Detect, SAM3_VideoTrack, SAM3_TrackToMask nodes. **Tier 1.** |
+| build_sam3_mask | SAM 3 | **No** | **SAM 3.1 Multiplex** | https://github.com/Comfy-Org/ComfyUI/pull/13408 | low | Same. **Tier 1.** |
+| build_sam3_extract | SAM 3 | **No** | **SAM 3.1 Multiplex** | https://github.com/Comfy-Org/ComfyUI/pull/13408 | low | Same. **Tier 1.** |
+| build_normal_map | Standard normal estimator | Conditionally | RoSE (ICLR 2026 Oral) | https://github.com/LMozart/ICLR2026-RoSE | medium | Shading-sequence normal estimation; no ComfyUI node yet. Monitor. |
+| build_depth_map_v3 | Depth Anything v3 | Conditionally | SurGe (Jun 2026) | https://github.com/karimknaebel/surge | medium | Best zero-shot surface geometry; no ComfyUI node yet. Monitor. |
+| build_hunyuan_3d_mesh | HunyuanVideo 3D | Conditionally | TRELLIS 2 | https://github.com/visualbruno/ComfyUI-Trellis2 | low | ComfyUI nodes since Feb 2026; open-source, quad topology, ~12–16 GB. Tier 2. |
+| build_hunyuan_3d_textured | HunyuanVideo 3D textured | Conditionally | TRELLIS 2 | https://github.com/visualbruno/ComfyUI-Trellis2 | low | Same; adds PBR textures, UV unwrap, hole-filling. Tier 2. |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+These require only installing updated model weights or node packs — no new pipeline logic.
+
+### 1. SAM 3.1 Multiplex → build_sam3_segment / build_sam3_mask / build_sam3_extract / build_klein_sam3_inpaint / build_magic_eraser
+- **PR**: https://github.com/Comfy-Org/ComfyUI/pull/13408
+- **Weights**: https://huggingface.co/Comfy-Org/sam3.1
+- Native nodes: `SAM3_Detect`, `SAM3_VideoTrack`, `SAM3_TrackToMask`
+- Multiplex shared-memory tracker, bit-packed mask IDs, text + point conditioned. Merged into ComfyUI core in the July 4–11 window.
+- VRAM: ~8–10 GB
+
+### 2. SeedVR2 v2.5 → build_seedvr2_video_upscale
+- **Node pack**: https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler
+- Modular 4-node redesign; BlockSwap CPU offload; GGUF Q4_K_M quantization. Same 7B model weights, dramatically better memory management.
+- Now installable via ComfyUI Manager.
+- VRAM: 8 GB (GGUF Q4 + BlockSwap), 12–16 GB (FP8)
+
+### 3. HyperSwap 1c_256 → build_faceswap / build_video_reactor
+- **Swap model**: `hyperswap_1c_256.onnx` (FaceFusion Labs, Apache 2.0)
+- Drop models into `ComfyUI/models/hyperswap/`; already supported in ComfyUI-ReActor (issue #143).
+- 256px face resolution vs 128px for legacy `inswapper_128.onnx`; same inference speed.
+- Became the default in FaceFusion 3.7.0 (Jun 30 2026).
+- VRAM: minimal (ONNX, ~200 MB model)
+
+### 4. LTX-2.3 (22B FP8) → build_ltx_video
+- **Model page**: https://ltx.io/model/ltx-2-3
+- **HuggingFace**: https://huggingface.co/Lightricks/LTX-Video (FP8 variant)
+- Native ComfyUI v0.27.0 support (Jun 30). 4K, up to 50 FPS, synchronized audio.
+- FP8 quantized variant fits 16 GB VRAM; Context Windows prevent OOM on longer sequences.
+- Also ships LTX-2 IC-LoRA Pixel Spatial Upscaler (2× / 4× latent upscaling, relevant to build_video_upscale).
+- VRAM: ~16 GB (FP8)
+
+### 5. ComfyUI-RMBG v3.0.0 → build_rembg_birefnet / build_rembg_v3
+- **Node pack**: https://github.com/1038lab/ComfyUI-RMBG
+- Single node exposing RMBG-2.0, BEN, **BEN2** (Confidence Guided Matting, hair + 4K), **BiRefNet-HR** (2048×2048), SAM3, GroundingDINO.
+- BEN2 surpasses both BiRefNet-general and RMBG-2.0 on hair edges and 4K images.
+- VRAM: ~6–8 GB (BEN2 / BiRefNet-HR)
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+These expand Spellcaster's capability surface and require wiring new builders.
+
+### 6. Seedream 5.0 Pro → new `build_seedream_edit` (API-only)
+- **ComfyUI blog**: https://blog.comfy.org/p/seedream-50-pro
+- Released July 8, 2026; partner node in ComfyUI v0.27.1.
+- Reasoning image model: point/lasso/sketch/color-swap editing, layer export to alpha PNG, 2K output, 10+ languages.
+- Requires Volcano Engine / BytePlus / fal API key — no local weights.
+- VRAM: N/A
+
+### 7. Krea 2 Turbo → new `build_krea2_txt2img`
+- **HuggingFace**: https://huggingface.co/Comfy-Org/Krea-2
+- 12.9B DiT; Turbo variant = 8-step distilled, ~12 GB. Ships with 9 style LoRAs under Krea 2 Community License.
+- ComfyUI v0.27.1 added Advanced Krea 2 Model Merging node (Jul 8).
+- Could also back `build_style_transfer` via the 9 bundled style LoRAs.
+- VRAM: ~12 GB (Turbo)
+
+### 8. FlashVSR → new `build_flashvsr_video_upscale`
+- **GitHub**: https://github.com/OpenImagingLab/FlashVSR
+- CVPR 2026 (OpenImagingLab / Alibaba). One-step diffusion video SR with locality-constrained sparse attention.
+- 12× faster than prior diffusion VSR; ~17 FPS at 768×1408 on A100.
+- Community ComfyUI ports: `smthemex/ComfyUI_FlashVSR`, `1038lab/ComfyUI-FlashVSR`, `naxci1/ComfyUI-FlashVSR_Stable`.
+- VRAM: 8–16 GB with LightVAE_W2.1 backbone
+
+### 9. DreamID-V 1.3B-Faster → additive to `build_faceswap_mtb` / new `build_dreamidv_video_faceswap`
+- **GitHub**: https://github.com/bytedance/DreamID-V
+- **HuggingFace**: https://huggingface.co/XuGuo699/DreamID-V
+- ECCV 2026 (ByteDance + Tsinghua). DiT-based face swap with superior temporal identity fidelity vs ONNX methods.
+- 1.3B-Faster variant is 16 GB feasible via `Goldlionren/ComfyUI_JR_DreamID-V` ComfyUI fork.
+- Slower than ONNX per frame; best reserved for high-quality final renders.
+- VRAM: ~16 GB (1.3B-Faster)
+
+### 10. LanPaint → augments build_inpaint / build_inpaint_fooocus / build_klein_inpaint / build_klein_auto_inpaint
+- **GitHub**: https://github.com/scraed/LanPaint
+- **Registry**: https://registry.comfy.org/publishers/scraed/nodes/LanPaint
+- Training-free KSampler replacement for inpainting — any checkpoint inpaints without a dedicated inpaint model.
+- Krea 2 inpaint support landed July 2, 2026. Supports Flux, Klein, Wan 2.2, Qwen-Image, SDXL, SD 1.5.
+- VRAM: inherits from loaded backbone (no overhead)
+
+### 11. TRELLIS 2 → new `build_trellis2_3d` / replacement for `build_hunyuan_3d_mesh` + `build_hunyuan_3d_textured`
+- **ComfyUI nodes**: https://github.com/visualbruno/ComfyUI-Trellis2
+- Microsoft Research; open-source + free commercial use. 4B-param structured-latent diffusion.
+- Multi-view input, GLB mesh, UV unwrap, PBR textures, quad topology, hole-filling, low-poly variant.
+- ComfyUI workflow updated Feb 28, 2026.
+- VRAM: ~12–16 GB
+
+### 12. RealRestorer → new `build_realrestorer` / complement to `build_supir`
+- **GitHub**: https://github.com/yfyang007/RealRestorer
+- **ComfyUI node**: https://github.com/StartHua/Comfyui_RealRestorer
+- Diffusion-model-based unified restoration; handles diverse degradations in one forward pass vs SUPIR's 5-stage pipeline.
+- Paper Mar 26, 2026; ComfyUI node already available.
+- VRAM: ~12–16 GB
+
+### 13. QwenStyle LoRA → augments `build_style_transfer` / `build_qwen_edit`
+- **GitHub**: https://github.com/witcherofresearch/Qwen-Image-Style-Transfer
+- LoRA + lightning LoRA trained on Qwen-Image-Edit. Zero-shot style transfer with superior content preservation.
+- Drop-in on Spellcaster's existing Qwen-Image-Edit backbone.
+- VRAM: ~12–16 GB (Qwen-Image base, no overhead vs current)
+
+### 14. Anima Base v1 → new `build_anima_txt2img`
+- **Docs**: https://docs.comfy.org/tutorials/image/anima/anima
+- 2B-param DiT (CircleStone Labs + ComfyUI Org); anime + illustration; tag + natural-language conditioning.
+- Released May 15, 2026. Very low VRAM makes it accessible where Klein cannot run.
+- VRAM: 6 GB
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+These are real advances but lack ComfyUI nodes, exceed 16 GB, or are research-code quality.
+
+| Item | Relevant method | Blocker | URL |
+|---|---|---|---|
+| SurGe (Jun 2026, best zero-shot geometry) | build_depth_map_v3 | No ComfyUI node | https://github.com/karimknaebel/surge |
+| RoSE — ICLR 2026 Oral normal estimation | build_normal_map | No ComfyUI node | https://github.com/LMozart/ICLR2026-RoSE |
+| ColorFLUX — CVPR 2026 colorization | build_colorize / build_ddcolor | No ComfyUI node | https://arxiv.org/abs/2603.28162 |
+| TeleStyle V2 (Jun 10, 2026) | build_style_transfer | No ComfyUI node; ~24 GB est. | https://github.com/Tele-AI/TeleStyleV2 |
+| DiffBIR v2.1 | build_face_restore / build_photo_restore | ComfyUI node exists; gaining traction — evaluate | https://github.com/XPixelGroup/DiffBIR |
+| Stable Video Infinity (SVI) — ICLR 2026 Oral | build_wan_video / build_wan22_t2v | Research-code quality ComfyUI workflow; fine-tuned Wan2.2 weights | https://github.com/vita-epfl/Stable-Video-Infinity |
+| Meshy 6 (official ComfyUI partner, Jan 2026) | build_hunyuan_3d_mesh / _textured | API/credit-based; best topology quality | https://blog.comfy.org/p/meshy-6-now-available-in-comfyui |
+| Hunyuan3D 3.1 / 3.5 Pro (Jan 2026) | build_hunyuan_3d_mesh / _textured | Check if existing checkpoint already resolves to 3.1; verify | https://github.com/Tencent-Hunyuan/Hunyuan3D-2 |
+| NVIDIA RTX Video SR | build_wavespeed_upscale | Hardware-gated (RTX required) | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI |
+| Qwen-Image-ControlNet-Union (InstantX) | build_controlnet_gen | Requires new Qwen-backbone ControlNet pipeline | https://huggingface.co/InstantX/Qwen-Image-ControlNet-Union |
+| FaceFusion 3.7.0 (Jun 30) | build_faceswap | FaceFusion wrapper node, not direct ReActor upgrade | https://github.com/facefusion/facefusion/releases/tag/3.7.0 |
+| Wan 2.2 5B Fun InP (start/end frame) | build_wan_flf | Primarily video; >16 GB for 14B variant | https://www.comfy.org/workflows/video_wan2_2_5B_fun_inpaint-00d3d57a5195/ |
+| MAGI-1.1 24B autoregressive video | (no current builder) | VRAM unclear for distilled; 24B+ for full | https://github.com/SandAI-org/MAGI-1 |
+| GSwap (TVCG) — 3D-Gaussian head swap | build_klein_headswap | Research-only; no inference code | https://ustc3dv.github.io/GSwap/ |
+| CA-IDD — diffusion face swap + gaze | build_faceswap | Research-only; no weights | https://arxiv.org/abs/2604.24493 |
+| RefSTAR — reference blind face restore | build_face_restore | GitHub code available, no ComfyUI wrapper | https://github.com/yinzhicun/RefSTAR |
+| LTX-2 IC-LoRA Pixel Spatial Upscaler | build_video_upscale | Requires LTX-2 pipeline context (not standalone) | https://github.com/Comfy-Org/ComfyUI/pull/13325 |
+| MiM-DiT — MoE-DiT all-in-one restore | build_supir | Research-only; no weights released | https://arxiv.org/abs/2603.02710 |
+
+---
+
+## No-finds (verified)
+
+The following were explicitly searched and nothing novel found in the Jul 4–11 window:
+
+- **Flux successor / SD4**: no announcement
+- **Flux.2 Klein successor** (beyond existing 4B/9B): no new release
+- **PuLID successor / update**: none found
+- **IC-Light update** (build_iclight): none found
+- **LaMa successor** (build_lama_remove): none found
+- **HunyuanVideo new version** (build_hunyuan_video): none found
+- **CogVideoX new version**: none found
+- **Mochi update**: none found
+- **FramePack update** (build_framepack_video): none found
+- **WAN FLF-specific update** (build_wan_flf): none found
+- **IP-Adapter FaceID new release** (build_faceid_img2img): none found (InsightFace 1.0 adds GUI, not open weights)
+- **build_photobooth / build_save_face_model**: no relevant finds
+- **build_lut**: no relevant finds
+- **build_rembg (base)**: no novel find for the vanilla rembg library path
+- **build_upscale / build_upscale_blend**: no novel find for Real-ESRGAN family
+
+---
+
+*Report generated by automated SOTA review agent. No implementation changes made. All upgrades require local node-pack installs on the user's machine.*
+
+*The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically after any builder changes are applied.*


### PR DESCRIPTION
## Summary

Automated daily SOTA survey for ISO week `2026-W28` (Jul 4–11, 2026). First run — no prior baseline. Hardware budget: RTX 5060 Ti, 16 GB VRAM.

| Tier | Count | Description |
|---|---|---|
| **Tier 1** — drop-in supersessions | **5** | Ship soon; only weights/node-pack installs required |
| **Tier 2** — additive new builders | **10** | New capabilities; node-pack wiring needed |
| **Tier 3** — monitor / not wire-ready | **17** | No ComfyUI node yet, research-only, or hardware-gated |
| No-finds (verified) | 14 families | Flux successor, PuLID, IC-Light, LaMa, HunyuanVideo, CogVideoX, Mochi, FramePack, WAN FLF, FaceID, etc. |

---

## Tier 1 — Drop-in supersessions (ship soon)

1. **SAM 3.1 Multiplex** → `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract` / `build_klein_sam3_inpaint` / `build_magic_eraser`
   Native ComfyUI PR [#13408](https://github.com/Comfy-Org/ComfyUI/pull/13408) merged in the Jul 4–11 window. Faster multi-object tracking, native nodes. Weights: `Comfy-Org/sam3.1`. VRAM ~8–10 GB.

2. **SeedVR2 v2.5** → `build_seedvr2_video_upscale`
   Modular 4-node redesign, BlockSwap offload, GGUF Q4_K_M — same 7B weights but 8 GB VRAM. Now in ComfyUI Manager. [`numz/ComfyUI-SeedVR2_VideoUpscaler`](https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler)

3. **HyperSwap 1c_256** → `build_faceswap` / `build_video_reactor`
   Drop-in ONNX swap model: 256px face resolution vs 128px inswapper_128. Already supported by ComfyUI-ReActor; became FaceFusion 3.7.0 default (Jun 30). Models go in `ComfyUI/models/hyperswap/`.

4. **LTX-2.3** (22B, FP8 ≤16 GB) → `build_ltx_video`
   Native ComfyUI v0.27.0 support (Jun 30). 4K, 50 FPS, synchronized audio. Apache 2.0 FP8 variant fits 16 GB. Also ships IC-LoRA Pixel Spatial Upscaler for in-pipeline 2×/4× upscaling.

5. **ComfyUI-RMBG v3.0.0** → `build_rembg_birefnet` / `build_rembg_v3`
   Multi-model bundle adding BEN2 (Confidence Guided Matting, hair + 4K) and BiRefNet-HR (2048px). [`1038lab/ComfyUI-RMBG`](https://github.com/1038lab/ComfyUI-RMBG). VRAM ~6–8 GB.

---

## Tier 2 — Additive new builders

| New builder | Model | VRAM |
|---|---|---|
| `build_seedream_edit` | Seedream 5.0 Pro (API, Jul 8 partner node) | N/A |
| `build_krea2_txt2img` | Krea 2 Turbo 12.9B + 9 style LoRAs | ~12 GB |
| `build_flashvsr_video_upscale` | FlashVSR (CVPR 2026), 4 community ComfyUI ports | 8–16 GB |
| `build_dreamidv_video_faceswap` | DreamID-V 1.3B-Faster (16 GB via JR fork) | ~16 GB |
| `build_trellis2_3d` | TRELLIS 2 (Microsoft, open-source, Feb 2026 ComfyUI nodes) | 12–16 GB |
| `build_realrestorer` | RealRestorer (ComfyUI node, Mar 2026) | 12–16 GB |
| LanPaint augments inpaint builders | Universal training-free inpainting KSampler | backbone |
| QwenStyle LoRA augments `build_qwen_edit` | LoRA on Qwen-Image-Edit for style transfer | same |
| `build_anima_txt2img` | Anima Base v1 (2B DiT, anime/illustration) | 6 GB |
| LTX IC-LoRA upscaler (within `build_ltx_video`) | In-pipeline 2×/4× latent upscaling | LTX-2 |

---

## Tier 3 — Monitor / not wire-ready

SurGe (depth, Jun 2026, no ComfyUI node), RoSE (normals, ICLR 2026 Oral, no node), ColorFLUX (CVPR 2026 colorization, no node), TeleStyle V2 (Jun 10, no node), DiffBIR v2.1 (face restore, gaining traction), Stable Video Infinity (SVI, ICLR 2026 Oral, research-code), Meshy 6 (API/credit-based 3D), Hunyuan3D 3.1/3.5 Pro (verify existing checkpoint), NVIDIA RTX VSR (hardware-gated), FaceFusion 3.7.0, GSwap (research, no code), CA-IDD (research, no weights), RefSTAR (face restore, GitHub only), Wan 2.2 5B Fun InP, MAGI-1.1 24B.

---

## Files changed

- `_dev_docs/upgrade_research/2026-W28.md` — full findings table + tier breakdowns
- `_dev_docs/upgrade_research/2026-W28.json` — machine-readable records (44 items across all builders)

---

> **Do not merge** — leave open for human review and triage.
>
> The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically after any builder changes are applied locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDFddWEx7XncMKA8FwTr7N)_