### PR TITLE
chore(research): daily SOTA review 2026-07-17

### DIFF
--- a/_dev_docs/upgrade_research/2026-W29.json
+++ b/_dev_docs/upgrade_research/2026-W29.json
@@ -1,0 +1,362 @@
+[
+  {
+    "method": "build_klein_img2img,build_klein_inpaint,build_klein_refine,build_klein_repose,build_klein_headswap,build_klein_blend,build_klein_detail,build_klein_face_detail,build_klein_scene_img2img,build_klein_color_match,build_klein_virtual_tryon,build_klein_generate_object,build_klein_batch_variations,build_klein_auto_inpaint,build_klein_sam3_inpaint,build_txt2img,build_img2img",
+    "category": "checkpoint",
+    "name": "NVIDIA PiD v1.5 (Pixel Diffusion Decoder)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/nvidia/PiD",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "~IN-WINDOW (Jul 9). Drop-in VAE decode replacement for FLUX.2 / Klein 4B/9B. Use checkpoint 2kto4k_v1pt5 (fixes corner artifacts and colour drift vs v1.0). Adds ~2 GB VRAM; output up to 4K. Native ComfyUI since v0.27.0. Tier 1 priority for all Klein builders."
+  },
+  {
+    "method": "build_faceswap,build_faceswap_model",
+    "category": "checkpoint",
+    "name": "HyperSwap_1c_256.onnx (FaceFusion Labs)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "OUTSIDE WINDOW (May 2026). Drop-in replacement for inswapper_128.onnx in ReActor. 256-px crop vs 128-px; confirmed quality uplift. Place in ReActor models directory. No workflow changes required. Use _1a for speed, _1c for quality."
+  },
+  {
+    "method": "build_sam3_segment,build_sam3_mask,build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (facebook/sam3.1) — Object Multiplex",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "OUTSIDE WINDOW (Mar 2026). Drop-in checkpoint upgrade. Object Multiplex: ~7x faster at 128 simultaneous objects; single-object quality equivalent to SAM3. Same directory structure. 72K downloads confirm production stability. ComfyUI nodes: yolain/ComfyUI-Easy-Sam3."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "Depth Anything 3 v1.1 (DA3-LARGE-1.1)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/depth-anything/DA3-LARGE-1.1",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "OUTSIDE WINDOW (Dec 2025). Refined DA3-LARGE checkpoint (Apache-2.0). Also DA3-Streaming for long-video depth under 12 GB. PozzettiAndrea ComfyUI-DepthAnythingV3 already supports v1.1. Straightforward weight swap."
+  },
+  {
+    "method": "build_seedvr2_video_upscale,build_face_restore,build_photo_restore,build_detail_hallucinate,build_seedv2r",
+    "category": "node_pack",
+    "name": "ComfyUI v0.28.0 — native SeedVR2 + MediaPipe",
+    "source": "github",
+    "url": "https://github.com/comfy-org/ComfyUI/releases/tag/v0.28.0",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "IN-WINDOW (Jul 15). Core ComfyUI release. Adds: native SeedVR2 image+video upscaling (PR #14424), native MediaPipe face detection (BlazeFace, FaceMesh 478-landmark, ARKit blendshapes), PiD 1.5 support, --models-directory flag. Keep custom SeedVR2 node for GGUF/streaming. VAE fix may require v0.28.1 patch."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "lora",
+    "name": "LTX-2.3-22b-LoRA-Foley-V2A (Lightricks)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-LoRA-Foley-V2A",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "IN-WINDOW (Jul 15). Official Lightricks Foley LoRA. Adds synchronised sound-effect generation (footsteps, impacts, ambience, weather) to silent video. Weight-file swap only; same VRAM envelope as LTX-2.3 22B base. Use step-500 checkpoint. Community workflow: FuzzPuppy/LTX-2.3-Foley-Workflow."
+  },
+  {
+    "method": "build_txt2img,build_generate_anything",
+    "category": "checkpoint",
+    "name": "Krea-2-Turbo (12B, 8-step distilled)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/krea/Krea-2-Turbo",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "OUTSIDE WINDOW (Jun 22-23). 12B single-stream DiT; FP8 ~12 GB; native 2K; ~2-3s on consumer GPU. 1 500+ community LoRAs. ComfyUI native nodes since v0.27.0 (Jun 30). Krea Community License: free commercial for studios <50 seats. Qwen3-VL encoder + Qwen Image VAE. Best near-term SDXL successor candidate."
+  },
+  {
+    "method": "build_txt2img,build_generate_anything",
+    "category": "checkpoint",
+    "name": "NVIDIA PixelDiT 1.3B (VAE-free, CVPR 2026)",
+    "source": "github",
+    "url": "https://github.com/NVlabs/PixelDiT",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "OUTSIDE WINDOW (Jun 30 via ComfyUI v0.27.0). 1.3B, ~5-6 GB total (model + Gemma-2B encoder). VAE-free pixel-space DiT. CVPR 2026 Best Paper Finalist. Comfy-Org official repack available. 1024px cap. Ideal lightweight draft builder."
+  },
+  {
+    "method": "build_txt2img,build_generate_anything,build_qwen_edit,build_magic_eraser,build_style_transfer,build_inpaint",
+    "category": "checkpoint",
+    "name": "Boogu-Image-0.1 (Base/Turbo/Edit/Edit-Turbo, Apache-2.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo",
+    "risk": "medium",
+    "confidence": 0.87,
+    "notes": "IN-WINDOW (technical report arXiv:2607.13125, Jul 16; hotfix Jul 8). Apache-2.0. Unified gen+edit: object removal, style transfer, inpainting, poster layers, bilingual text. ~14 GB FP8 Turbo. ComfyUI via kijai PR #14523. Needs community stress-testing before production use."
+  },
+  {
+    "method": "build_txt2img,build_generate_anything",
+    "category": "checkpoint",
+    "name": "ByteDance Seedream 5.0 Pro (cloud Partner Node)",
+    "source": "github",
+    "url": "https://docs.comfy.org/tutorials/partner-nodes/bytedance/seedream-5-pro",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "~IN-WINDOW (ComfyUI v0.27.1, Jul 8). Cloud API only; zero local VRAM. Deep-thinking prompt reasoning, web-search augmented generation, native 2048px, pixel-level editing, 10+ design layers, multilingual in-image text. Adds API cost dependency."
+  },
+  {
+    "method": "build_txt2img,build_generate_anything",
+    "category": "checkpoint",
+    "name": "Ideogram 4 open weights (9.3B, NF4/FP8/GGUF)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ideogram-ai/ideogram-4-nf4",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "OUTSIDE WINDOW (Jun 3). Best open-weight model for text-in-image (signage, logos, QR codes). NF4 ~12 GB; FP8 exactly 16 GB (tight). Ideogram Community License — verify commercial use restrictions. GGUF community quantisations available."
+  },
+  {
+    "method": "build_txt2img,build_img2img,build_generate_anything",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image-Dev (8B, MIT, FP8 ~10 GB)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
+    "risk": "low",
+    "confidence": 0.68,
+    "notes": "OUTSIDE WINDOW (May 8). MIT licensed. UiT (Pixel-level Unified Transformer); no external VAE/text encoder. FP8 ~10 GB, leaves ~6 GB headroom. Supports txt2img, instruction editing, subject personalization. Native ComfyUI PR #13817. Good VRAM-efficient alternative to FLUX.2-dev."
+  },
+  {
+    "method": "build_inpaint,build_outpaint,build_lama_remove,build_klein_inpaint",
+    "category": "node_pack",
+    "name": "LanPaint — training-free any-model inpaint node",
+    "source": "github",
+    "url": "https://github.com/scraed/LanPaint",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "OUTSIDE WINDOW (Apr 2026). Available via ComfyUI Registry (publisher: scraed). Works with FLUX.2, SDXL, Wan 2.2, Klein, Hunyuan, Z-Image. No additional model weights. Apr 2026 update adds temporally consistent video inpainting. A/B test vs Fooocus inpaint on edge sharpness before replacing."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux-Chroma (Apache-2.0 alt)",
+    "source": "github",
+    "url": "https://github.com/PaoloC68/ComfyUI-PuLID-Flux-Chroma",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "OUTSIDE WINDOW (May 16). First PuLID for Chroma (8.9B Apache-2.0 FLUX.1-schnell fork). ~11-12 GB (Chroma FP8 + PuLID overhead). Compliance advantage: Chroma Apache-2.0 vs Klein NSFW license. Verify identity fidelity before production use."
+  },
+  {
+    "method": "build_wan22_t2v,build_wan_video",
+    "category": "checkpoint",
+    "name": "LingBot-Video-Dense-1.3B (Ant Group, #1 RBench open)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/robbyant/lingbot-video-dense-1.3b",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "~IN-WINDOW (Jul 8). 1.3B dense; T2V/I2V/TI2V; Wan 2.2 DiT backbone; ~6 GB VRAM. #1 RBench open-source. Community ComfyUI: realrebelai/LingBot_ComfyUI. FP8: ALXOPENSOURCE/lingbot-video-1.3b-fp8. FastVideo diffusers port Jul 13. Native PR WIP. Robotics-heavy training; verify general cinematic quality."
+  },
+  {
+    "method": "build_wan22_t2v,build_wan_video",
+    "category": "checkpoint",
+    "name": "LingBot-Video-MoE-30B-A3B (Ant Group, GGUF)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/robbyant/lingbot-video-moe-30b-a3b",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "~IN-WINDOW (Jul 8). Sparse MoE; 3B active parameters per pass; ~3x faster than comparable dense. GGUF: realrebelai/LingBot-30B-3B_GGUF_ComfyUI. Requires 24 GB+ system RAM for weight paging even with 8 GB active VRAM. Use 1.3B dense on 16 GB target hardware instead."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "Wan-AI/Wan-Dancer-14B (music-to-dance)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI/Wan-Dancer-14B",
+    "risk": "high",
+    "confidence": 0.92,
+    "notes": "IN-WINDOW (Jul 10). Official Wan-AI music-to-dance model on Wan 2.2 backbone. 149 frames/pass; 720p 30fps. VRAM: ~24 GB (FP8) — EXCEEDS 16 GB BUDGET. No GGUF confirmed. Monitor for community quantised port. ComfyUI template at Comfy-Org/Wan-Dancer. Paper: arXiv:2607.09581."
+  },
+  {
+    "method": "build_wan_flf",
+    "category": "checkpoint",
+    "name": "DreamX-World-5B (Alibaba/FastVideo, camera-controlled world model)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/FastVideo/DreamX-World-5B-Diffusers",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "NEAR-MISS (Jul 6 — 4 days before window). Built on Wan2.2-TI2V-5B; long-horizon up to ~60s video, camera action control, region-guided object placement. ~16 GB (same envelope as Wan2.2-TI2V-5B). No ComfyUI node yet. Cam variant: FastVideo/DreamX-World-5B-Cam-Diffusers. License unconfirmed Apache-2.0 — verify. Paper: arXiv:2606.16993."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh,build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "TRELLIS.2-4B (Microsoft, PBR mesh, MIT)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/microsoft/TRELLIS.2-4B",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "OUTSIDE WINDOW (Dec 2025). 4B sparse O-Voxel; fully UV-unwrapped PBR mesh in one pass; MIT license; 1.49M downloads. 16 GB exact ceiling on RTX 5060 Ti — run alone. ComfyUI: ComfyUI-Trellis2 (visualbruno) or ComfyUI-TRELLIS2 (PozzettiAndrea). Best Hunyuan3D alternative for PBR output."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "TripoSplat (VAST-AI, Gaussian-splat 3D, MIT)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/VAST-AI/TripoSplat",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "OUTSIDE WINDOW (May 31). DINOv2 encoder + triplane + flow-matching denoiser; outputs .ply/.splat (not UV mesh). Native GAUSSIAN type in ComfyUI v0.23.0. Template in ComfyUI Template Library. ~8 GB VRAM. MIT. Fast 3D preview; use Hunyuan3D or TRELLIS.2 downstream if UV texture required."
+  },
+  {
+    "method": "build_klein_headswap,build_klein_face_detail",
+    "category": "lora",
+    "name": "BFS-Best-Face-Swap LoRA for Klein (Alissonerdx)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+    "risk": "medium",
+    "confidence": 0.87,
+    "notes": "OUTSIDE WINDOW (Jun 20). IC-LoRA for Klein 4B/9B and Qwen-Image-Edit-2511. FK 4B variant: ~12 GB. 360 HF likes, 2.9K downloads — highest-traction face-swap LoRA for Klein stack. Community forks: justusgeorge10, chfm, PcZerokey. Civitai ComfyUI workflow available. Additive to existing builders."
+  },
+  {
+    "method": "build_klein_headswap,build_faceswap",
+    "category": "lora",
+    "name": "BFS-Best-Face-Swap-Video Bernini-R LoRA (tralaleloss)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tralaleloss/BFS-Best-Face-Swap-Video",
+    "risk": "high",
+    "confidence": 0.55,
+    "notes": "IN-WINDOW (Jul 11). IC-LoRA for ByteDance/Bernini-R video headswap. Base model 14.3B — ~22 GB VRAM, EXCEEDS BUDGET. Monitor for Q8/FP8 quantised Bernini-R fork. No ComfyUI node for Bernini-R confirmed. Interesting concept; not deployable on 16 GB yet."
+  },
+  {
+    "method": "build_faceid_img2img",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2 (Klein backend)",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "OUTSIDE WINDOW (May 2026). First PuLID for FLUX.2 Klein 4B/9B. InsightFace AntelopeV2 + EVA-CLIP (~800 MB auto-download). Klein 9B + PuLID ~14 GB; 4B path ~10 GB. Improves identity fidelity vs IP-Adapter FaceID. Test Klein 4B path first."
+  },
+  {
+    "method": "build_faceswap,build_faceswap_model,build_faceswap_mtb",
+    "category": "node_pack",
+    "name": "ReActor 0.7.0 ALPHA (InsightFace-free rewrite)",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "OUTSIDE WINDOW (Apr 2026). ALPHA — removes InsightFace C++ dependency. v0.6.2 stable is the safe current path (+ HyperSwap + GPEN 2048). Face Similarity node useful for quality gates. Do not deploy 0.7.0 ALPHA in production until stable release."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "IConFace — Reference-Aware Face Restoration (paper only)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2605.02814",
+    "risk": "high",
+    "confidence": 0.35,
+    "notes": "OUTSIDE WINDOW (May 4). Academic paper only; no public weights. AdaFace identity anchor + degraded cross-attention. Monitor authors (Axi Niu, Jinyang Zhang) and NTIRE 2026 repo jkwang28/NTIRE2026_RealWorld_Face_Restoration for code release."
+  },
+  {
+    "method": "build_photo_restore,build_face_restore",
+    "category": "checkpoint",
+    "name": "RealRestorer (Step1X-Edit finetune, 12.4B)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "high",
+    "confidence": 0.55,
+    "notes": "OUTSIDE WINDOW (Mar 2026). 12.4B params, ~24 GB VRAM in bf16. English+Chinese prompts. Apache-2.0. 2.7K downloads. Monitor for FP8/Q8 quantised version. Conceptually strong for build_photo_restore but hardware-infeasible at 16 GB currently."
+  },
+  {
+    "method": "build_normal_map,build_depth_map_v3,build_sam3_segment",
+    "category": "checkpoint",
+    "name": "GenCeption — Video Diffusion as General Vision (paper only, ECCV 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2607.09024",
+    "risk": "high",
+    "confidence": 0.55,
+    "notes": "IN-WINDOW (Jul 10). 73 HF upvotes. ECCV 2026 paper. No model weights released. Authors: Kaiming He, Joao Carreira, Andrew Zisserman. Could unify depth+normals+segmentation into one video-diffusion pass. Monitor genception.github.io for code/weight release post-ECCV."
+  },
+  {
+    "method": "build_rembg,build_rembg_birefnet,build_rembg_v3,build_sam3_segment,build_sam3_mask,build_sam3_extract",
+    "category": "node_pack",
+    "name": "ComfyUI-RMBG v3.0.0 (1038lab — SAM3 + BEN2 + SDMatte)",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-RMBG",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "OUTSIDE WINDOW (Jan 2026). All-in-one node: RMBG-2.0, BiRefNet, BEN2, SAM3+GroundingDINO, SDMatte, INSPYRENET. Text-prompted segmentation, face (19-class), clothes (18-class), fashion matting. Consolidates multiple Spellcaster rembg + sam3 builders under one dependency. Actively maintained."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "checkpoint",
+    "name": "Bria V-RMBG 3.0 (video background removal, commercial API)",
+    "source": "github",
+    "url": "https://www.prnewswire.com/news-releases/bria-launches-v-rmbg-3-0-state-of-the-art-video-background-removal-model-302796516.html",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "OUTSIDE WINDOW (Jun 10). Temporally-aware video rembg; 63%+ win rate vs competitors; 9x faster. API-only — no open weights confirmed. Relevant if Spellcaster adds video background removal workflow. Monitor Bria HF for open model announcement."
+  },
+  {
+    "method": "build_sam3_segment,build_sam3_extract",
+    "category": "checkpoint",
+    "name": "GeoSAM2 — 3D Part Segmentation (VAST-AI, CVPR 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/VAST-AI/GeoSAM2",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "OUTSIDE WINDOW (Apr 2026). SAM2 + LoRA + residual geometry fusion for 3D part segmentation. Weight: geosam2.pt. No ComfyUI node — requires custom script. Relevant for Hunyuan3D or TripoSplat downstream part-extraction workflows. ~10 GB VRAM."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "AnyDepth — DINOv3 + SDT lightweight depth (ICLR 2026, paper)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2601.02760",
+    "risk": "medium",
+    "confidence": 0.55,
+    "notes": "OUTSIDE WINDOW (Jan 2026). Paper only; public weights not confirmed. DINOv3-based, ~4 GB VRAM estimate. Could be lighter than DA3-LARGE-1.1. Monitor arxiv authors' GitHub for weight release."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "3AM — SAM2 with Geometric Consistency for Wide-Baseline Video",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2601.08831",
+    "risk": "medium",
+    "confidence": 0.60,
+    "notes": "OUTSIDE WINDOW (Jan 2026). Integrates MUSt3R 3D features into SAM2. +15.9 IoU on ScanNet++ vs SAM2 for wide-angle scenes. Paper only; weights not confirmed. Monitor jayisaking.github.io/3AM-Page."
+  },
+  {
+    "method": "build_qwen_edit,build_controlnet_gen,build_inpaint",
+    "category": "controlnet",
+    "name": "Qwen-Image DiffSynth ControlNets (canny + depth patches)",
+    "source": "github",
+    "url": "https://www.runcomfy.com/comfyui-nodes/ComfyUI-QwenImageLoraLoader/nunchaku-qwen-image-diffsynth-controlnet",
+    "risk": "low",
+    "confidence": 0.55,
+    "notes": "OUTSIDE WINDOW (Sep 2025). Lightweight model-patch ControlNets for Qwen-Image (canny, depth, inpaint). ~2 GB per patch; stored in models/model_patches. Node: QwenImageDiffsynthControlNet. May already be in stack — verify before treating as new. InstantX also has a standard Qwen ControlNet implementation."
+  },
+  {
+    "method": "build_faceswap,build_faceswap_model",
+    "category": "node_pack",
+    "name": "FaceFusion 3.7.1 (performance patch)",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion/releases",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "NEAR-MISS (Jul 5 — 5 days before window). Fixes frame-distribution regression from 3.7.0. HyperSwap 1a/1b/1c_256 remain the backbone. Stability patch only; no new swap model. The FaceFusion ComfyUI node (huygiatrng/Facefusion_comfyui) exposes HyperSwap to ComfyUI."
+  },
+  {
+    "method": "build_klein_headswap,build_faceswap",
+    "category": "checkpoint",
+    "name": "DreamID-V-Wan-1.3B JR fork (video face-swap, 16 GB path)",
+    "source": "github",
+    "url": "https://github.com/Goldlionren/ComfyUI_JR_DreamID-V",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "OUTSIDE WINDOW (Feb 2026). ECCV 2026. Video face-swap DiT; three variants (MediaPipe, DWPose, Faster). JR fork validated on RTX 5060 Ti 16 GB via FFN chunking + VAE micro-batching + T5 CPU offload. T5-XXL (~10 GB) offloads to CPU RAM — ensure 32 GB system RAM. Potential new build_dreamid_video builder."
+  },
+  {
+    "method": "build_faceswap,build_faceswap_model,build_video_reactor",
+    "category": "checkpoint",
+    "name": "wynnn2168/Nano_faceswap (84M diffusion, Jul 17, no docs)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/wynnn2168/Nano_faceswap",
+    "risk": "high",
+    "confidence": 0.25,
+    "notes": "IN-WINDOW (Jul 17 — modified today). 84M param diffusers face-swap. No model card, no documentation, 72 downloads, 4 likes. Architecture tag: diffusers. Unknown quality. Monitor only — do not integrate until author publishes README and benchmarks."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W29.md
+++ b/_dev_docs/upgrade_research/2026-W29.md
@@ -1,0 +1,165 @@
+# Spellcaster daily SOTA review — 2026-07-17
+
+ISO week: `2026-W29`. Baseline: _none — first review_.
+
+Hardware budget: RTX 5060 Ti, 16 GB VRAM. Research window: 2026-07-10 → 2026-07-17.
+Strictly-in-window items are marked **[W]**; near-miss (≤10 days) items are marked **[~W]**.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / upgrade | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| `build_klein_*` (all 15) | FLUX.2 Klein 4B / 9B | ✅ Yes — with upgrade | **PiD v1.5** VAE decoder → 2–4K output [~W] | https://huggingface.co/nvidia/PiD | Low | Drop-in decode swap; adds ~2 GB VRAM. Highest-priority Tier-1 find. |
+| `build_txt2img` | Flux / SDXL | Partial | **Krea-2-Turbo** 12B, 8-step, native 2K, FP8 ~12 GB | https://huggingface.co/krea/Krea-2-Turbo | Medium | 1 500+ community LoRAs; ~3.5 weeks old; ComfyUI native since v0.27.0. |
+| `build_txt2img` | Flux / SDXL | Partial | **NVIDIA PixelDiT 1.3B** VAE-free, ~5 GB | https://github.com/NVlabs/PixelDiT | Low | CVPR 2026 finalist; draft/iteration model; 1024px cap; Comfy-Org official nodes. |
+| `build_txt2img` / `build_generate_anything` | Flux / SDXL | Partial | **Boogu-Image-0.1** (Base/Turbo/Edit) Apache-2.0 [W] | https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo | Medium | arXiv 2607.13125 (Jul 16); unified gen+edit; Qwen3-VL-8B enc; ~14 GB FP8. |
+| `build_generate_anything` | Flux / SDXL | Partial | **Seedream 5.0 Pro** cloud API Partner Node [~W] | https://docs.comfy.org/tutorials/partner-nodes/bytedance/seedream-5-pro | Low | No local VRAM; adds API cost. ComfyUI v0.27.1 (Jul 8). |
+| `build_generate_anything` | Flux / SDXL | Partial | **Ideogram 4** open weights, best text-in-image | https://huggingface.co/ideogram-ai/ideogram-4-nf4 | Medium | NF4 fits ~12 GB; FP8 exactly 16 GB (tight). Best for signage/logo prompts. |
+| `build_qwen_edit` | Qwen-Image-2511 | ✅ Yes — with option | **Boogu-Image-0.1-Edit** Apache-2.0 alt [W] | https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo | Medium | Same Qwen3-VL-8B encoder family; permissive license advantage. |
+| `build_inpaint` / `build_outpaint` | SDXL / Flux inpaint ckpt | Partial | **LanPaint** training-free any-model inpaint | https://github.com/scraed/LanPaint | Low | Extends inpaint to Flux2/Klein; no extra weights; Apr 2026 added video. |
+| `build_inpaint_fooocus` | Fooocus inpaint (SDXL) | ✅ Yes | — | — | — | No replacement found in window. |
+| `build_controlnet_gen` | ControlNet (canny/depth/pose) | ✅ Yes | **Qwen DiffSynth ControlNets** (additive, canny+depth for Qwen) | https://www.runcomfy.com/comfyui-nodes/ComfyUI-QwenImageLoraLoader/nunchaku-qwen-image-diffsynth-controlnet | Low | Additive only; ~2 GB per patch. May already be in stack — verify first. |
+| `build_pulid_flux` | PuLID Flux | Partial | **PuLID-Flux-Chroma** (Chroma Apache-2.0 alt) | https://github.com/PaoloC68/ComfyUI-PuLID-Flux-Chroma | Medium | Apache-2.0 license advantage vs Klein NSFW license. Verify identity fidelity. |
+| `build_lumina2_txt2img` | Lumina2 | ✅ Yes | — | — | — | No update found in window. |
+| `build_iclight` | IC-Light v2 | ✅ Yes | — | — | — | No IC-Light v3 found. |
+| `build_magic_eraser` | LaMa / SAM3 | Partial | **Boogu-Image-0.1-Edit** (object removal) [W] | https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo | Medium | Edit-Turbo handles object removal; performance vs LaMa unverified. |
+| `build_lama_remove` | LaMa | ✅ Yes | **LanPaint** as complement | https://github.com/scraed/LanPaint | Low | LanPaint + Klein may supersede LaMa for diffusion-quality removal. |
+| `build_wan_video` / `build_wan22_t2v` | Wan 2.1 / 2.2 | Partial | **LingBot-Video-Dense-1.3B** (#1 RBench open) [~W] | https://huggingface.co/robbyant/lingbot-video-dense-1.3b | Medium | Jul 8; 1.3B; 6 GB VRAM; Wan2.2 DiT backbone; community ComfyUI node. |
+| `build_wan_animate_video` | Wan2.2-TI2V | Partial | **Wan-Dancer-14B** (music-to-dance) [W] | https://huggingface.co/Wan-AI/Wan-Dancer-14B | High | Jul 10; **24 GB VRAM required** — exceeds budget. Wait for GGUF. |
+| `build_wan_flf` | Wan2.2-TI2V | Partial | **DreamX-World-5B** (long-horizon camera control) [~W] | https://huggingface.co/FastVideo/DreamX-World-5B-Diffusers | Medium | Jul 6 (near-miss); 5B, ~16 GB; camera action control; no ComfyUI node yet. |
+| `build_ltx_video` | LTX-2.3 22B | ✅ Yes + extension | **LTX-2.3 Foley LoRA V2A** (Video-to-Audio) [W] | https://huggingface.co/Lightricks/LTX-2.3-22b-LoRA-Foley-V2A | Low | Jul 15; official Lightricks LoRA; same VRAM as base; weight-file swap only. |
+| `build_hunyuan_video` | HunyuanVideo-1.5 | ✅ Yes | — | — | — | No Jul 2026 update found. Last release Nov 2025. |
+| `build_mochi_video` | Mochi 1 | ✅ Yes | — | — | — | Still Oct 2024 weights; no new release. |
+| `build_cogvideo_video` | CogVideoX-5b | ✅ Yes | — | — | — | No new weights in window. |
+| `build_framepack_video` | FramePack | ✅ Yes | — | — | — | P1 research WIP; no open weights. |
+| `build_video_upscale` / `build_seedvr2_video_upscale` | SeedVR2 + custom node | ✅ Yes + upgrade | **ComfyUI v0.28.0 native SeedVR2** [W] | https://github.com/comfy-org/ComfyUI/releases/tag/v0.28.0 | Low | Jul 15; removes custom-node dependency for standard pipelines. Keep custom node for GGUF/streaming. |
+| `build_wavespeed_upscale` | WaveSpeed | ✅ Yes | — | — | — | Last updated May 2026; no Jul update. |
+| `build_faceswap` | ReActor + inswapper_128 | No | **HyperSwap_1c_256.onnx** drop-in | https://huggingface.co/facefusion/models-3.3.0 | Low | Drop-in to ReActor; 256px crop vs 128px; confirmed quality uplift. |
+| `build_faceswap_model` | ReActor inswapper | Partial | HyperSwap_1c_256 + ReActor 0.6.2 | https://github.com/Gourieff/ComfyUI-ReActor | Low | v0.6.2 adds HyperSwap + GPEN 2048 support. |
+| `build_faceswap_mtb` | MTB faceswap | ✅ Yes | — | — | — | No MTB update in window. |
+| `build_klein_headswap` | Klein + custom headswap | Partial | **BFS-Best-Face-Swap LoRA** (Alissonerdx, Jun 2026) | https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap | Medium | Klein 4B/9B compatible; FK 4B ~12 GB; 360 HF likes, 2.9K downloads. |
+| `build_klein_headswap` | Klein | Partial | **BFS-Video Bernini-R LoRA** [~W] | https://huggingface.co/tralaleloss/BFS-Best-Face-Swap-Video | High | Jul 11; **base model 14B ≈ 22 GB** — exceeds budget. Monitor for Q8 fork. |
+| `build_klein_face_detail` | Klein | Partial | BFS-Best-Face-Swap LoRA (also targets this) | https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap | Medium | See build_klein_headswap above. |
+| `build_photobooth` | Klein iterative | ✅ Yes | — | — | — | No direct replacement found. |
+| `build_faceid_img2img` | FaceID IP-Adapter | Partial | **PuLID-Flux2 v0.6.2** (Klein backend) | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Medium | Klein 9B ~14 GB; 4B variant ~10 GB. Better identity fidelity with Klein. |
+| `build_face_restore` | CodeFormer | ✅ Yes + upgrade | **ComfyUI v0.28.0 MediaPipe** (detection layer) [W] | https://github.com/comfy-org/ComfyUI/releases/tag/v0.28.0 | Low | Jul 15; native BlazeFace + FaceMesh; no extra deps. Improves face detection feeding into restore. |
+| `build_photo_restore` | upscale + CodeFormer | Partial | **SeedVR2 FP8** (native v0.28.0) [W] | https://github.com/comfy-org/ComfyUI/releases/tag/v0.28.0 | Low | Jul 15; SeedVR2 FP8 runs ~12 GB; superior to classical upscale+restore pipeline. |
+| `build_detail_hallucinate` | SR upscaler | Partial | SeedVR2 FP8 via v0.28.0 native [W] | https://github.com/comfy-org/ComfyUI/releases/tag/v0.28.0 | Low | Jul 15; diffusion-based detail enhancement vs tile upscale. |
+| `build_supir` | SUPIR | ✅ Yes | — | — | — | No SUPIR update found. |
+| `build_rembg` | rembg | ✅ Yes | **ComfyUI-RMBG v3.0.0** (consolidation) | https://github.com/1038lab/ComfyUI-RMBG | Low | Node consolidates rembg + birefnet + rembg_v3 + SAM3. Jan 2026 update. |
+| `build_rembg_birefnet` | BiRefNet-general | ✅ Yes | ComfyUI-RMBG v3.0.0 (consolidation) | https://github.com/1038lab/ComfyUI-RMBG | Low | As above. |
+| `build_rembg_v3` | RMBG-2.0 | ✅ Yes | **Bria V-RMBG 3.0** (video only, API) | https://www.prnewswire.com/news-releases/bria-launches-v-rmbg-3-0-state-of-the-art-video-background-removal-model-302796516.html | Medium | Video temporal consistency; commercial API only, no open weights. |
+| `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract` | SAM3 | No | **SAM 3.1** (Object Multiplex, 7× faster multi-object) | https://huggingface.co/facebook/sam3.1 | Low | Mar 2026; drop-in checkpoint swap; same directory structure; 72K HF downloads. |
+| `build_normal_map` | ControlNet-Aux normals | ✅ Yes | — | — | — | GenCeption paper (Jul 10, no weights yet) may unify this in future. |
+| `build_depth_map_v3` | DA3-LARGE | No | **DA3-LARGE-1.1** refined checkpoint | https://huggingface.co/depth-anything/DA3-LARGE-1.1 | Low | Dec 2025; Apache-2.0; DA3-Streaming for video; checkpoint swap only. |
+| `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured` | HunyuanVideo 3D | Partial | **TRELLIS.2-4B** (PBR mesh, MIT) | https://huggingface.co/microsoft/TRELLIS.2-4B | Medium | Dec 2025; 16 GB exactly (tight); PBR materials superior to Hunyuan3D; ComfyUI wrappers exist. |
+| `build_hunyuan_3d_mesh` | HunyuanVideo 3D | Partial | **TripoSplat** (Gaussian-splat alt, 8 GB) | https://huggingface.co/VAST-AI/TripoSplat | Low | May 2026; native GAUSSIAN type in ComfyUI v0.23.0; no UV mesh — splat output only. |
+| `build_seedv2r` | SeedVR temporal | ✅ Yes | Native SeedVR2 in v0.28.0 [W] | https://github.com/comfy-org/ComfyUI/releases/tag/v0.28.0 | Low | Jul 15; native support simplifies node graph. Custom node still needed for GGUF. |
+| `build_colorize` / `build_ddcolor` | DDColor | ✅ Yes | — | — | — | No DDColor update in window. |
+| `build_color_match` / `build_klein_color_match` | colour-matching | ✅ Yes | — | — | — | No new model found. |
+| `build_lut` | LUT grading | ✅ Yes | — | — | — | No new model found. |
+| `build_layer_blend` / `build_frame_assembly` / `build_upscale_blend` | Composite ops | ✅ Yes | — | — | — | No new model found. |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+These require no new node-pack installs and carry low integration risk.
+
+### 1. HyperSwap_1c_256.onnx → `build_faceswap` / `build_faceswap_model`
+Replace `inswapper_128.onnx` with `hyperswap_1c_256.onnx` (or `_1a` / `_1b` for speed). Download from `facefusion/models-3.3.0` and drop into the same ReActor models directory. No workflow changes required. 256-px crop gives measurably better blending than 128-px.
+
+### 2. NVIDIA PiD v1.5 → `build_klein_*` / `build_txt2img` / `build_img2img`
+Swap the VAE decode node for the PiD decode node in any FLUX.2 or Klein workflow. The `2kto4k_v1pt5` checkpoint is recommended (fixes corner artifacts and colour drift from v1.0). Adds ~2 GB VRAM; output resolution extends to 4K. ComfyUI native support since v0.27.0. Highest-priority find for the Klein NSFW family.
+
+### 3. SAM 3.1 checkpoint → `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract`
+Drop-in checkpoint upgrade from `facebook/sam3` to `facebook/sam3.1`. Object Multiplex variant is ~7× faster when tracking many objects simultaneously; single-object quality is equivalent. Same directory structure; no node changes needed. 72 K downloads confirm production stability.
+
+### 4. DA3-LARGE-1.1 checkpoint → `build_depth_map_v3`
+Replace the existing DA3-LARGE checkpoint with `depth-anything/DA3-LARGE-1.1`. Apache-2.0 license. Also download DA3-Streaming checkpoint for any video depth workflows. Straightforward weight swap; PozzettiAndrea ComfyUI-DepthAnythingV3 node already supports v1.1.
+
+### 5. ComfyUI v0.28.0 core upgrade → `build_seedvr2_video_upscale` / `build_face_restore` / `build_photo_restore` / `build_detail_hallucinate` / `build_seedv2r`
+The July 15 release adds:
+- **Native SeedVR2** image + video upscaling (removes hard dep on custom node for standard pipelines)
+- **Native MediaPipe face detection** — BlazeFace, FaceMesh 478-landmark, ARKit blendshapes; replaces ControlNet-Aux MediaPipe preprocessor
+- PiD 1.5 model support, `--models-directory` flag, video audio-decode crash fix
+Keep the custom SeedVR2 node installed alongside for GGUF/chunked-streaming features.
+
+### 6. LTX-2.3-22b Foley LoRA → `build_ltx_video` (additive, new audio output)
+`Lightricks/LTX-2.3-22b-LoRA-Foley-V2A` adds synchronised Foley sound-effect generation to the existing LTX-2.3 22B model. It is a pure LoRA weight-file addition (no architecture change), so VRAM footprint is identical to the base model already in the stack. Point to step-500 checkpoint. FuzzPuppy's community fork includes a ready-made ComfyUI workflow.
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install)
+
+These add new capabilities to the palette but require installing a new custom node or new base checkpoint.
+
+### A. NVIDIA PixelDiT 1.3B — new lightweight draft builder
+Requires ComfyUI v0.27.0+. Download `pixeldit_1300m_1024px_bf16.safetensors` + `gemma_2_2b_it_elm_bf16.safetensors` from Comfy-Org. Operates in pixel space (no VAE); ~5–6 GB total VRAM, leaving ~10 GB free for compositing. Propose new builder `build_pixeldit_txt2img` as a rapid-iteration alternative to FLUX.2-dev for 1024px outputs.
+
+### B. Boogu-Image-0.1-Edit family — Apache-2.0 Qwen-architecture unified editor
+`Boogu/Boogu-Image-0.1-Edit-Turbo` via kijai's ComfyUI PR #14523. Qwen3-VL-8B encoder, Flux VAE, ~14 GB at FP8 Turbo (fits 16 GB). Propose builders: `build_boogu_txt2img`, `build_boogu_edit` (object removal, style transfer, inpainting). Direct Apache-2.0 alternative to `build_qwen_edit` with broader editing vocabulary. Needs ≥3 weeks of community stress-testing before deploying in production.
+
+### C. LanPaint node — training-free inpainting for Flux2/Klein
+Install from ComfyUI Registry (publisher: scraed). Enables inpainting via any model in the stack (including Klein) without a dedicated inpaint checkpoint. Propose as an overlay mode in `build_inpaint` and `build_klein_inpaint`. A/B test against Fooocus inpaint on edge sharpness before replacing existing workflows.
+
+### D. LingBot-Video-Dense-1.3B — #1 open video model, 6 GB VRAM
+Install `realrebelai/LingBot_ComfyUI` node. Download FP8 variant `ALXOPENSOURCE/lingbot-video-1.3b-fp8`. T2V/I2V/TI2V in 6 GB; supports max 832×480, 81 frames. Propose `build_lingbot_t2v` as a memory-efficient alternative to `build_wan22_t2v` for shorter clips. Native ComfyUI PR is WIP from comfyanonymous — switch to official node when stable.
+
+### E. BFS-Best-Face-Swap LoRA for Klein → `build_klein_headswap` / `build_klein_face_detail`
+`Alissonerdx/BFS-Best-Face-Swap` — IC-LoRA targeting Klein 4B/9B and Qwen-Image-Edit. FK 4B variant runs ~12 GB. Download from HuggingFace; follow community ComfyUI workflow on Civitai. Propose as a reference-guided mode inside the existing `build_klein_headswap` and `build_klein_face_detail` builders (add a `lora_mode: "bfs"` toggle).
+
+### F. TripoSplat — Gaussian-splat 3D path
+Requires ComfyUI v0.23.0+ for native GAUSSIAN data type. Template in ComfyUI Template Library. Download `VAST-AI/TripoSplat`. 8 GB VRAM, zero external dependencies. Propose `build_tripo_splat` as a fast 3D preview mode alongside the existing `build_hunyuan_3d_mesh` pipeline (splat → downstream mesher if UV texture needed).
+
+### G. GeoSAM2 — 3D part segmentation
+`VAST-AI/GeoSAM2` — CVPR 2026. Weights: `geosam2.pt`. No ComfyUI node yet — requires custom integration script. Relevant for Hunyuan3D or TripoSplat post-processing where you need part-level masks. Add to backlog pending a community ComfyUI wrapper.
+
+### H. ComfyUI-RMBG v3.0.0 node consolidation
+Install `1038lab/ComfyUI-RMBG` (if not already present). Unifies `build_rembg`, `build_rembg_birefnet`, `build_rembg_v3`, and `build_sam3_*` under a single node pack with text-prompted segmentation and per-category matting (face 19-class, clothes 18-class). Low risk.
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Blocker | Action |
+|---|---|---|
+| **Wan-Dancer-14B** (Wan-AI, Jul 10) | ~24 GB VRAM — exceeds budget | Wait for GGUF quantised port from community; monitor `Wan-AI/Wan-Dancer-14B` HF community tab |
+| **Krea-2-Turbo** (12B, Jun 23) | Released 3.5 weeks ago; limited community battle-testing | Evaluate quality vs FLUX.2-dev on Spellcaster test prompts; native ComfyUI nodes in v0.27.0 |
+| **TRELLIS.2-4B** (Microsoft, Dec 2025) | 16 GB exact ceiling — leaves no headroom | Test on RTX 5060 Ti alone; if stable, integrate as `build_trellis2_3d`. ComfyUI wrapper: `ComfyUI-Trellis2` |
+| **Ideogram 4** (Jun 2026) | FP8 tight at 16 GB; Community License restricts redistribution | NF4 variant (~12 GB) is safer; primarily useful for text-heavy prompts; verify license for commercial use |
+| **DreamX-World-5B** (Jul 6, near-miss) | No ComfyUI node yet; license unconfirmed Apache-2.0 | Monitor `FastVideo/DreamX-World-5B-Diffusers`; useful for `build_wan_flf` with camera control |
+| **LingBot-Video-MoE-30B** (Jul 8) | Needs 24 GB+ system RAM for weight paging despite 8 GB active VRAM | Use 1.3B dense variant instead until native ComfyUI PR lands |
+| **BFS-Video Bernini-R LoRA** (Jul 11) | Bernini-R 14B base needs ~22 GB VRAM | Wait for Q8/FP8 quantised Bernini-R; monitor `tralaleloss/BFS-Best-Face-Swap-Video` |
+| **PuLID-Flux2 v0.6.2** (May 2026) | Klein 9B + PuLID ~14 GB (borderline); verify identity fidelity vs existing build_pulid_flux | Test Klein 4B path first (~10 GB) before full rollout |
+| **ReActor 0.7.0 ALPHA** | ALPHA — InsightFace-free path may break `build_faceswap_model` face-embedding workflow | Wait for stable v0.7.0; use v0.6.2 stable + HyperSwap_1c as recommended path |
+| **Bria V-RMBG 3.0** | Commercial API only; no open weights confirmed | Monitor Bria HF for open model release; relevant only for video background removal |
+| **DreamID-V-Wan JR fork** (Feb 2026) | T5-XXL offloads to CPU (slow); confirmed 16 GB path but complex setup | Test with JR fork's `--device_placement flexible` flag; potential new `build_dreamid_video` builder |
+| **PuLID-Flux-Chroma** (May 2026) | Encoder "hacks" risk; Chroma license vs Klein | Test jeankassio / PaoloC68 fork identity fidelity; relevant only if Chroma Apache-2.0 compliance needed |
+| **GenCeption** (paper, Jul 10) | No model weights released | Monitor `genception.github.io`; could unify depth+normals+seg into one pass (ECCV 2026 paper) |
+| **IConFace** (paper, May 2026) | No weights released | Monitor NTIRE 2026 challenge repo `jkwang28/NTIRE2026_RealWorld_Face_Restoration` |
+| **RealRestorer** (Mar 2026) | 12.4B params — needs ~24 GB; no ComfyUI node | Monitor for FP8/Q8 quantisation; Step1X-Edit based |
+| **HiDream-O1-Image-Dev** (May 2026) | Released 2+ months ago; ~10 GB FP8 | Good VRAM headroom + MIT license; consider as `build_hidream_txt2img` for budget-constrained runs |
+| **Qwen DiffSynth ControlNets** (Sep 2025) | May already be in stack | Verify before treating as new; additive canny/depth conditioning for `build_qwen_edit` |
+
+---
+
+## No-finds (verified)
+
+The following items were specifically checked and found to have no new release in the 2026-W29 window:
+
+- **IC-Light v3**: No release found; still on v2.
+- **Lumina2 checkpoint update**: No new Lumina2 checkpoint in window.
+- **Fooocus inpaint new model**: No update found.
+- **HunyuanVideo update**: Last open release HunyuanVideo-1.5 (Nov 2025); no Jul 2026 update.
+- **Mochi 1 update**: Still on Oct 2024 preview weights.
+- **CogVideoX new weights**: No new model in window; ComfyUI wrapper maintenance only.
+- **FramePack P1 open weights**: Research WIP; no open weights released.
+- **WaveSpeed FlashVSR update**: Last updated May 2026; no Jul update.
+- **Wan 2.7 open weights**: API-only release Apr 2026; community open weights not published.
+- **DDColor update**: No new checkpoint in window.
+- **SUPIR update**: No new release found.
+- **New IC-Light LoRAs**: None found in window.
+- **New Klein fine-tunes (Civitai/HF)**: Community LoRAs present but no SOTA-level new variant confirmed in window.


### PR DESCRIPTION
## Summary

Daily SOTA audit for 2026-W29 (2026-07-10 → 2026-07-17). First review — no prior baseline.
Hardware budget: RTX 5060 Ti, 16 GB VRAM.

### Counts

| Tier | Count |
|---|---|
| Tier 1 — drop-in supersessions (ship soon) | 6 |
| Tier 2 — additive new builders (needs node-pack install) | 8 |
| Tier 3 — monitor / not wire-ready | 17 |
| No-finds (verified) | 13 |
| Total candidates in JSON | 36 |

### Tier 1 highlights (actionable now, low risk)

| # | Item | Affects | Action |
|---|---|---|---|
| 1 | **HyperSwap_1c_256.onnx** | `build_faceswap`, `build_faceswap_model` | Drop `inswapper_128.onnx` in ReActor models dir; no workflow changes |
| 2 | **NVIDIA PiD v1.5** (`nvidia/PiD`, ~Jul 9) | All `build_klein_*` + txt2img | Swap VAE decode node for PiD decode; output extends to 4K, +~2 GB VRAM |
| 3 | **SAM 3.1** (`facebook/sam3.1`) | `build_sam3_segment/mask/extract` | Drop-in checkpoint swap; 7× faster multi-object; same dir structure |
| 4 | **DA3-LARGE-1.1** | `build_depth_map_v3` | Checkpoint swap only; Apache-2.0 |
| 5 | **ComfyUI v0.28.0** (Jul 15) | SeedVR2, face detection, PiD 1.5 support | Update ComfyUI; native SeedVR2 + MediaPipe face detection land in core |
| 6 | **LTX-2.3 Foley LoRA** (Lightricks, Jul 15) | `build_ltx_video` | LoRA weight-file adds V2A Foley audio; same VRAM as base |

### Strictly in-window items (Jul 10–17)

- **Wan-Dancer-14B** (Jul 10) — music-to-dance; 24 GB needed → Tier 3, wait for GGUF
- **BFS-Video Bernini-R LoRA** (Jul 11) — video headswap; 14B base ~22 GB → Tier 3
- **LTX-2.3 Foley LoRA** (Jul 15) → Tier 1
- **ComfyUI v0.28.0** (Jul 15) → Tier 1
- **Boogu-Image-0.1 tech report** (Jul 16) — Apache-2.0 unified edit model → Tier 2
- **GenCeption paper** (Jul 10, ECCV 2026) — paper only, no weights → Tier 3
- **LingBot-Video** (Jul 8, near-miss) — #1 RBench open video, 6 GB → Tier 2

### Notable non-finds

IC-Light v3, Lumina2 update, HunyuanVideo update, Mochi 1 update, CogVideoX new weights, FramePack P1 open weights, WaveSpeed Jul update, Wan 2.7 open weights — all checked, nothing new this week.

---

> **Note for the reviewer:** The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically. No action needed there — this PR is research-only. Do not merge without human review; all Tier-1 items require local node-pack validation on the RTX 5060 Ti before deployment.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dv2CMC5cs7r4phRnqKkxm)_