### PR TITLE
chore(research): daily SOTA review 2026-07-13

### DIFF
--- a/_dev_docs/upgrade_research/2026-W29.json
+++ b/_dev_docs/upgrade_research/2026-W29.json
@@ -1,0 +1,222 @@
+[
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3-nvfp4 (Lightricks official Blackwell FP4 checkpoint)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3-nvfp4",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Tier 1 -- drop-in supersession. LTX-2.3 22B any-to-any model supersedes the original LTX-Video 2B. Main HF repo lastModified Jul 9 2026 (in-window); community distilled/resharded variants appeared Jul 10-11. nvfp4 checkpoint created March 2026 by Lightricks for NVIDIA Blackwell; 13.8K downloads confirms active use. RTX 5060 Ti is Blackwell so FP4 tensor cores are available; estimated ~11 GB VRAM for transformer alone. Requires MXFP4 support in diffusers -- verify before wiring. W22 T2-E tracked LTX-Video-0.9.7-dev (2B community mirror); this is a wholly different, larger-generation model."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 BF16 / FP8 full checkpoint (Lightricks/LTX-2.3)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3",
+    "risk": "medium",
+    "confidence": 0.8,
+    "notes": "Tier 3 -- VRAM blocker. BF16 checkpoint ~44 GB; FP8 variant ~22 GB; both exceed 16 GB budget on RTX 5060 Ti. 783K downloads (FP8) confirm wide adoption on 24+ GB cards. Use nvfp4 path (see record above) for 16 GB deployment. In-window: lastModified Jul 9 2026."
+  },
+  {
+    "method": "new:build_boogu_txt2img",
+    "category": "checkpoint",
+    "name": "Boogu-Image-0.1-Base + Boogu-Image-0.1-Turbo (Apache-2.0, 10B)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Boogu/Boogu-Image-0.1-Base",
+    "risk": "low",
+    "confidence": 0.8,
+    "notes": "Tier 2 -- additive new builder. Single-Stream DiT 10B model for text-to-image. Apache-2.0 license. FP8-scaled fits 16 GB with sequential CPU offload; 24 GB preferred for unquantized. Released Jun 16 2026; Turbo variant (4-step distilled) in same family. Native ComfyUI support confirmed. Complements HiDream-O1 (W22 T2-B) -- different architecture (standard latent-diffusion vs. HiDream pixel-native). Propose new build_boogu_txt2img method."
+  },
+  {
+    "method": "new:build_boogu_edit",
+    "category": "checkpoint",
+    "name": "Boogu-Image-0.1-Edit-Turbo (Apache-2.0, 10B, Jul 8 hotfix IN-WINDOW)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Tier 2 -- additive new builder. IN-WINDOW: Jul 8 2026 hotfix fixes severe image quality degradation and broken object-removal from the original Jun 16 release. 4-step distilled instruction-based image editing; unified with generation in one model family. 10B, FP8 fits 16 GB. Native ComfyUI integration. Propose new build_boogu_edit method. Fills unified-edit gap alongside build_qwen_edit."
+  },
+  {
+    "method": "new:build_ltx_cinemagraph",
+    "category": "lora",
+    "name": "LTX-2.3-22b-LoRA-Cinemagraph (Lightricks official IC-LoRA)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-LoRA-Cinemagraph",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Tier 2 -- additive new builder. IN-WINDOW: created Jul 5, updated Jul 6 2026. Official Lightricks IC-LoRA for selective-motion / cinemagraph effects (subject moves, background stays). Gated HF model (access request required). Two Lightricks demo Spaces confirm active maintenance. Requires LTX-2.3 base (T1-A upgrade first). VRAM: same as nvfp4 path (~11 GB via Blackwell FP4). New capability distinct from build_wan_flf (semantic first-last-frame interpolation). Propose new build_ltx_cinemagraph method or cinemagraph mode in build_ltx_video."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "lora",
+    "name": "LTX-2.3-22b-IC-LoRA-Pixel-Spatial-Upscaler (Lightricks official)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Pixel-Spatial-Upscaler",
+    "risk": "medium",
+    "confidence": 0.7,
+    "notes": "Tier 3. Official Lightricks IC-LoRA for video spatial super-resolution using LTX-2.3 as generative upscaler backbone. Created Jun 23 2026 (outside window but newly surfaced). Gated model. Full diffusion-pass upscaling vs. frame-by-frame ESRGAN -- quality likely higher but compute much heavier. Only viable on 16 GB via nvfp4 base (T1-A required). Monitor alongside T1-A deployment."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "node_pack",
+    "name": "Seedream 5 Pro (ByteDance ComfyUI partner node, Jul 8 2026)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/seedream-50-pro",
+    "risk": "high",
+    "confidence": 0.9,
+    "notes": "Tier 3. IN-WINDOW: added as ComfyUI partner node in v0.27.1 on Jul 8 2026. Features: deep-thinking prompt reasoning, real-time web search, point/lasso/sketch editing, layer separation, native 2K, on-image text in 10+ languages. NOT a local model -- cloud API (requires ByteDance API key). Risk=high because cloud dependency is architecturally incompatible with Spellcaster local-inference model."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "MobileWan (Qualcomm AI Research, arxiv:2607.06173)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2607.06173",
+    "risk": "high",
+    "confidence": 0.4,
+    "notes": "Tier 3. IN-WINDOW: paper published Jul 7 2026. Compresses WAN 2.2 5B for mobile via recurrent reformulation, causal linear attention, learnable head pruning, step distillation, memory-optimised VAE. Generates 5s 480x832 @16 FPS in 20 seconds on mobile. VBench 83.79. No public checkpoint confirmed at survey time; project page at qualcomm-ai-research.github.io/mobilewan. Architectural signal that WAN 5B can be compressed without major quality loss."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "node_pack",
+    "name": "drozbay/Wan2.2-S2V-14B-module (Jul 11 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/drozbay/Wan2.2-S2V-14B-module",
+    "risk": "medium",
+    "confidence": 0.45,
+    "notes": "Tier 3. IN-WINDOW: created Jul 11 2026. Community ComfyUI module wrapping Wan-AI/Wan2.2-S2V-14B (speech/sound-to-video). Base model at BF16 ~28 GB; FP8 ~14 GB (marginal for 16 GB). 0 downloads at survey time; unproven stability. Not a new model, just a ComfyUI integration. Relevant if Spellcaster adds audio-driven video generation to WAN stack."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "lora",
+    "name": "rzgar/Wan2.2-IS2V (Image+Sound-to-Video finetune, Jul 12 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/rzgar/Wan2.2-IS2V",
+    "risk": "high",
+    "confidence": 0.35,
+    "notes": "Tier 3. IN-WINDOW: created Jul 12 2026. Community finetune of WAN 2.2 I2V A14B adding simultaneous image+audio conditioning. 4 likes, 0 downloads. Very early and unproven. WAN 2.2 A14B at BF16 ~28 GB exceeds 16 GB budget unless quantised."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "ZipDepth (ECCV 2026, arxiv:2607.08771)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2607.08771",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Tier 3. IN-WINDOW: submitted Jul 9 2026. 6.1M-parameter zero-shot monocular depth model, knowledge-distilled from DA3-Large across 14.1M images. Best accuracy/efficiency trade-off among lightweight models. NOT a quality replacement for DA3-large -- explicitly a mobile/embedded compression. DA3 still wins on quality for RTX 5060 Ti. Weights: github.com/fabiotosi92/ZipDepth."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "technique",
+    "name": "SAM-MT (multi-target video segmentation, arxiv:2607.08688)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2607.08688",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "Tier 3. IN-WINDOW: featured Jul 8 2026. Multi-target VIDEO object segmentation built on SAM2 (not SAM3). Per-target queries with decoupled masked attention and sparse memory; >36 FPS for 10 simultaneous targets. Critical caveat: SAM2-based not SAM3 -- does not supersede Spellcaster SAM3 pipeline. Focus is video tracking, not static image segmentation. No public weights."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "BEN2-ONNX (square-zero-labs, Jul 10 2026 format update)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/square-zero-labs/BEN2-ONNX",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Tier 3. IN-WINDOW: lastModified Jul 10 2026 (created Feb 13 2026). ONNX/transformers.js repackaging of existing BEN2 model (PramaLLC/BEN2, MIT). Format-only update enabling browser/CPU inference; no segmentation quality change. BiRefNet native migration (W22 T1-B) is the actionable upgrade for build_rembg_birefnet."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "technique",
+    "name": "Ink3D / OrbitPainter + TextureOptimizer (ECCV 2026, arxiv:2607.01222)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2607.01222",
+    "risk": "medium",
+    "confidence": 0.6,
+    "notes": "Tier 3. Near-window: Jul 1 2026. Two-stage texture pipeline: OrbitPainter generates 360-degree orbit-scan video of an object; TextureOptimizer neural-bakes frames onto a pre-existing mesh. Does NOT generate geometry -- requires mesh input. Complements rather than replaces Hunyuan3D. No HF model weights confirmed. VRAM unknown."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "FaceFusion 3.7.1 (Jul 5 2026, one day before window)",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion/releases/tag/3.7.1",
+    "risk": "low",
+    "confidence": 0.6,
+    "notes": "Tier 3. Near-window: released Jul 5 2026. Minor patch fixing frame distribution regression from 3.7.0 and image-to-image with two simultaneous processors. Standalone pipeline, not a ComfyUI node. HyperSwap_1a_256 is its default swapper -- same upgrade as W22 T1-D covers for ComfyUI-ReActor."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "technique",
+    "name": "IConFace (Identity-Structure Asymmetric Conditioning, arxiv:2605.02814)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2605.02814",
+    "risk": "medium",
+    "confidence": 0.45,
+    "notes": "Tier 3. Outside window (May 4 2026) but not in W22. AdaFace identity anchor + degraded cross-attention + low-rank residuals. Unified reference-aware and no-reference face restoration paths. NTIRE 2026 placement. No public code or weights. Potential CodeFormer successor. Also relevant to build_photo_restore."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Ideogram 4 (9.3B, NF4/FP8, Jun 3 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ideogram-ai/ideogram-4-nf4",
+    "risk": "high",
+    "confidence": 0.85,
+    "notes": "Tier 3. Outside window (Jun 3 2026) but not in W22; newly surfaced this cycle. Ranked #1 among open-weight models on DesignArena; best-in-class text rendering; native 2K. NF4 fits 16 GB with offloading. HARD BLOCKER: Ideogram Non-Commercial Model Agreement -- commercial deployment requires separate paid license. Do not wire unless licensing is resolved. Also relevant to build_generate_anything."
+  },
+  {
+    "method": "build_inpaint",
+    "category": "checkpoint",
+    "name": "PixelHacker (0.8B inpainting, arxiv:2504.20438, Apr 2026)",
+    "source": "github",
+    "url": "https://github.com/hustvl/PixelHacker",
+    "risk": "medium",
+    "confidence": 0.6,
+    "notes": "Tier 3. Outside window (Apr 2026) but not in W22. 0.8B diffusion inpainting using Latent Categories Guidance; 116 foreground + 21 background semantic categories. No ComfyUI node exists. ECCV'26 follow-up 'Moebius' accepted but not released. Different strength from LaMa (semantic consistency vs. texture fill). Also relevant to build_magic_eraser, build_lama_remove."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "BFS Best-Face-Swap-Video IC-LoRA community forks (Jul 9-11 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
+    "risk": "medium",
+    "confidence": 0.55,
+    "notes": "Tier 3. IN-WINDOW: multiple forks created Jul 9-11 2026 -- but these are copies of the Jan 24 2026 original (last modified Jun 20). No new model released in window, only community forks. IC-LoRA for LTX-2/Bernini-R video head-swap with first-frame identity conditioning. 14B base marginal for 16 GB. Apache-2.0 (Bernini-R). Different from build_klein_headswap (static image vs. video)."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "HyperSwap 256 (1a/1b/1c) via ComfyUI-ReActor v0.6.2",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "ALREADY KNOWN -- logged W22 T1-D. Not a novel W29 finding. 2x pixel resolution over inswapper_128. Models at huggingface.co/facefusion/models-3.3.0. FaceFusion 3.7.1 (Jul 5) is a minor patch on same underlying model family."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2 (iFayens) -- native Klein 4B/9B weights",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.7,
+    "notes": "ALREADY KNOWN -- logged W22 T1-A (migration required from discontinued sipie800 fork). Also relevant to build_klein_face_detail, build_faceid_img2img, build_pulid_flux. No new update to v0.6.2 found in W29 window."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image (8B MIT, pixel-native UiT)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "ALREADY KNOWN -- logged W22 T2-B. New W29 T2-A (Boogu-Image) is complementary not redundant. No new HiDream-O1 release in W29 window. FP8 ~10 GB VRAM; MIT license; ComfyUI via Saganaki22/HiDream_O1-ComfyUI."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W29.md
+++ b/_dev_docs/upgrade_research/2026-W29.md
@@ -1,0 +1,219 @@
+# Spellcaster daily SOTA review — 2026-07-13
+
+ISO week: `2026-W29`. Baseline: `2026-W22`.
+
+Research window: 2026-07-06 -> 2026-07-13.
+Hardware budget: RTX 5060 Ti, 16 GB VRAM.
+76 `build_*` methods audited across four families.
+
+> **Already-known tracking**: Items already on the W22 punch list are flagged in-table and collected in the "Already known" section at the end. They are not re-surfaced as novel findings this cycle.
+
+---
+
+## Findings table
+
+| # | Method(s) | Current backbone | Still SOTA? | Replacement / upgrade | Source URL | Risk | Notes |
+|---|-----------|-----------------|-------------|----------------------|------------|------|-------|
+| **IMAGE-GEN + EDITING** |
+| 1 | build_txt2img, build_img2img | SDXL / Flux 1 Dev / Klein 4B/9B | Yes | -- | -- | -- | No new architecture this week; HiDream-O1 already logged W22 T2-B |
+| 2 | build_inpaint | SDXL / Flux / Klein | Yes | -- | -- | -- | PixelHacker (Apr 2026) still no ComfyUI node; Tier 3 |
+| 3 | build_outpaint | SDXL / Flux | Yes | -- | -- | -- | No candidate found |
+| 4 | build_inpaint_fooocus | SDXL Fooocus inpaint | Yes | -- | -- | -- | HiDream-O1 instruction edit (W22 T2-B) is architectural alternative |
+| 5 | build_controlnet_gen | ControlNet (canny/depth/pose...) | Yes | -- | -- | -- | No new ControlNet architecture confirmed in window |
+| 6 | build_generate_anything | SDXL / Flux | Yes | -- | -- | -- | -- |
+| 7 | build_style_transfer | SDXL / Flux | Yes | -- | -- | -- | -- |
+| 8 | build_klein_img2img | Klein 4B/9B | Yes | -- | -- | -- | No Klein successor found |
+| 9 | build_klein_img2img_ref | Klein 4B/9B + ref | Yes | -- | -- | -- | -- |
+| 10 | build_klein_inpaint | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 11 | build_klein_refine | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 12 | build_klein_scene_img2img | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 13 | build_klein_blend | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 14 | build_klein_repose | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 15 | build_klein_headswap | Klein 4B/9B | Yes | -- | -- | -- | PuLID-Flux2 migration already logged W22 T1-A |
+| 16 | build_klein_virtual_tryon | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 17 | build_klein_batch_variations | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 18 | build_klein_auto_inpaint | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 19 | build_klein_sam3_inpaint | Klein 4B/9B + SAM3 | Yes | -- | -- | -- | -- |
+| 20 | build_klein_generate_object | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 21 | build_klein_detail | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 22 | build_klein_face_detail | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 23 | build_klein_color_match | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 24 | build_pulid_flux | PuLID v0.9.1 + Flux 1 Dev | Yes | -- | -- | -- | Migration to PuLID-Flux2 v0.6.2 already logged W22 T1-A |
+| 25 | build_lumina2_txt2img | Lumina2 | Yes | -- | -- | -- | Lumina-Image 2.0 transition is months old; no in-window change |
+| 26 | build_qwen_edit | Qwen2.5-VL | Yes | -- | -- | -- | Qwen-Image-2.0 weights still uncertain (W22 T3); no in-window change |
+| 27 | build_iclight | IC-Light | Yes | -- | -- | -- | No newer relighting model found this week |
+| 28 | build_layer_blend | compositing utility | Yes | -- | -- | -- | -- |
+| 29 | build_magic_eraser | SAM3 + LaMa | Yes | -- | -- | -- | VOID video inpaint already logged W22 T2 additive |
+| 30 | build_lama_remove | LaMa | Yes | -- | -- | -- | PixelHacker Tier 3 (no ComfyUI node) |
+| **VIDEO-GEN + UPSCALE** |
+| 31 | build_wan_video | WAN 2.1 i2v | Yes | -- | -- | -- | No WAN 3.0 confirmed |
+| 32 | build_wan22_t2v | WAN 2.2 t2v | Yes | -- | -- | -- | VideoRLVR fine-tune already logged W22 T2-D |
+| 33 | build_wan_flf | WAN 2.1 first-last-frame | Yes | -- | -- | -- | -- |
+| 34 | build_wan_animate_video | WAN 2.2 animate | Yes | -- | -- | -- | S2V-14B community ComfyUI module (Jul 11, audio-driven); Tier 3 |
+| 35 | build_wan_video_blockswap | WAN + BlockSwap | Yes | -- | -- | -- | Kijai NVFP4 already logged W22 T2-C |
+| 36 | build_wan_video_blockswap_t2v | WAN + BlockSwap t2v | Yes | -- | -- | -- | -- |
+| 37 | build_ltx_video | LTX-Video original (2B) | NO | LTX-2.3-nvfp4 (22B, Blackwell FP4) | https://huggingface.co/Lightricks/LTX-2.3-nvfp4 | Medium | TIER 1 -- LTX-2.3 22B supersedes; nvfp4 targets RTX 50xx; main repo updated Jul 9 |
+| 38 | build_hunyuan_video | HunyuanVideo | Yes | -- | -- | -- | No update found in window |
+| 39 | build_mochi_video | Mochi | Yes | -- | -- | -- | -- |
+| 40 | build_cogvideo_video | CogVideoX | Yes | -- | -- | -- | -- |
+| 41 | build_framepack_video | FramePack | Yes | -- | -- | -- | Last community activity Jun 2026; no new release |
+| 42 | build_frame_assembly | frame assembly utility | Yes | -- | -- | -- | -- |
+| 43 | build_video_upscale | ESRGAN frame-by-frame | Yes | -- | -- | -- | LTX-2.3 spatial upscaler IC-LoRA is alternative (Tier 3) |
+| 44 | build_seedvr2_video_upscale | SeedVR2 temporal | Yes | -- | -- | -- | -- |
+| 45 | build_video_reactor | ReActor video + inswapper_128 | Yes | -- | -- | -- | HyperSwap 256 already logged W22 T1-D |
+| 46 | build_wavespeed_upscale | WaveSpeed / SeedVR2 2K | Yes | -- | -- | -- | -- |
+| 47 | build_upscale | 4x-UltraSharp | Yes | -- | -- | -- | -- |
+| 48 | build_upscale_blend | upscaler blend | Yes | -- | -- | -- | -- |
+| **FACE + PORTRAIT** |
+| 49 | build_faceswap | ReActor + inswapper_128 | Yes | -- | -- | -- | HyperSwap 256 upgrade already logged W22 T1-D |
+| 50 | build_faceswap_model | ReActor model train | Yes | -- | -- | -- | -- |
+| 51 | build_faceswap_mtb | MTB faceswap | Yes | -- | -- | -- | HyperSwap targets ReActor path only |
+| 52 | build_klein_headswap | Klein 4B/9B | Yes | -- | -- | -- | PuLID-Flux2 already logged W22 T1-A |
+| 53 | build_klein_face_detail | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 54 | build_photobooth | iterative face-ref gen | Yes | -- | -- | -- | -- |
+| 55 | build_save_face_model | ReActor face model | Yes | -- | -- | -- | -- |
+| 56 | build_faceid_img2img | FaceID embedding | Yes | -- | -- | -- | -- |
+| 57 | build_face_restore | CodeFormer | Yes | -- | -- | -- | IConFace (May 2026 paper, no code); Tier 3 |
+| 58 | build_photo_restore | CodeFormer + upscale | Yes | -- | -- | -- | -- |
+| 59 | build_detail_hallucinate | detail super-resolution | Yes | -- | -- | -- | -- |
+| **RESTORE / STYLE / 3D** |
+| 60 | build_supir | SUPIR (SDXL-based) | Yes | -- | -- | -- | No new diffusion restoration model this week |
+| 61 | build_color_match | non-diffusion color match | Yes | -- | -- | -- | -- |
+| 62 | build_klein_color_match | Klein 4B/9B | Yes | -- | -- | -- | -- |
+| 63 | build_colorize | Klein colorize | Yes | -- | -- | -- | No DDColor/colorization update found |
+| 64 | build_ddcolor | DDColor artistic | Yes | -- | -- | -- | -- |
+| 65 | build_lut | LUT utility | Yes | -- | -- | -- | -- |
+| 66 | build_rembg | RMBG-1.4 | Yes | -- | -- | -- | -- |
+| 67 | build_rembg_birefnet | BiRefNet | Yes | -- | -- | -- | BiRefNet native migration already logged W22 T1-B; BEN2-ONNX (Jul 10) is format-only |
+| 68 | build_rembg_v3 | RMBG-2.0 | Yes | -- | -- | -- | V-RMBG 3.0 video (Jun 10) predates window |
+| 69 | build_sam3_segment, build_sam3_mask, build_sam3_extract | SAM3 | Yes | -- | -- | -- | SAM-MT (Jul 8 paper) is SAM2-based video multi-target; Tier 3 |
+| 70 | build_normal_map | custom backbone | Yes | -- | -- | -- | MoGe-2 upgrade already logged W22 T1-C |
+| 71 | build_depth_map_v3 | DA3-large | Yes | -- | -- | -- | ZipDepth (Jul 9): 50x lightweight DA3 compression, not quality upgrade; Tier 3 |
+| 72 | build_hunyuan_3d_mesh | Hunyuan3D | Yes | -- | -- | -- | Jul 6 Tencent news was Hy3 LLM (295B), not Hunyuan3D |
+| 73 | build_hunyuan_3d_textured | Hunyuan3D textured | Yes | -- | -- | -- | Ink3D (Jul 1 paper) adds 360-degree texture gen but is paper-only; Tier 3 |
+| 74 | build_seedv2r | SeedVR temporal consistency | Yes | -- | -- | -- | -- |
+
+---
+
+## Tier 1 -- Drop-in supersessions (ship soon)
+
+### T1-A: LTX-2.3-nvfp4 -> build_ltx_video
+
+**Affected:** `build_ltx_video`
+
+Lightricks released LTX-2.3 as their new flagship video model (22B parameters, any-to-any: t2v, i2v, v2v, audio-to-video, first-last-frame). It completely supersedes the original LTX-Video (2B) that `build_ltx_video` currently targets. The main HuggingFace repo received a `lastModified` update on July 9 2026 (in-window), with community derivative repositories (distilled variants, resharded FP8) appearing July 10-11.
+
+The default BF16 checkpoint at 22B requires ~44 GB VRAM and the FP8 variant ~22 GB -- both exceed the 16 GB budget. However, Lightricks publishes an **official `nvfp4` checkpoint** (`Lightricks/LTX-2.3-nvfp4`) explicitly targeting NVIDIA Blackwell GPUs (the RTX 5060 Ti is Blackwell). Estimated VRAM: ~11 GB for the transformer, which fits 16 GB with care. The nvfp4 checkpoint has 13.8K downloads, confirming active use on Blackwell hardware.
+
+Note: W22 T2-E tracked "LTX-Video-0.9.7-dev" as a minor community-mirror version bump of the 2B model. LTX-2.3 is a wholly different, larger-generation model -- not a continuation of 0.9.7-dev.
+
+**Action:** Update `build_ltx_video` to target `Lightricks/LTX-2.3-nvfp4`. Verify MXFP4/nvfp4 inference support in the installed diffusers version and ComfyUI-LTXVideo node pack before deploying. Test VRAM peak before replacing production config.
+
+**Source:** https://huggingface.co/Lightricks/LTX-2.3-nvfp4
+**Risk:** Medium (nvfp4 inference path requires up-to-date diffusers; test VRAM peak before replacing production config)
+
+---
+
+## Tier 2 -- Additive new builders (needs node-pack install + workflow wiring)
+
+### T2-A: Boogu-Image-0.1 family -> new build_boogu_txt2img + build_boogu_edit
+
+**Affected:** New builders; additive alongside `build_txt2img`, `build_img2img`
+
+Boogu-Image-0.1 is a 10B Apache-2.0 unified generation and editing model using a Single-Stream DiT architecture. Released June 16 2026; the Edit-Turbo variant received a quality hotfix on **July 8 2026 (in-window)** fixing severe image quality degradation and broken object-removal in the original release.
+
+Model family:
+- `Boogu/Boogu-Image-0.1-Base` -- standard text-to-image (Turbo: 4-step distilled)
+- `Boogu/Boogu-Image-0.1-Edit` -- instruction-based image editing
+- `Boogu/Boogu-Image-0.1-Edit-Turbo` -- 4-step distilled edit (hotfix Jul 8, in-window)
+
+FP8-scaled variants fit 16 GB with sequential CPU offload (24 GB preferred for unquantized). Native ComfyUI support. Apache-2.0 license is clean.
+
+Relationship to W22 T2-B (HiDream-O1): complementary, not redundant. HiDream-O1 is pixel-native (no external VAE); Boogu-Image uses conventional latent-diffusion, which aligns more directly with existing Spellcaster wiring patterns.
+
+**Source (Base):** https://huggingface.co/Boogu/Boogu-Image-0.1-Base
+**Source (Edit-Turbo, in-window hotfix):** https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo
+**Risk:** Low (Apache-2.0; ComfyUI support confirmed; hotfix resolves known quality issues)
+
+---
+
+### T2-B: LTX-2.3-22b-LoRA-Cinemagraph -> new cinemagraph capability on build_ltx_video
+
+**Affected:** Extension of `build_ltx_video` (requires T1-A upgrade first)
+
+Lightricks published an official IC-LoRA for LTX-2.3 targeting selective-motion / cinemagraph effects: the subject animates while the background remains still. Created July 5 and updated **July 6 2026 (in-window)**. Two demo Spaces confirm active Lightricks maintenance.
+
+This is a new capability not currently in Spellcaster -- closest analogue is `build_wan_flf` (first-last-frame interpolation) but the cinemagraph effect is distinct (selective motion vs. semantic interpolation between endpoints).
+
+**Gated model**: requires HuggingFace access request at `Lightricks/LTX-2.3-22b-LoRA-Cinemagraph`.
+**VRAM:** Same as T1-A (nvfp4 path required on 16 GB).
+**Source:** https://huggingface.co/Lightricks/LTX-2.3-22b-LoRA-Cinemagraph
+**Risk:** Low (official Lightricks release; gating is access-request not commercial)
+
+---
+
+## Tier 3 -- Monitor / not wire-ready
+
+| Item | Target method | Blocker | Revisit trigger |
+|------|--------------|---------|-----------------|
+| Seedream 5 Pro (ByteDance ComfyUI partner node, Jul 8) | build_txt2img / build_img2img | Cloud API only; requires ByteDance API key; incompatible with Spellcaster local-first architecture | Only if an API-wrapper builder pattern is adopted |
+| LTX-2.3 BF16 / FP8 full checkpoint | build_ltx_video | BF16 ~44 GB; FP8 ~22 GB; both exceed 16 GB budget | Only if VRAM budget expands or per-layer offload lands in ComfyUI |
+| LTX-2.3-22b-IC-LoRA-Pixel-Spatial-Upscaler | build_video_upscale | Gated; same VRAM constraint as T1-A; full diffusion-pass upscaling vs. ESRGAN | Test alongside T1-A on nvfp4 path; quality-vs-speed comparison vs. SeedVR2 |
+| MobileWan (Qualcomm AI, arxiv:2607.06173, Jul 7) | build_wan_video, build_wan22_t2v | Paper only; no confirmed public checkpoint; mobile target | Public checkpoint release at qualcomm-ai-research.github.io/mobilewan |
+| drozbay/Wan2.2-S2V-14B-module (Jul 11) | build_wan_animate_video | Community ComfyUI module; base S2V-14B at BF16 ~28 GB, FP8 ~14 GB (marginal); 0 downloads | Stability / VRAM reports; adds audio-driven video generation |
+| rzgar/Wan2.2-IS2V (Jul 12) | build_wan_video | Very early community finetune (4 likes, 0 downloads); WAN A14B BF16 exceeds 16 GB | Community uptake + independent quality validation |
+| ZipDepth (ECCV 2026, arxiv:2607.08771, Jul 9) | build_depth_map_v3 | 6.1M param DA3 compression for mobile; not a quality improvement at desktop | Only if preview-speed depth is a specific UI requirement |
+| SAM-MT (arxiv:2607.08688, Jul 8) | build_sam3_segment | Paper only; SAM2-based (not SAM3); multi-target video tracking, not static image seg; no weights | Public weights + SAM3 migration if Meta updates SAM-MT to SAM3 base |
+| BEN2-ONNX (square-zero-labs, Jul 10 update) | build_rembg_birefnet | Format-only update (ONNX/transformers.js repackaging); no quality change | Only if JS inference path is added to Spellcaster |
+| Ink3D / OrbitPainter + TextureOptimizer (ECCV 2026, arxiv:2607.01222, Jul 1) | build_hunyuan_3d_textured | Paper only; no HF weights; requires mesh input, does not generate geometry | Weights + ComfyUI node release |
+| FaceFusion 3.7.1 (Jul 5, one day before window) | build_faceswap | Standalone pipeline, not ComfyUI node; minor regression-fix patch; HyperSwap (W22 T1-D) covers swap upgrade | Only if FaceFusion wrapper builder is added |
+| IConFace (arxiv:2605.02814, May 2026) | build_face_restore, build_photo_restore | Paper only; no public code or weights; AdaFace identity anchor for face restoration | Code release on HuggingFace or GitHub |
+| Ideogram 4 (9.3B, NF4/FP8, Jun 3 2026) | build_txt2img, build_generate_anything | Ideogram Non-Commercial Model Agreement is a hard blocker | Commercial licensing deal or open license release |
+| PixelHacker (arxiv:2504.20438, Apr 2026) | build_inpaint, build_lama_remove | No ComfyUI node; ECCV'26 follow-up 'Moebius' not released | ComfyUI node release or 'Moebius' release |
+| BFS IC-LoRA video head-swap community forks (Jul 9-11) | build_klein_headswap | Forks are copies of Jan 2026 original (no new content); LTX-2/Bernini-R 14B marginal for 16 GB | Original model on nvfp4 path + quality comparison vs. Klein headswap |
+
+---
+
+## No-finds (verified)
+
+The following current Spellcaster backbones were actively searched -- no superseding release or substantive update found in the 2026-07-06 to 2026-07-13 window:
+
+| Method | Backbone | Verified via |
+|--------|---------|--------------|
+| build_wan_video, build_wan22_t2v | WAN 2.1/2.2 (Wan-AI) | HF hub search, web search; WAN 3.0 does not exist as of Jul 13 2026 |
+| build_hunyuan_video | HunyuanVideo | HF hub; Jul 6 Tencent news was Hy3 LLM (295B), not HunyuanVideo |
+| build_mochi_video | Mochi | HF hub; no updates found |
+| build_cogvideo_video | CogVideoX | HF hub; no updates found |
+| build_framepack_video | FramePack | GitHub; last community activity Jun 2026 |
+| build_iclight | IC-Light | HF + web; DiffusionLight-Turbo (2025) predates window; no newer relighting model |
+| build_supir | SUPIR (SDXL-based) | HF + GitHub; ASASR (W22 T3) still no checkpoint |
+| build_ddcolor | DDColor artistic | HF model search, web; no new colorization model |
+| build_rembg_v3 | RMBG-2.0 (briaai) | HF; V-RMBG 3.0 is video-only (Jun 10) and predates window |
+| build_sam3_segment | SAM3 | HF + GitHub; no SAM release in window; SAM 3.1 was March 2026 |
+| build_depth_map_v3 | DA3-large | HF; ZipDepth (Tier 3) is compression not replacement |
+| build_hunyuan_3d_mesh | Hunyuan3D | HF; no Hunyuan3D update found |
+| build_lama_remove | LaMa | HF + GitHub; no update found |
+| build_color_match, build_klein_color_match | color-match utility | No new backbone |
+| build_colorize | Klein colorize | No new open colorization model found |
+| build_upscale, build_upscale_blend | 4x-UltraSharp | No new ESRGAN model in window |
+
+---
+
+## Already known (logged in W22)
+
+Items found by this cycle's research that are already on the W22 punch list. Not re-surfaced as novel findings.
+
+| W22 ref | Item | Status in W29 |
+|---------|------|---------------|
+| W22 T1-A | ComfyUI-PuLID-Flux2 v0.6.2 (iFayens) -- sipie800 migration | Still open if not yet installed locally |
+| W22 T1-B | BiRefNet native ComfyUI (Comfy-Org/BiRefNet) | Still open |
+| W22 T1-C | MoGe-2 for build_normal_map | Still open |
+| W22 T1-D | HyperSwap 256 ONNX via ReActor | Still open; FaceFusion 3.7.1 (Jul 5) is a minor patch on same underlying model |
+| W22 T2-B | HiDream-O1-Image 8B (MIT) | Still open; Boogu-Image (W29 T2-A) is complementary not redundant |
+| W22 T2-C | Kijai/WanVideo_comfy_nvfp4 (Blackwell WAN) | Still open |
+| W22 T2-D | VideoRLVR-Wan2.2 RL fine-tune | Still open |
+| W22 T2-E | LTX-Video-0.9.7-dev (2B community mirror) | Superseded by W29 T1-A (LTX-2.3 22B is a wholly different generation) |
+
+---
+
+*Generated by Spellcaster daily SOTA review agent. Nightly workflow snapshots are refreshed automatically by `tools/export_comfyui_workflows.py` at 03:30 local time -- no manual snapshot action needed after local node-pack installs.*


### PR DESCRIPTION
## Summary

Automated daily SOTA sweep for ISO week **2026-W29** (2026-07-06 -> 2026-07-13).
Baseline: `2026-W22` (last reviewed 2026-05-29). 76 `build_*` methods audited across four families.
Hardware budget: RTX 5060 Ti, 16 GB VRAM.

### Tier counts

| Tier | Count | Description |
|------|-------|-------------|
| **Tier 1** — Drop-in supersessions | **1** | Ship soon; local node-pack / checkpoint change only |
| **Tier 2** — Additive new builders | **3** | New `build_*` methods to wire; needs node-pack install |
| **Tier 3** — Monitor / not wire-ready | **15** | Paper-only, VRAM blockers, license issues, or cloud-only |
| **No-finds (verified)** | **16** | Searched; no supersession found in window |
| **Already known (W22)** | **8** | Found by research but already on W22 punch list |

### Tier 1 highlights

**T1-A: `build_ltx_video` -> LTX-2.3-nvfp4**
The original LTX-Video (2B) is significantly outclassed by Lightricks' new LTX-2.3 (22B, any-to-any). The main HF repo was updated Jul 9 (in-window). The official `nvfp4` checkpoint explicitly targets NVIDIA Blackwell (RTX 5060 Ti qualifies); estimated ~11 GB VRAM. W22 T2-E tracked LTX-Video-0.9.7-dev as a 2B community mirror -- LTX-2.3 is a wholly different generation, not a continuation.
Risk: **Medium** -- verify MXFP4 diffusers support before wiring.
Source: https://huggingface.co/Lightricks/LTX-2.3-nvfp4

### Tier 2 highlights

**T2-A: Boogu-Image-0.1 family -> `build_boogu_txt2img` + `build_boogu_edit`** (new)
Apache-2.0, 10B Single-Stream DiT. Edit-Turbo hotfix landed **Jul 8 (in-window)**. FP8 fits 16 GB. ComfyUI-native. Complements HiDream-O1 (W22 T2-B) with a conventional latent-diffusion approach.
Source: https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo

**T2-B: LTX-2.3-22b-LoRA-Cinemagraph -> `build_ltx_cinemagraph`** (new)
Official Lightricks IC-LoRA; selective-motion / cinemagraph effects. Updated **Jul 6 (in-window)**. Gated (HF access request). Requires T1-A first.
Source: https://huggingface.co/Lightricks/LTX-2.3-22b-LoRA-Cinemagraph

### Notable Tier 3 items

- **Seedream 5 Pro** (Jul 8, in-window) -- cloud API only; blocked by local-first architecture
- **MobileWan** (Qualcomm, arxiv:2607.06173, Jul 7) -- paper only, no weights; confirms WAN 5B can be heavily compressed
- **ZipDepth** (ECCV 2026, Jul 9) -- lightweight DA3 compression for mobile; DA3 still preferred at desktop for quality
- **SAM-MT** (Jul 8) -- SAM2-based multi-target video tracking; paper only; does not supersede SAM3
- **Ideogram 4** (Jun 3) -- newly surfaced this cycle; hard-blocked by Non-Commercial license
- **IConFace** (May 2026) -- potential CodeFormer successor; paper only, no weights

### W22 punch list status

Items from the W22 punch list that remain open (T1 and T2 items not yet locally installed):
T1-A (PuLID-Flux2 migration) | T1-B (BiRefNet native) | T1-C (MoGe-2 normal map) | T1-D (HyperSwap 256)
T2-B (HiDream-O1-Image) | T2-C (Kijai WAN NVFP4) | T2-D (VideoRLVR-Wan2.2)

W22 T2-E (LTX-Video-0.9.7-dev) is superseded by W29 T1-A -- LTX-2.3 makes the 2B lineage obsolete.

---

**Do not merge** -- this PR is the daily audit trail. Implementation upgrades require local node-pack installs on the user's machine and cannot be applied remotely.

> The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh ComfyUI workflow snapshots automatically after any local node-pack installs -- no manual snapshot action needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_012a94KWVbtpUJmwp7LCw16Q)_