### PR TITLE
chore(research): daily SOTA review 2026-07-12

### DIFF
--- a/_dev_docs/upgrade_research/2026-W28.json
+++ b/_dev_docs/upgrade_research/2026-W28.json
@@ -1,0 +1,282 @@
+[
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Object Multiplex)",
+    "source": "github",
+    "url": "https://github.com/facebookresearch/sam3",
+    "risk": "low",
+    "confidence": 0.97,
+    "notes": "Meta released Mar 27 2026; ComfyUI PR #13408 merged Apr 23 2026. Drop-in checkpoint swap; adds joint multi-object tracking. Also applies to build_sam3_mask and build_sam3_extract."
+  },
+  {
+    "method": "build_sam3_extract",
+    "category": "checkpoint",
+    "name": "EfficientSAM3 v0.4.0",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Simon7108528/EfficientSAM3",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Knowledge distillation of SAM3 to 89–95M params (vs ~900M+). Three Stage-3 variants: EV-M, RV-M, TV-M. Merged into HF Transformers. Use for VRAM-constrained runs. Also applies to build_sam3_segment."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 256 (1b balanced / 1c quality)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "ONNX face-swap at 256px (2x vs inswapper_128). Supported in ComfyUI-ReActor v0.6.x. 1a has known black-circle artifact — use 1b or 1c. Also applies to build_faceswap_model and build_video_reactor."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "node_pack",
+    "name": "ComfyUI-ReActor v0.6.x — Restore Face Advanced",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "New ReActorRestoreFaceAdvanced node restricts restoration to swapped face region only. ReActorSetWeight adds 0-100% swap strength control in 12.5% steps. Also improves build_faceswap, build_faceswap_model, build_faceswap_mtb."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "ComfyUI-FlashVSR_Stable (CVPR 2026)",
+    "source": "github",
+    "url": "https://github.com/naxci1/ComfyUI-FlashVSR_Stable",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "One-step diffusion video SR. VRAM-managed: tiled VAE → tiled DiT → chunking fallback. 5 VAE options incl Wan2.1/2.2. Full mode on 16GB for short clips; Tiny Long for longer. Also applies to build_wavespeed_upscale and build_seedvr2_video_upscale. HF: https://huggingface.co/1038lab/FlashVSR"
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 FP8 distilled",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3-fp8",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "22B param T2V/I2V, 4K native, synchronized audio. FP8 fits 16GB with sequential offloading. ComfyUI-LTXVideo already supports 2.3 — checkpoint swap only. Set sampler=euler_ancestral_cfg_pp, CFG=1, steps=8 for fast variant."
+  },
+  {
+    "method": "build_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX Video Super Resolution (ComfyUI v0.27.1)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Shipped as Partner Node in ComfyUI v0.27.1 (Jul 8 2026). Hardware Tensor Core upscaling, ~30x faster than SW upscalers, ~2-4GB VRAM on RTX 50-series (NVFP4). Speed-first; no detail hallucination. Also applies to build_video_upscale and build_wavespeed_upscale."
+  },
+  {
+    "method": "build_rembg",
+    "category": "node_pack",
+    "name": "ComfyUI-RMBG v3.0.0 (1038lab)",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-RMBG",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Unified node pack covering RMBG-2.0, BiRefNet, BEN, BEN2, SAM/SAM2/SAM3, GroundingDINO, SDMatte, INSPYRENET. SAM3 added v2.9.4. BEN2 added v1.7.0. Also applies to build_rembg_birefnet and build_rembg_v3."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Krea-2-Turbo FP8",
+    "source": "huggingface",
+    "url": "https://huggingface.co/krea/Krea-2-Turbo",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "12B param, 8-step distilled, 2K native, ~2 sec on consumer GPU (Jun 22 2026). Community license (free commercial <50 seats). FP8 fits 16GB. 594 likes / 175K downloads. Parallel architecture path alongside Flux/Klein. Also applies to build_img2img and build_style_transfer."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "controlnet",
+    "name": "Krea-2-depth-controlnet",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Patil/Krea-2-depth-controlnet",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "Depth ControlNet LoRA for Krea-2 (Jul 3 2026). 92 likes. ComfyUI node: https://github.com/facok/comfyui-krea2-controlnet (depth, canny, pose, lineart, normal). Requires Krea-2 base model."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "node_pack",
+    "name": "InfiniteYou (ByteDance, ICCV 2025 Highlight)",
+    "source": "github",
+    "url": "https://github.com/bytedance/ComfyUI_InfiniteYou",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "InfuseNet injects face identity via residual connections into Flux DiT. Outperforms PuLID on identity similarity and CLIPScore. Official ComfyUI nodes from ByteDance. Also applies to build_faceid_img2img. Paper: https://huggingface.co/papers/2503.16418"
+  },
+  {
+    "method": "build_lama_remove",
+    "category": "checkpoint",
+    "name": "Moebius 0.22B (ECCV 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/hustvl/Moebius",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Knowledge-distilled from PixelHacker (Jun 17-18 2026). Matches FLUX.1-Fill-Dev at >15x faster (26ms/step). MIT license. <2GB VRAM. No dedicated ComfyUI node yet — wrap via diffusers or await comfyui-inpaint-nodes integration. Also applies to build_magic_eraser."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "Bernini-R 1.3B (ByteDance, Apache 2.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ByteDance/Bernini-R",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Unified T2V/I2V/editing built on Wan2.2 DiT (Jun 2026). 1.3B variant comfortably fits 16GB. Shares Wan2.2 VAE/DiT infrastructure. GGUF quants of 14B variant at https://huggingface.co/neuregex/Bernini-R-GGUF Also applies to build_wan22_t2v and build_wan_video."
+  },
+  {
+    "method": "build_cogvideo_video",
+    "category": "node_pack",
+    "name": "VOID — Netflix Video Object Removal (Apache 2.0)",
+    "source": "github",
+    "url": "https://github.com/netflix/void-model",
+    "risk": "low",
+    "confidence": 0.70,
+    "notes": "CogVideoX fine-tune for physics-aware video object removal (shadows, reflections, motion). ComfyUI PR #13403 merged natively. Tutorial: https://docs.comfy.org/tutorials/utility/void-video-inpainting. May 2026."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Pixal3D (TencentARC, SIGGRAPH 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/TencentARC/Pixal3D",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Pixel-aligned image-to-3D via TRELLIS.2 backbone (May 24 2026). Near-reconstruction fidelity + PBR textures. MIT license. Native 16-24GB; GGUF community quants targeting ~8GB. Also applies to build_hunyuan_3d_textured. GitHub: https://github.com/TencentARC/Pixal3D"
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "PixelDiT-1300M (NVIDIA, CVPR 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/nvidia/PixelDiT-1300M-1024px",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "1.3B VAE-free pixel-space DiT; <6GB VRAM. Native ComfyUI support in v0.27.0. Best Paper Finalist. Quality ceiling vs larger models unknown. Tutorial: https://docs.comfy.org/tutorials/image/pixeldit/pixeldit"
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "BFS-Best-Face-Swap LoRA (Alissonerdx)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "LoRA for Qwen-Image-Edit-2511 (Klein base). 492K downloads, 681 likes. Instruction-based face/head swap. VRAM: 12-14GB for base model — tight on 16GB. Jun 17 2026 fork: https://huggingface.co/justusgeorge10/BFS-Best-Face-Swap. Also applies to build_klein_face_detail."
+  },
+  {
+    "method": "build_lut",
+    "category": "node_pack",
+    "name": "Code2Collapse ComfyUI-CustomNodePacks (72 nodes)",
+    "source": "github",
+    "url": "https://github.com/Code2Collapse/ComfyUI-CustomNodePacks",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "72-node VFX suite: SAM2.1/SAM3 segmentation, ViTMatte alpha matting, .cube LUT, EXR I/O, depth warp, normal→curvature, render pass compositing, grain matching, temporal anchors, video mask propagation. May 2026. Also improves build_normal_map, build_sam3_* builders."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "RealRestorer (StepFun/SUSTech, Apache 2.0 code / NC weights)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "high",
+    "confidence": 0.80,
+    "notes": "TIER 3 MONITOR. DiT-based restoration handling 9 degradation types. Step1X-Edit backbone requires ~20GB — exceeds 16GB budget. Quantized variants expected. Mar 2026. Also applies to build_seedv2r and build_photo_restore. Paper: https://arxiv.org/abs/2603.25502"
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image-Dev (8B, MIT, pixel-native)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
+    "risk": "high",
+    "confidence": 0.82,
+    "notes": "TIER 3 MONITOR. Pixel-native unified model (no VAE). Txt2img + instruction editing + personalization in one 8B model. May 2026. 16GB BF16; FP8 ~8GB. Complex pipeline. Tutorial: https://docs.comfy.org/tutorials/image/hidream/hidream-o1. Also applies to build_qwen_edit."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "SAM2Matting — SAM3 variant (ECCV 2026)",
+    "source": "github",
+    "url": "https://github.com/FudanCVL/SAM2Matting",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "TIER 3 MONITOR (weights pending). Decouples SAM2/SAM3 as tracker from dedicated matting head. Sub-pixel alpha quality (hair, semi-transparent edges). Text/point/box prompts. SAM3 variant ~8GB. HF weights not yet released. Paper: https://huggingface.co/papers/2606.27339"
+  },
+  {
+    "method": "build_wan_video_blockswap",
+    "category": "checkpoint",
+    "name": "MobileWan (Qualcomm AI Research, Jul 7 2026)",
+    "source": "huggingface",
+    "url": "https://hf.co/papers/2607.06173",
+    "risk": "high",
+    "confidence": 0.50,
+    "notes": "TIER 3 MONITOR. Research paper only; no weights released. Adapts Wan2.2-5B for constant-memory via RNN-mode attention + head pruning (20-30% heads removed without quality loss). Also applies to build_wan_video_blockswap_t2v. Project: https://qualcomm-ai-research.github.io/mobilewan"
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "AniGen (VAST AI, SIGGRAPH 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/VAST-AI/AniGen",
+    "risk": "high",
+    "confidence": 0.82,
+    "notes": "TIER 3 MONITOR. Single-image to rigged, animatable 3D (mesh + skeleton + skinning weights) via S3 Fields. TRELLIS.2 backbone. MIT license. ~16GB. New data type requires new builder logic and export nodes. Only relevant if pipeline has animation consumers."
+  },
+  {
+    "method": "build_wan_video_blockswap_t2v",
+    "category": "node_pack",
+    "name": "Sol Video Inference Engine (MIT/Tsinghua, Jun 24 2026)",
+    "source": "huggingface",
+    "url": "https://arxiv.org/abs/2606.23743",
+    "risk": "high",
+    "confidence": 0.30,
+    "notes": "TIER 3 MONITOR. Training-free agent-based acceleration: auto-selects caching/sparse-attn/token-pruning/quant/kernel-fusion. >2x speedup on LTX-2.3 and Wan-based models. No public code or ComfyUI node. B200-only benchmarks. Also applies to build_ltx_video."
+  },
+  {
+    "method": "build_faceswap_mtb",
+    "category": "lora",
+    "name": "BFS-Best-Face-Swap-Video (LTX-2.3 IC-LoRA)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
+    "risk": "high",
+    "confidence": 0.55,
+    "notes": "TIER 3 MONITOR. IC-LoRA for LTX-2.3/Bernini-R for video face swap. Creator-flagged as test stage with identity leakage on cuts. ComfyUI-BFSNodes required. Updated Jun 20 2026. Monitor V4 for stability."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Krea-2-Turbo INT4 (ConvRot community quant)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/AX1Y2JP/Krea-2-Turbo-INT4-ConvRot",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "TIER 3 MONITOR. Community INT4 quant of Krea-2-Turbo uploaded Jul 12 2026 (today). ~6-8GB estimated VRAM. No community testing data yet. Monitor for quality reports over next week."
+  },
+  {
+    "method": "build_iclight",
+    "category": "checkpoint",
+    "name": "LBM Relighting (Jasper AI)",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-LBM",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "TIER 3 MONITOR. Single-step latent bridge matching relighting via reference image. SDXL-based, ~8GB. CC-BY-NC-4.0 restricts commercial use. Additive complement to IC-Light. HF: https://huggingface.co/jasperai/LBM_relighting"
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "ReSwapper 256 (somanchiu)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/somanchiu/reswapper",
+    "risk": "low",
+    "confidence": 0.70,
+    "notes": "TIER 3 MONITOR. Open-source AGPL-3.0 face-swap ONNX (128px + 256px). Community consensus: identity similarity slightly below inswapper_128. Useful as open-license fallback. Supported in ComfyUI-ReActor v0.6.x."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W28.md
+++ b/_dev_docs/upgrade_research/2026-W28.md
@@ -1,0 +1,268 @@
+# Spellcaster daily SOTA review — 2026-07-12
+
+ISO week: `2026-W28`. Baseline: none (inaugural review).
+
+Hardware budget: RTX 5060 Ti, 16 GB VRAM. All entries at or below budget unless noted.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / Upgrade | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| build_txt2img | SDXL / Flux / Klein | Partial | Krea-2-Turbo FP8 (12B, 2K native, 2-sec) | https://huggingface.co/krea/Krea-2-Turbo | Medium | FP8 fits 16 GB; community license (free commercial <50 seats) |
+| build_img2img | SDXL / Flux | Partial | Krea-2-Turbo FP8 | https://huggingface.co/krea/Krea-2-Turbo | Medium | Same swap as txt2img |
+| build_inpaint | SDXL / Flux Fill | Yes | — | — | — | No Tier-1 successor; Moebius covers object-removal sub-case |
+| build_outpaint | SDXL / Flux | Yes | — | — | — | No Tier-1 successor |
+| build_inpaint_fooocus | Fooocus inpaint | Yes | — | — | — | No direct successor found |
+| build_controlnet_gen | ControlNet SDXL/Flux | Partial | Krea-2-depth-controlnet (LoRA, Jul 3) | https://huggingface.co/Patil/Krea-2-depth-controlnet | Medium | Requires Krea-2 base; comfyui-krea2-controlnet node exists |
+| build_generate_anything | SDXL / Flux | Yes | — | — | — | Krea-2-Turbo viable but not a direct successor |
+| build_style_transfer | SDXL / Flux | Yes | — | — | — | Krea-2-Turbo viable but not a direct successor |
+| build_klein_img2img | Klein 4B/9B | Yes | — | — | — | No Klein successor; BFL architecture still current |
+| build_klein_img2img_ref | Klein 4B/9B | Yes | — | — | — | No changes |
+| build_klein_headswap | Klein + headswap | Partial | BFS-Best-Face-Swap LoRA (Qwen/Klein, 492K DL) | https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap | Medium | Instruction-edit paradigm; complement rather than replacement |
+| build_klein_face_detail | Klein | Partial | BFS-Best-Face-Swap LoRA | https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap | Medium | Same LoRA as headswap; enhances face fidelity |
+| build_klein_repose | Klein | Yes | — | — | — | No changes |
+| build_klein_blend | Klein | Yes | — | — | — | No changes |
+| build_klein_batch_variations | Klein | Yes | — | — | — | No changes |
+| build_klein_inpaint | Klein | Yes | — | — | — | No changes |
+| build_klein_virtual_tryon | Klein | Yes | — | — | — | No changes |
+| build_klein_scene_img2img | Klein | Yes | — | — | — | No changes |
+| build_klein_refine | Klein | Yes | — | — | — | No changes |
+| build_klein_auto_inpaint | Klein | Yes | — | — | — | No changes |
+| build_klein_sam3_inpaint | Klein + SAM3 | Partial | SAM 3.1 checkpoint for segment step | https://github.com/facebookresearch/sam3 | Low | SAM 3.1 merged into ComfyUI core (PR #13408) |
+| build_klein_generate_object | Klein | Yes | — | — | — | No changes |
+| build_klein_detail | Klein | Yes | — | — | — | No changes |
+| build_klein_color_match | Klein | Yes | — | — | — | No changes |
+| build_pulid_flux | PuLID on Flux | No | InfiniteYou (ByteDance, outperforms PuLID on identity + CLIPScore) | https://github.com/bytedance/ComfyUI_InfiniteYou | Medium | Official ComfyUI node from ByteDance; ICCV 2025 Highlight |
+| build_lumina2_txt2img | Lumina2 | Yes | — | — | — | No Lumina2 updates found this week |
+| build_qwen_edit | Qwen-Image-Edit | Partial | HiDream-O1-Image-Dev unifies gen+edit in 8B | https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev | High | May 2026; pixel-native, no VAE; 16 GB BF16, FP8 ~8 GB; tutorial at docs.comfy.org |
+| build_iclight | IC-Light | Partial | LBM Relighting (single-step, reference-image guided) | https://github.com/1038lab/ComfyUI-LBM | Low | CC-BY-NC-4.0; additive alternative, not replacement |
+| build_layer_blend | Layer blend | Yes | — | — | — | No changes |
+| build_magic_eraser | SAM3 + LaMa | No | Moebius 0.22B (ECCV 2026; MIT; 15x faster than FLUX.1-Fill) | https://huggingface.co/hustvl/Moebius | Medium | No dedicated ComfyUI node yet; wrap via diffusers; trivial VRAM |
+| build_lama_remove | LaMa | No | Moebius 0.22B | https://huggingface.co/hustvl/Moebius | Medium | Direct functional successor; awaiting ComfyUI wrapper |
+| build_wan_video | Wan 2.1 | Partial | Bernini-R 1.3B extends animate/edit capability | https://huggingface.co/ByteDance/Bernini-R | Medium | Shares Wan2.2 VAE/DiT; open Apache 2.0 |
+| build_wan22_t2v | Wan 2.2 | Partial | Bernini-R 1.3B | https://huggingface.co/ByteDance/Bernini-R | Medium | 1.3B variant comfortably fits 16 GB |
+| build_wan_flf | Wan (first-last-frame) | Yes | — | — | — | No FLF-specific successor; Bernini-R could add this capability |
+| build_wan_animate_video | Wan | Partial | Bernini-R 1.3B (unified T2V/I2V/edit) | https://huggingface.co/ByteDance/Bernini-R | Medium | Best candidate for this builder |
+| build_wan_video_blockswap | Wan + blockswap | Yes | MobileWan (research, Jul 7) once weights land | https://hf.co/papers/2607.06173 | High | Research paper only; RNN-mode constant-memory attn; no weights yet |
+| build_wan_video_blockswap_t2v | Wan + blockswap | Yes | MobileWan (watch) | https://hf.co/papers/2607.06173 | High | Same as above |
+| build_ltx_video | LTX 0.9.8 (13B) | No | LTX-2.3 FP8/GGUF (22B, 4K, audio sync, Mar 2026) | https://huggingface.co/Lightricks/LTX-2.3 | Medium | ComfyUI-LTXVideo node already supports 2.3; sampler switch to euler_ancestral_cfg_pp, CFG=1, steps=8 (fast variant) |
+| build_hunyuan_video | HunyuanVideo 1.5 | Yes | — | — | — | No HunyuanVideo 2.0 found |
+| build_mochi_video | Mochi | Yes | — | — | — | No updates |
+| build_cogvideo_video | CogVideoX 5B | Partial | VOID (Netflix, video object removal, CogVideoX-based, ComfyUI PR #13403) | https://github.com/netflix/void-model | Low | Extends CogVideo; adds physics-aware object removal |
+| build_framepack_video | FramePack | Yes | FramePack-P1 (anti-drift; paper Jun 2025, no weights yet) | — | High | Watch only |
+| build_frame_assembly | frame→video | Yes | — | — | — | No changes |
+| build_video_upscale | 4x-UltraSharp | No | FlashVSR_Stable (CVPR 2026; VRAM-managed, tiling, OOM fallback) | https://github.com/naxci1/ComfyUI-FlashVSR_Stable | Low | Drop-in node; complements SeedVR2; 5 VAE options incl Wan2.1/2.2 |
+| build_seedvr2_video_upscale | SeedVR2 | Partial | FlashVSR_Stable as parallel path | https://github.com/naxci1/ComfyUI-FlashVSR_Stable | Low | SeedVR2 better on noisy sources; FlashVSR faster on clean |
+| build_video_reactor | ReActor + face swap | Partial | HyperSwap 256 1b/1c as face model | https://huggingface.co/facefusion/models-3.3.0 | Low | 2× face resolution; supported in ComfyUI-ReActor v0.6.x |
+| build_wavespeed_upscale | WaveSpeed API | Partial | RTX VSR (ComfyUI v0.27.1 partner node; Tensor Core, ~30× faster than SW) | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | Low | Hardware-accelerated; sharpens pixels without hallucination |
+| build_upscale | 4x-UltraSharp | Partial | RTX VSR as fast hardware path | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | Low | Speed-first; keep 4x-UltraSharp for quality-first path |
+| build_upscale_blend | blend upscale | Yes | — | — | — | No changes |
+| build_faceswap | inswapper_128 | No | HyperSwap 256 1b/1c (2× resolution; ReActor v0.6.x) | https://huggingface.co/facefusion/models-3.3.0 | Low | Drop-in within ReActor; change model path only |
+| build_faceswap_model | face model swap | No | HyperSwap 256 1b/1c | https://huggingface.co/facefusion/models-3.3.0 | Low | Same as faceswap |
+| build_faceswap_mtb | MTB face swap | Partial | ReActor Advanced restore node (targeted restoration) | https://github.com/Gourieff/ComfyUI-ReActor | Low | ReActorRestoreFaceAdvanced restricts restoration to swapped region |
+| build_klein_headswap | Klein | Partial | BFS-Best-Face-Swap LoRA (Qwen/Klein) | https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap | Medium | VRAM tight at 12–14 GB for Qwen-Image-Edit-2511 base |
+| build_klein_face_detail | Klein | Partial | BFS-Best-Face-Swap LoRA | https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap | Medium | See above |
+| build_photobooth | Flux / Klein | Yes | — | — | — | No dedicated successor found |
+| build_save_face_model | face encoder | Yes | — | — | — | No changes |
+| build_faceid_img2img | FaceID | No | InfiniteYou (official ComfyUI nodes, outperforms PuLID + FaceID) | https://github.com/bytedance/ComfyUI_InfiniteYou | Medium | ICCV 2025 Highlight; InfuseNet residual injection into Flux DiT |
+| build_face_restore | CodeFormer / GFPGAN | Partial | ReActor Restore Face Advanced (targeted region); RealRestorer for heavy degradation | https://github.com/Gourieff/ComfyUI-ReActor | Low | GFPGAN/CodeFormer themselves not updated; node quality improved |
+| build_photo_restore | GAN restore | Partial | RealRestorer (DiT-based, 9 degradation types, Apache 2.0 code / NC weights) | https://huggingface.co/RealRestorer/RealRestorer | High | ~20 GB for Step1X-Edit DiT; needs quantized variant before RTX 5060 Ti fit |
+| build_detail_hallucinate | SDXL / Flux | Yes | — | — | — | No changes |
+| build_supir | SUPIR (SDXL) | Partial | RealRestorer (when quantized); RTX VSR as fast pre-pass | https://huggingface.co/RealRestorer/RealRestorer | High | SUPIR still best quality-per-VRAM locally; RealRestorer VRAM exceeds budget until quants arrive |
+| build_color_match | color match | Yes | — | — | — | No changes |
+| build_klein_color_match | Klein | Yes | — | — | — | No changes |
+| build_colorize | iColoriT / DDColor | Yes | — | — | — | No new colorization models found |
+| build_ddcolor | DDColor | Yes | — | — | — | No DDColor 2026 update found |
+| build_lut | LUT node | Partial | Code2Collapse CustomNodePacks (72-node VFX suite, .cube LUT support) | https://github.com/Code2Collapse/ComfyUI-CustomNodePacks | Low | Additive; richer LUT pipeline options |
+| build_rembg | rembg | Partial | ComfyUI-RMBG v3.0.0 (unified: RMBG-2.0 + BiRefNet + BEN2 + SAM3) | https://github.com/1038lab/ComfyUI-RMBG | Low | Single node pack now covers all three rembg builders |
+| build_rembg_birefnet | BiRefNet | Partial | SAM2Matting SAM3 variant (ECCV 2026; text/point/box → alpha matte) — weights pending | https://github.com/FudanCVL/SAM2Matting | Medium | HF weights not yet released; monitor FudanCVL |
+| build_rembg_v3 | RMBG-2.0 | Yes | — | — | — | RMBG-3.0 does not exist; VRMBG-3.0 is video-only |
+| build_sam3_segment | SAM3 | No | SAM 3.1 (Object Multiplex, faster multi-object; ComfyUI PR #13408 merged) | https://github.com/facebookresearch/sam3 | Low | Drop-in checkpoint swap; 3.1 weights on facebookresearch/sam3 |
+| build_sam3_mask | SAM3 | No | SAM 3.1 | https://github.com/facebookresearch/sam3 | Low | Same as segment |
+| build_sam3_extract | SAM3 | No | SAM 3.1 + EfficientSAM3 v0.4.0 (89M params, text/region/exemplar prompts) | https://huggingface.co/Simon7108528/EfficientSAM3 | Low | EfficientSAM3 for VRAM-constrained runs |
+| build_normal_map | Omnidata / DSINE | Partial | Code2Collapse CustomNodePacks (normal→curvature conversion node) | https://github.com/Code2Collapse/ComfyUI-CustomNodePacks | Low | Processing step, not a new inference model |
+| build_depth_map_v3 | DA3 (da3_large) | Yes | — | — | — | No DA4 found; DA3 (ICLR 2026) is current SOTA |
+| build_hunyuan_3d_mesh | HunyuanVideo 3D | Partial | Pixal3D (TencentARC, SIGGRAPH 2026, pixel-aligned, MIT) | https://huggingface.co/TencentARC/Pixal3D | Medium | ~16–24 GB native; GGUF community quants targeting ~8 GB |
+| build_hunyuan_3d_textured | HunyuanVideo 3D | Partial | Pixal3D (PBR textures, near-reconstruction fidelity) | https://huggingface.co/TencentARC/Pixal3D | Medium | AniGen adds rigging/animation on top — watch |
+| build_seedv2r | SeedV2R | Partial | RealRestorer (when quantized); RTX VSR as fast final pass | https://huggingface.co/RealRestorer/RealRestorer | High | Same VRAM caveat as supir |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+These require only a checkpoint swap or node-pack update on the local machine. No new builder code needed in Spellcaster.
+
+### T1-1: SAM 3.1 checkpoint → `build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract`
+Meta released SAM 3.1 on March 27, 2026. The key addition is **Object Multiplex** — shared-memory joint multi-object tracking that is significantly faster than running the tracker independently per object. Native ComfyUI support was merged April 23, 2026 (PR #13408). This is a direct checkpoint swap; the API surface is unchanged.
+
+- Weights: https://github.com/facebookresearch/sam3
+- Action: swap checkpoint to SAM 3.1 in all three sam3 builders
+- Risk: **LOW**
+
+### T1-2: EfficientSAM3 v0.4.0 → `build_sam3_segment`, `build_sam3_extract`
+Knowledge distillation of SAM3 to 89–95M parameters (vs SAM3's ~900M+). Three Stage-3 variants: EV-M (exemplar), RV-M (region), TV-M (text). SAM3-LiteText merged into HuggingFace Transformers.
+
+- Weights: https://huggingface.co/Simon7108528/EfficientSAM3
+- Action: add lightweight variant config option; use for VRAM-constrained runs
+- Risk: **LOW**
+
+### T1-3: HyperSwap 256 (1b quality / 1c best) → `build_faceswap`, `build_faceswap_model`, `build_video_reactor`
+ONNX face-swap models at 256 px output (vs inswapper_128's 128 px). **2× resolution**. Supported in ComfyUI-ReActor v0.6.x. Models drop into `ComfyUI/models/hyperswap/`. The `1a` variant has a known black-circle artifact — use `1b` or `1c`.
+
+- Models: https://huggingface.co/facefusion/models-3.3.0
+- Action: update model path in ReActor; benchmark `1c` before deploying
+- Risk: **LOW**
+
+### T1-4: ReActor Restore Face Advanced node → `build_face_restore`, `build_faceswap`, `build_faceswap_model`, `build_faceswap_mtb`
+New `ReActorRestoreFaceAdvanced` node in ComfyUI-ReActor v0.6.x applies face restoration **only to the swapped face region**, not the full image. Also adds `ReActorSetWeight` (0–100% swap strength in 12.5% steps).
+
+- Node: https://github.com/Gourieff/ComfyUI-ReActor
+- Action: switch face_restore and all faceswap builders to use Advanced node
+- Risk: **LOW**
+
+### T1-5: FlashVSR_Stable → `build_video_upscale`, `build_wavespeed_upscale`, `build_seedvr2_video_upscale`
+CVPR 2026. One-step diffusion-based streaming video super-resolution with locality-constrained sparse attention. **ComfyUI node: `naxci1/ComfyUI-FlashVSR_Stable`** — includes tiled VAE → tiled DiT → chunking progressive OOM fallback, 5 VAE options (Wan2.1 and Wan2.2 VAEs included), auto-download. At 16 GB on the RTX 5060 Ti: full mode for short clips, Tiny Long mode for longer videos.
+
+- GitHub: https://github.com/naxci1/ComfyUI-FlashVSR_Stable
+- HF: https://huggingface.co/1038lab/FlashVSR
+- Action: add FlashVSR_Stable as a parallel upscale path; retain SeedVR2 for noisy/blurry sources where it recovers more detail
+- Risk: **LOW**
+
+### T1-6: LTX-2.3 FP8 → `build_ltx_video`
+Lightricks LTX-2.3 (March 5, 2026) is a 22B parameter T2V/I2V model with native 4K output and synchronized audio. The **FP8 distilled variant** (`Lightricks/LTX-2.3-fp8`) fits on 16 GB with sequential offloading. **ComfyUI-LTXVideo already supports LTX-2.3** — this is a checkpoint upgrade, not a node change.
+
+- HF: https://huggingface.co/Lightricks/LTX-2.3 | FP8: https://huggingface.co/Lightricks/LTX-2.3-fp8
+- Action: swap checkpoint to LTX-2.3-fp8; set sampler to `euler_ancestral_cfg_pp`, CFG=1, steps=8 for fast variant
+- Risk: **MEDIUM** (sampler config change required)
+
+### T1-7: ComfyUI v0.27.1 RTX VSR → `build_upscale`, `build_video_upscale`, `build_wavespeed_upscale`
+ComfyUI v0.27.1 (July 8, 2026) ships NVIDIA RTX Video Super Resolution as a first-class Partner Node (`Comfy-Org/Nvidia_RTX_Nodes_ComfyUI`). Hardware Tensor Core upscaling, claimed ~30× faster than software upscalers, ~2–4 GB VRAM on RTX 50-series (NVFP4 path).
+
+- Repo: https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI
+- Action: add as optional fast final-pass in upscale builders; keep diffusion-based upscalers for quality-first path
+- Risk: **LOW**
+
+### T1-8: ComfyUI-RMBG v3.0.0 unified → `build_rembg`, `build_rembg_birefnet`, `build_rembg_v3`
+`1038lab/ComfyUI-RMBG` now covers RMBG-2.0, BiRefNet, BEN, BEN2, SAM/SAM2/SAM3, GroundingDINO, SDMatte, INSPYRENET in a single node set. SAM3 segmentation added in v2.9.4; BEN2 in v1.7.0. This simplifies the three separate rembg builders.
+
+- GitHub: https://github.com/1038lab/ComfyUI-RMBG
+- Action: verify Spellcaster's rembg builders target this node pack; it now serves as the upstream for model additions
+- Risk: **LOW**
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+These represent genuine new capabilities or parallel paths that require new builder code or node-pack installation on the local machine.
+
+### T2-1: Krea-2-Turbo + depth ControlNet → new `build_txt2img` / `build_controlnet_gen` path
+**Krea-2-Turbo** (June 22, 2026): 12B parameter model, 8-step distilled, 2K native, ~2 seconds on consumer GPU. Community license (free commercial for studios under 50 seats). FP8 fits comfortably in 16 GB. 594 likes / 175K downloads on HF. An INT4 community quant landed July 12, 2026 (`AX1Y2JP/Krea-2-Turbo-INT4-ConvRot`) — needs community vetting.
+
+**Krea-2-depth-controlnet** (July 3, 2026): Depth ControlNet LoRA for Krea-2 (92 likes). ComfyUI node: `facok/comfyui-krea2-controlnet`.
+
+- HF: https://huggingface.co/krea/Krea-2-Turbo | ControlNet: https://huggingface.co/Patil/Krea-2-depth-controlnet
+- ComfyUI node: https://github.com/facok/comfyui-krea2-controlnet
+- Risk: **MEDIUM** — new pipeline (`Krea2Pipeline`); parallel to Flux/Klein, not a replacement
+
+### T2-2: InfiniteYou → new `build_pulid_flux` / `build_faceid_img2img` path
+ByteDance (ICCV 2025 Highlight). InfuseNet injects face identity features via residual connections into Flux DiT, outperforming PuLID on identity similarity and CLIPScore. Official ComfyUI nodes from ByteDance.
+
+- GitHub: https://github.com/bytedance/ComfyUI_InfiniteYou
+- Paper: https://huggingface.co/papers/2503.16418
+- Risk: **MEDIUM** — new InfuseNet component; official ComfyUI nodes already available
+
+### T2-3: Moebius 0.22B → new `build_lama_remove` / `build_magic_eraser` path
+ECCV 2026. Knowledge-distilled from PixelHacker. 0.22B params. Matches FLUX.1-Fill-Dev (11.9B) at >15× faster inference (26ms/step). MIT license. Runs in <2 GB VRAM.
+
+**No dedicated ComfyUI node exists yet.** Can be loaded via diffusers pipeline or added to `comfyui-inpaint-nodes` (Acly) once community wraps it.
+
+- HF: https://huggingface.co/hustvl/Moebius | GitHub: https://github.com/hustvl/Moebius
+- Risk: **MEDIUM** — needs ComfyUI wrapper before wiring
+
+### T2-4: Bernini-R 1.3B → new `build_wan_animate_video` / `build_wan22_t2v` path
+ByteDance Bernini (open-sourced June 2026, Apache 2.0). Architecture: Qwen2.5-VL planner + Wan2.2 DiT renderer. Bernini-R 1.3B lightweight variant fits easily on 16 GB. Handles T2V, I2V, video editing, style transfer, relighting, camera motion mimicry, subject insertion.
+
+- HF: https://huggingface.co/ByteDance/Bernini-R | Full: https://huggingface.co/ByteDance/Bernini-Diffusers
+- GitHub: https://github.com/bytedance/Bernini
+- Risk: **MEDIUM** — shares Wan2.2 VAE/DiT; Qwen planner adds new dependency
+
+### T2-5: VOID (Netflix) → new `build_cogvideo_video` object-removal path
+Open-source (Apache 2.0) video object removal built on and fine-tuned from CogVideoX. Physically reasons about shadows, reflections, and motion caused by removed subject. **ComfyUI PR #13403 merged natively.**
+
+- GitHub: https://github.com/netflix/void-model
+- Tutorial: https://docs.comfy.org/tutorials/utility/void-video-inpainting
+- Risk: **LOW** as standalone; MEDIUM if integrated into `build_cogvideo_video` (separate mask pipeline required)
+
+### T2-6: Pixal3D (TencentARC) → new `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured` path
+SIGGRAPH 2026. Image-to-3D via pixel-aligned feature back-projection (TRELLIS.2 backbone). Near-reconstruction-level fidelity + PBR textures. MIT license. Community GGUF quants targeting ~8 GB.
+
+- HF: https://huggingface.co/TencentARC/Pixal3D | GitHub: https://github.com/TencentARC/Pixal3D
+- Risk: **MEDIUM** — different architecture from HunyuanVideo 3D; new builder needed. Native TRELLIS.2 node support status: TBD.
+
+### T2-7: PixelDiT-1300M → lightweight `build_txt2img` fast-path
+NVIDIA CVPR 2026 Best Paper Finalist. 1.3B VAE-free pixel-space DiT. No external VAE encode/decode step. Native ComfyUI support added in v0.27.0. <6 GB VRAM.
+
+- HF: https://huggingface.co/nvidia/PixelDiT-1300M-1024px | Tutorial: https://docs.comfy.org/tutorials/image/pixeldit/pixeldit
+- Risk: **LOW** — native ComfyUI nodes exist. Quality ceiling unclear vs. larger models.
+
+### T2-8: BFS-Best-Face-Swap LoRA → `build_klein_headswap` enhancement
+LoRA for `Qwen/Qwen-Image-Edit-2511` (Klein base). 492K downloads, 681 likes. Instruction-based face/head swapping on the same architecture Spellcaster already uses.
+
+- HF: https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap (fork updated Jun 17, 2026: `justusgeorge10/BFS-Best-Face-Swap`)
+- Risk: **MEDIUM** — instruction-edit paradigm vs. embedding-based swap; VRAM tight at 12–14 GB base
+
+### T2-9: Code2Collapse CustomNodePacks → `build_lut`, `build_normal_map`, `build_sam3_*`
+72-node VFX suite: SAM2.1/SAM3 segmentation, alpha matting (ViTMatte), .cube LUT application, EXR I/O, depth warp, normal→curvature conversion, render pass compositing, grain matching, temporal anchors, video mask propagation.
+
+- GitHub: https://github.com/Code2Collapse/ComfyUI-CustomNodePacks
+- Risk: **LOW** — additive; installs via ComfyUI Manager
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+| # | Name | Builder(s) | Blocker | URL | ETA |
+|---|---|---|---|---|---|
+| 1 | RealRestorer | build_supir, build_seedv2r, build_photo_restore | ~20 GB for Step1X-Edit DiT; exceeds 16 GB budget until quantized variants land | https://huggingface.co/RealRestorer/RealRestorer | 2–4 weeks for community quants |
+| 2 | HiDream-O1-Image-Dev | build_txt2img, build_qwen_edit | Complex pixel-native pipeline; no VAE; high integration risk | https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev | Needs ComfyUI native tutorial validation |
+| 3 | SAM2Matting (SAM3 variant) | build_rembg_birefnet | HF weights not yet released for SAM3 matting head | https://github.com/FudanCVL/SAM2Matting | Watch FudanCVL HF org |
+| 4 | MobileWan | build_wan_video_blockswap, build_wan_video_blockswap_t2v | Research paper only (Jul 7); no weights; no ComfyUI integration | https://hf.co/papers/2607.06173 | 4–8 weeks if community adapts |
+| 5 | AniGen (VAST AI) | build_hunyuan_3d_mesh, build_hunyuan_3d_textured | New data type (skeleton + skinning); requires new builder logic and export nodes | https://huggingface.co/VAST-AI/AniGen | Only relevant if pipeline has animation consumers |
+| 6 | DreamSR | build_supir | arXiv only; no public weights; no ComfyUI node | https://arxiv.org/abs/2605.15682 | Watch GitHub for weights release |
+| 7 | CanonSwap | build_faceswap_mtb (video) | No ComfyUI node; research code only | https://github.com/Pixel-Talk/CanonSwap | Needs wrapper development |
+| 8 | Sol Video Inference Engine | build_ltx_video, build_wan_video | Research paper; B200-only benchmarks; no consumer GPU results | https://arxiv.org/abs/2606.23743 | Watch for code/ComfyUI release |
+| 9 | BFS-Best-Face-Swap-Video | build_faceswap_mtb | Creator-flagged as test stage; identity leakage on cuts | https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video | Monitor V4 |
+| 10 | Krea-2-Turbo INT4 (ConvRot) | build_txt2img | Fresh community upload Jul 12; no quality benchmark yet | https://huggingface.co/AX1Y2JP/Krea-2-Turbo-INT4-ConvRot | Test within 1 week |
+| 11 | LBM Relighting | build_iclight | CC-BY-NC-4.0 restricts commercial use | https://github.com/1038lab/ComfyUI-LBM | Available for non-commercial experiments |
+| 12 | ReSwapper 256 | build_faceswap | Community consensus rates below inswapper_128 on identity similarity | https://huggingface.co/somanchiu/reswapper | Monitor; useful as open-license fallback |
+| 13 | VRMBG-3.0 (Briaai) | build_rembg_v3 | Video-only; gated non-commercial license; no still-image improvement | https://huggingface.co/briaai/VRMBG-3.0 | N/A for still-image pipeline |
+| 14 | FramePack-P1 | build_framepack_video | Paper published Jun 2025; no downloadable weights | — | Watch for release |
+
+---
+
+## No-finds (verified)
+
+The following were explicitly searched and confirmed absent:
+
+| Query | Result |
+|---|---|
+| Flux3 / Black Forest Labs new release | Not found. Flux.2 (Nov 2025) + Klein (Jan 2026) remain current BFL releases. |
+| IC-Light v3 | Not found. IC-Light V2 (fal.ai) is current state of art. |
+| New LaMa/MAT GAN-based inpainting successor | Not found. Field has moved to distilled diffusion (Moebius is the successor paradigm). |
+| Lumina2 update or successor | Not found. |
+| SD4 open weights | Conflicting reports of April 2026 announcement; no confirmed open-weight release. |
+| Wan 2.3 open weights | Does not exist. Open-weight line ends at Wan 2.2. Commercial API reached 2.7; closed weights. |
+| HunyuanVideo 2.0 | Not found. HunyuanVideo 1.5 (Nov 2025) remains current. |
+| FramePack-P1 weights | Paper posted Jun 2025; no weights released as of Jul 12, 2026. |
+| inswapper successor from Insightface | Not found. HyperSwap and ReSwapper are active alternatives. |
+| GFPGAN v2 / CodeFormer v2 | Not found. Neither model updated in 2026. |
+| InstantID v2 | Not found. Project moved to maintenance-only April 2025. |
+| IP-Adapter v3 | Not found. Last notable update was Flux/SDXL patches Feb 2026. |
+| RMBG-3.0 (still-image) | Does not exist. VRMBG-3.0 is video-only; still-image remains at RMBG-2.0. |
+| SAM4 | Does not exist. Meta's line ends at SAM 3.1 (Mar 2026). |
+| Depth Anything V4 | Not found. DA3 (ICLR 2026) is current SOTA; `build_depth_map_v3` is up to date. |
+| DDColor 2026 update | Not found. No new model or architecture update. |
+| Seedance 2.5 open weights | Closed commercial model only; third-party repos are API wrappers. |
+| WaveSpeed local weights | WaveSpeed Ultimate Video Upscaler is API-only; no local node. |


### PR DESCRIPTION
## Summary

Inaugural automated daily SOTA audit (ISO week `2026-W28`) covering all 74 `build_*` workflow builders across four families. Research via four parallel sub-agents (image-gen, video-gen, face/portrait, restore/style/3D), each querying HuggingFace MCP, web search, GitHub, and Civitai.

---

## Findings at a glance

| Tier | Count | Description |
|---|---|---|
| **Tier 1 — drop-in (ship soon)** | **8** | Checkpoint swap or node-pack update only; no new Spellcaster builder code |
| **Tier 2 — additive new builders** | **9** | New capability paths; need node-pack install on local machine |
| **Tier 3 — monitor / not wire-ready** | **14** | VRAM overbudget, research-only, no ComfyUI node, or known quality issues |
| **No-finds (verified)** | **18** | Explicitly searched and confirmed absent |

---

## Tier 1 highlights (immediate action on local machine)

| # | Item | Builder(s) | Risk |
|---|---|---|---|
| T1-1 | **SAM 3.1** — Object Multiplex, ComfyUI PR #13408 merged | sam3_segment / mask / extract | LOW |
| T1-2 | **EfficientSAM3 v0.4.0** — 89M lightweight SAM3 distillation | sam3_segment / extract | LOW |
| T1-3 | **HyperSwap 256** (1b/1c) — 2× face resolution in ReActor v0.6 | faceswap / faceswap_model / video_reactor | LOW |
| T1-4 | **ReActor Restore Face Advanced** — targeted region-only restoration | face_restore / all faceswap builders | LOW |
| T1-5 | **FlashVSR_Stable** (CVPR 2026) — VRAM-managed one-step video SR | video_upscale / wavespeed / seedvr2 | LOW |
| T1-6 | **LTX-2.3 FP8** — 22B model, 4K, audio, fits 16 GB | ltx_video | MEDIUM |
| T1-7 | **ComfyUI v0.27.1 RTX VSR** — NVIDIA Tensor Core upscaling (~30× SW) | upscale / video_upscale | LOW |
| T1-8 | **ComfyUI-RMBG v3.0.0** — unified rembg node for all three rembg builders | rembg / rembg_birefnet / rembg_v3 | LOW |

## Tier 2 highlights (new builders, node install required)

| # | Item | Builder path |
|---|---|---|
| T2-1 | **Krea-2-Turbo FP8** + depth ControlNet | new txt2img / controlnet_gen architecture path |
| T2-2 | **InfiniteYou** (ByteDance) — outperforms PuLID; official ComfyUI node | pulid_flux / faceid_img2img replacement |
| T2-3 | **Moebius 0.22B** (ECCV 2026, MIT) — LaMa successor at <2 GB VRAM | lama_remove / magic_eraser |
| T2-4 | **Bernini-R 1.3B** (ByteDance, Apache 2.0) — Wan2.2-based unified T2V/I2V/edit | wan_animate_video / wan22_t2v |
| T2-5 | **VOID** (Netflix, Apache 2.0) — physics-aware video object removal | cogvideo_video |
| T2-6 | **Pixal3D** (TencentARC, SIGGRAPH 2026) — pixel-aligned image-to-3D | hunyuan_3d_mesh / hunyuan_3d_textured |
| T2-7 | **PixelDiT-1300M** (NVIDIA) — VAE-free, <6 GB, native ComfyUI | txt2img lightweight path |
| T2-8 | **BFS-Best-Face-Swap LoRA** — Klein/Qwen headswap via instruction edit | klein_headswap / klein_face_detail |
| T2-9 | **Code2Collapse CustomNodePacks** (72 nodes) — VFX suite incl LUT/.cube, SAM3, ViTMatte | lut / normal_map / sam3_* |

## Key no-finds confirmed

Flux3, IC-Light v3, Wan 2.3 open weights, HunyuanVideo 2.0, SAM4, Depth Anything V4, RMBG-3.0 (still-image), GFPGAN v2, CodeFormer v2, InstantID v2, SD4 open weights — none exist as of 2026-07-12.

---

> **Note:** The local `tools/export_comfyui_workflows.py` nightly export (scheduled 03:30) will automatically refresh ComfyUI workflow snapshots. No manual snapshot action is needed alongside this PR.

---

*Do not merge — leave open for human review. Implementation upgrades require local node-pack installs that can only happen on your machine.*

---
_Generated by [Claude Code](https://claude.ai/code/session_016RqtkjYZwBEuLrNogyQi8k)_