### PR TITLE
chore(research): daily SOTA review 2026-07-18

### DIFF
--- a/_dev_docs/upgrade_research/2026-W29.json
+++ b/_dev_docs/upgrade_research/2026-W29.json
@@ -1,0 +1,182 @@
+[
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Boogu-Image-0.1-Edit-Turbo fp8",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "NEW TODAY (Jul 18): Official FP8 weights pushed today. 4-step distilled instruction-driven edit model. Apache-2.0. ComfyUI-Boogu node pack required (github.com/boogu-project/ComfyUI-Boogu). GGUF Q4 ~5-6 GB, FP8 ~10 GB. Direct competitor to build_qwen_edit. arXiv:2607.13125."
+  },
+  {
+    "method": "build_img2img",
+    "category": "checkpoint",
+    "name": "Boogu-Image-0.1-Edit fp8",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Boogu/Boogu-Image-0.1-Edit",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Weights updated Jul 16. 10.3B instruction-driven editing model. Apache-2.0. FP8 official weights ~10 GB. arXiv:2607.13125 (Jul 14). Requires ComfyUI-Boogu node pack. Also see ComfyUI tutorial at docs.comfy.org/tutorials/image/boogu/boogu-image-0.1."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Boogu-Image-0.1-Turbo fp8",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Boogu/Boogu-Image-0.1-Turbo-fp8",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Updated Jul 16. 4-step distilled T2I. Apache-2.0. FP8 official ~10 GB, GGUF Q4 ~5-6 GB. Community GGUF: realrebelai/Boogu-Image-Turbo_GGUFs (15.6K downloads). Requires ComfyUI-Boogu node pack."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "node_pack",
+    "name": "ComfyUI v0.28.0 — Save 3D (Advanced) / Save Splat / Save Point Cloud",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "NEW vs PR #127. Released Jul 15. Adds Save 3D (Advanced), Save Splat, and Save Point Cloud export nodes to ComfyUI core. GLB/OBJ/PLY output. No new weights required. Ships with ComfyUI >= 0.28.0 upgrade."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "node_pack",
+    "name": "ComfyUI v0.28.0 — Hunyuan3D obj output optional",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "NEW vs PR #127. Obj output in Hunyuan3D Text/Image-to-3D nodes is now optional, removing mandatory intermediate step that was causing workflow failures. Ships with ComfyUI >= 0.28.0."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTXV Audio VAE (LTX23_audio_vae_bf16.safetensors)",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "NEW vs PR #127 (which knew about LTX Foley LoRA — this is different). ComfyUI 0.28.0 adds native LTXV Audio VAE Loader node. Model file goes in models/vae/. Enables audio-conditioned video generation without Lightricks custom node."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTXv Spatial Upscaler 0.9.7 (Lightricks)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/ltxv-spatial-upscaler-0.9.7",
+    "risk": "medium",
+    "confidence": 0.50,
+    "notes": "Latent-domain spatial upscaler trained on LTX Video representations. Higher fidelity than pixel-space upscalers for LTX-generated content. Present on HF as of Jul 18; exact release date unconfirmed — may predate Jul 11 window."
+  },
+  {
+    "method": "build_photobooth",
+    "category": "node_pack",
+    "name": "ComfyUI-LongCat-Avatar (LongCat Video Avatar 1.5)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/vantagewithai/LongCat-Video-Avatar-1.5-GGUF-ComfyUI",
+    "risk": "medium",
+    "confidence": 0.55,
+    "notes": "NEW — missed in all prior W29 reviews. ComfyUI node released Jul 11 per aggregator. 13.6B audio+image-to-video talking-head model. GGUF Q4 ~12-14 GB (tight on 16 GB). Built on kijai/WanVideo. New capability: audio-driven portrait video. New builder suggested: build_longcat_avatar."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "node_pack",
+    "name": "ComfyUI-facerestore_advanced (flickleafy)",
+    "source": "github",
+    "url": "https://github.com/flickleafy/ComfyUI-facerestore_advanced",
+    "risk": "low",
+    "confidence": 0.25,
+    "notes": "Quality-gated fallback chain: CodeFormer → GFPGAN → GPEN 1024/2048. Reuses existing model weights (no new downloads). SSIM + artifact detection gating. Date unclear. Low-risk evaluation item. Not in any prior W29 review."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "OSDFace (CVPR 2025)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/jkwang28/OSDFace",
+    "risk": "high",
+    "confidence": 0.10,
+    "notes": "One-step diffusion face restoration. NTIRE 2026 challenge confirms distilled-diffusion approaches beat CodeFormer. Weights uploaded Nov 2024. No ComfyUI node wrapper yet. Watch jkwang28/OSDFace repo. Long-term replacement path for build_face_restore."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "RealRestorer (12.4B, Apache-2.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/RealRestorer/RealRestorer",
+    "risk": "medium",
+    "confidence": 0.15,
+    "notes": "March 2026 — outside window. 12.4B, Apache-2.0. Covers 9 degradation types. ComfyUI node: github.com/StartHua/Comfyui_RealRestorer. On RTX 5060 Ti 16 GB: use sequential_offload + tile ≤1024px. Not in any prior W29 review."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D-PolyGen (Tencent)",
+    "source": "github",
+    "url": "https://github.com/Tencent-Hunyuan/Hunyuan3D-2.1/issues/111",
+    "risk": "high",
+    "confidence": 0.30,
+    "notes": "Intelligent mesh retopology (clean quad/tri topology) for Hunyuan3D pipeline. Weights NOT open-sourced (GitHub issue #111 unresolved as of Jul 18). Announcement tweet date ambiguous (~Jul 7, 2025 vs 2026). Monitor tencent/Hunyuan3D on HF for weights drop."
+  },
+  {
+    "method": "build_colorize",
+    "category": "checkpoint",
+    "name": "ColorFLUX — structure-color decoupling colorization",
+    "source": "huggingface",
+    "url": "https://arxiv.org/pdf/2603.28162",
+    "risk": "high",
+    "confidence": 0.10,
+    "notes": "March 2026 paper. Better temporal consistency on degraded historic photos vs DDColor. No public weights or ComfyUI node found. Monitor for release."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "MiM-DiT — MoE-in-MoE Image Restoration",
+    "source": "huggingface",
+    "url": "https://arxiv.org/abs/2603.02710",
+    "risk": "high",
+    "confidence": 0.10,
+    "notes": "March 2026 paper. Dual MoE routing for 9 degradation types in single pass — could replace SUPIR 5-stage pipeline. No public HF weights or ComfyUI node found. Monitor for weights release."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 1a/1b/1c (256 px, ReActor)",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/issues/143",
+    "risk": "low",
+    "confidence": 0.30,
+    "notes": "ALREADY KNOWN — PR #124/#127 Tier 1. 256px vs 128px (inswapper_128), same ReActor nodes, new model path. Active rendering bug #226 (black-circle artifact). Hold for bug fix before enabling."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "node_pack",
+    "name": "ComfyUI v0.28.0 — native SeedVR2 integration",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "ALREADY KNOWN — PR #127 Tier 1. Promotes SeedVR2 from custom node (numz/ComfyUI-SeedVR2) to ComfyUI core. Stable landing (reverted #14359, merged #14424). GGUF Q4_K_M fits 8 GB."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (facebook/sam3.1)",
+    "source": "huggingface",
+    "url": "https://ai.meta.com/blog/segment-anything-model-3/",
+    "risk": "low",
+    "confidence": 0.50,
+    "notes": "ALREADY KNOWN — PR #124/#127 Tier 1. 2x faster than SAM 3.0. ~4 GB FP16. Gated model — request Meta access at hf.co/facebook/sam3.1 first. Paper published ICLR 2026 Jul 13 (in-window)."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "Comfy-Org/BiRefNet — model refresh Jul 14",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/BiRefNet",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "ALREADY KNOWN — PR #125 Tier 1. Same arch/nodes. Pull latest weights from Comfy-Org/BiRefNet repo for quality improvement. MIT licence."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W29.md
+++ b/_dev_docs/upgrade_research/2026-W29.md
@@ -1,0 +1,148 @@
+# Spellcaster daily SOTA review — 2026-07-18
+
+ISO week: `2026-W29`. Baseline: `2026-W29.md` on `daily-sota-review/2026-07-17` (PR #127).
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / Update | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| build_qwen_edit | Qwen VL | Challenged | Boogu-Image-0.1-Edit-Turbo fp8 | [HF](https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo) | medium | **NEW TODAY (Jul 18)** — fp8 weights pushed today; 4-step distilled instruction edit; Apache-2.0; GGUF Q4 ~5-6 GB |
+| build_img2img | Flux / Klein 4B | Yes | Boogu-Image-0.1-Edit (alt paradigm) | [HF](https://huggingface.co/Boogu/Boogu-Image-0.1-Edit) | medium | **NEW** — edit weights confirmed Jul 16; arXiv:2607.13125 (Jul 14); requires ComfyUI-Boogu node pack |
+| build_txt2img | Flux / Klein 4B | Yes | Boogu-Image-0.1-Turbo fp8 (alt) | [HF](https://huggingface.co/Boogu/Boogu-Image-0.1-Turbo-fp8) | medium | **NEW** — fp8 official Jul 16; 4-step distilled T2I; Apache-2.0; GGUF Q4 ~5-6 GB |
+| build_hunyuan_3d_mesh | HunyuanDiT 3D | Updated | ComfyUI 0.28.0 Save 3D / Save Splat / Save Point Cloud | [Changelog](https://docs.comfy.org/changelog) | low | **NEW vs PR #127** — explicit 3D export nodes not caught in prior W29 reviews |
+| build_hunyuan_3d_textured | HunyuanDiT 3D | Updated | ComfyUI 0.28.0 obj output optional | [Changelog](https://docs.comfy.org/changelog) | low | **NEW vs PR #127** — mandatory obj step removed, fixes workflow failures |
+| build_ltx_video | LTX Video 2.3 | Updated | LTXV Audio VAE native (ComfyUI 0.28.0) | [Changelog](https://docs.comfy.org/changelog) | low | **NEW vs PR #127** — distinct from Foley LoRA; native Audio VAE Loader in core; file → models/vae/ |
+| build_ltx_video | LTX Video 2.3 | Updated | LTXv Spatial Upscaler 0.9.7 (latent-domain) | [HF](https://huggingface.co/Lightricks/ltxv-spatial-upscaler-0.9.7) | medium | **NEW** — latent-space upscale post-pass; HF date unconfirmed (confidence 0.50) |
+| build_photobooth | iterative gen | New capability | ComfyUI-LongCat-Avatar v1.5 | [HF](https://huggingface.co/vantagewithai/LongCat-Video-Avatar-1.5-GGUF-ComfyUI) | medium | **NEW — missed in all prior W29 reviews** — audio-driven talking-head video; node released Jul 11 |
+| build_faceswap | inswapper_128.onnx | Challenged | HyperSwap 1a/1b/1c (256 px) | [GitHub](https://github.com/Gourieff/ComfyUI-ReActor/issues/143) | low | Already known — PR #127 Tier 1. Bug #226 still active; hold for fix |
+| build_seedvr2_video_upscale | SeedVR2 custom node | Updated | ComfyUI v0.28.0 native SeedVR2 | [Changelog](https://docs.comfy.org/changelog) | low | Already known — PR #127 Tier 1 |
+| build_seedv2r | SeedVR2 custom node | Updated | ComfyUI v0.28.0 native SeedVR2 | [Changelog](https://docs.comfy.org/changelog) | low | Already known — PR #127 Tier 1 |
+| build_sam3_segment | SAM 3.0 | Updated | SAM 3.1 (facebook/sam3.1) | [Meta AI](https://ai.meta.com/blog/segment-anything-model-3/) | low | Already known — PR #127 Tier 1. Gated model; request Meta license |
+| build_sam3_mask | SAM 3.0 | Updated | SAM 3.1 | [Meta AI](https://ai.meta.com/blog/segment-anything-model-3/) | low | Already known — PR #127 Tier 1 |
+| build_sam3_extract | SAM 3.0 | Updated | SAM 3.1 | [Meta AI](https://ai.meta.com/blog/segment-anything-model-3/) | low | Already known — PR #127 Tier 1 |
+| build_rembg_birefnet | BiRefNet | Updated | Comfy-Org/BiRefNet refresh Jul 14 | [HF](https://huggingface.co/Comfy-Org/BiRefNet) | low | Already known — PR #125 Tier 1 |
+| build_rembg_v3 | RMBG-2.0 | Updated | Comfy-Org/BiRefNet refresh Jul 14 | [HF](https://huggingface.co/Comfy-Org/BiRefNet) | low | Already known — PR #125 Tier 1 |
+| build_supir | SUPIR SDXL | Yes | PiD v1.5 (lighter alt, NSCLv1) | [Docs](https://docs.comfy.org/tutorials/image/pixeldit/pixeldit) | medium | Already known — PR #127 Tier 1. Non-commercial licence |
+| build_depth_map_v3 | DA3-LARGE | Updated | DA3-LARGE-1.1 | — | low | Already known — PR #127 Tier 1 |
+| build_wan_video | WAN 2.2 | Yes | int4 quantized checkpoints (0.28.0) | [Changelog](https://docs.comfy.org/changelog) | low | Already known — PR #127 Tier 1 |
+| build_face_restore | CodeFormer | Aging | OSDFace (no node yet) | [GitHub](https://github.com/jkwang28/OSDFace) | high | Monitor — NTIRE 2026 confirms distilled diffusion beats CodeFormer; waiting for ComfyUI wrapper |
+| build_colorize | Klein / DDColor | Yes | ColorFLUX (no weights) | [arXiv](https://arxiv.org/pdf/2603.28162) | high | Monitor — paper only, no weights |
+| build_iclight | IC-Light V2 | Yes | — | — | — | No-find — no IC-Light updates this week |
+| build_lama_remove | LaMa | Yes | — | — | — | No-find — no updates |
+| build_controlnet_gen | ControlNet | Yes | — | — | — | No-find — no new ControlNet models |
+| build_pulid_flux | PuLID Flux | Yes | — | — | — | No-find — no PuLID update since Mar 2026 |
+| build_hunyuan_video | HunyuanVideo 1.5 | Yes | — | — | — | No-find |
+| build_mochi_video | Mochi 1 | Yes | — | — | — | No-find |
+| build_cogvideo_video | CogVideoX | Yes | — | — | — | No-find |
+| build_framepack_video | FramePack | Yes | — | — | — | No-find |
+| build_faceid_img2img | IP-Adapter FaceID | Yes | — | — | — | No-find |
+| build_ddcolor | DDColor | Yes | — | — | — | No-find |
+| build_style_transfer | IP-Adapter | Yes | — | — | — | No-find |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+### 1. Boogu-Image-0.1-Edit-Turbo fp8 — weights pushed TODAY (July 18)
+
+PR #127 baseline caught only the July 16 paper/tech report. The official FP8-quantized weights for the 4-step distilled Edit-Turbo variant were pushed to HuggingFace **today**. GGUF Q4_K_M community quants also available (~5–6 GB). Apache-2.0 license — commercially permissive.
+
+- **Affects:** `build_qwen_edit` (competing builder path), `build_img2img`, `build_inpaint`
+- **Action:** Install ComfyUI-Boogu node pack; benchmark Edit-Turbo vs existing `build_qwen_edit` on identity-preserving edits
+- **VRAM:** FP8 ~10 GB, GGUF Q4 ~5–6 GB (both fit 16 GB)
+- **Confidence:** 0.92 (weights verified on HF as of Jul 18)
+
+### 2. ComfyUI 0.28.0 — Save 3D (Advanced) / Save Splat / Save Point Cloud nodes
+
+PR #127 covered 0.28.0 broadly (SeedVR2, PiD, int4) but did not explicitly call out the 3D export improvements. These add a clean GLB/OBJ/PLY export path and make the `obj` output optional in Hunyuan3D Text/Image-to-3D nodes, removing a mandatory intermediate step that caused workflow failures.
+
+- **Affects:** `build_hunyuan_3d_mesh`, `build_hunyuan_3d_textured`
+- **Action:** Upgrade ComfyUI to ≥0.28.0 (already Tier 1 from PR #127); test 3D export pipeline end-to-end
+- **VRAM:** No new weights; no additional VRAM cost
+- **Confidence:** 0.90
+
+### 3. ComfyUI 0.28.0 — LTXV Audio VAE native integration
+
+PR #127 knew about the LTX-2.3 Foley LoRA (audio sound effects). This is a **different** item: a standalone Audio VAE model (`LTX23_audio_vae_bf16.safetensors` → `models/vae/`) for audio-conditioned video generation, now natively supported via a new LTXV Audio VAE Loader node. No Lightricks custom node required after upgrading to 0.28.0.
+
+- **Affects:** `build_ltx_video`
+- **Action:** Download LTXV Audio VAE weights; add optional audio-conditioning path to `build_ltx_video`
+- **VRAM:** Audio VAE is compact; no meaningful VRAM increase on top of LTX 2.3 base
+- **Confidence:** 0.72
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+### 4. Boogu-Image-0.1-Edit + Boogu-Image-0.1-Turbo (full weight release confirmed)
+
+ArXiv:2607.13125 (July 14) with Apache-2.0 license. 10.3B unified image gen+edit model. Official FP8 weights on HuggingFace; GGUF community quants available. Two variants: Edit (full instruction editing) and Turbo (4-step distilled T2I). Requires ComfyUI-Boogu node pack.
+
+- **Affects:** `build_txt2img` (Turbo variant), `build_qwen_edit` / `build_img2img` (Edit variant)
+- **New builders:** `build_boogu_edit`, `build_boogu_txt2img`
+- **VRAM:** FP8 ~10 GB; GGUF Q4 ~5–6 GB
+- **Confidence:** 0.90 (paper + weights both confirmed Jul 14-16)
+
+### 5. ComfyUI-LongCat-Avatar — audio-driven portrait video (MISSED IN ALL PRIOR W29 REVIEWS)
+
+ComfyUI wrapper for LongCat Video Avatar 1.5 (13.6B audio+image-to-video) released **July 11**. Produces lip-synced, identity-stable talking-head video from a single portrait + audio track. GGUF Q4 weights (~12–14 GB) fit within 16 GB. Built on kijai/WanVideo wrapper.
+
+- **Affects:** `build_photobooth` (adjacent use case)
+- **New builder:** `build_longcat_avatar`
+- **VRAM:** Q4 GGUF ~12–14 GB (tight on 16 GB; fp16 full model exceeds ceiling)
+- **Confidence:** 0.55 (node release July 11 per aggregator search; HF weights last modified May 24)
+
+### 6. LTXv Spatial Upscaler 0.9.7 (Lightricks)
+
+Latent-domain spatial upscaler trained on LTX Video latent representations. Higher fidelity than pixel-space upscalers (4x-UltraSharp, etc.) for LTX-generated video content. Present on HuggingFace as of July 18; exact release date unconfirmed.
+
+- **Affects:** `build_ltx_video` (additive post-pass), `build_video_upscale`
+- **Action:** Wire as optional latent-domain upscale tail node in `build_ltx_video`
+- **VRAM:** Compact model; should fit comfortably within 16 GB
+- **Confidence:** 0.50 (HF presence confirmed; release date within window unverified)
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+| Item | Affected builder(s) | Blocker | Action |
+|---|---|---|---|
+| OSDFace (CVPR 2025, jkwang28/OSDFace) | `build_face_restore`, `build_photo_restore` | No ComfyUI node wrapper | Watch repo; NTIRE 2026 confirms it beats CodeFormer quality |
+| RealRestorer (Mar 2026, 12.4B, Apache-2.0) | `build_supir` | Heavy — needs sequential_offload + tiling ≤1024px on 16 GB | ComfyUI node exists (StartHua/Comfyui_RealRestorer); evaluate when SUPIR is the bottleneck |
+| Hunyuan3D-PolyGen (Tencent) | `build_hunyuan_3d_mesh` | Weights NOT open-sourced (GitHub #111 unresolved) | Monitor tencent/Hunyuan3D on HF for weights drop |
+| ComfyUI-facerestore_advanced (flickleafy) | `build_face_restore`, `build_photo_restore` | Release date unknown; quality-gated CodeFormer/GPEN wrapper | Low-risk eval — reuses existing model weights, adds auto-fallback chain |
+| Latent PMRF extension (arXiv 2507.00447, Jul 2026) | `build_supir` | Unclear if new weights released on HF | Check jkwang28/PMRF for updated checkpoints |
+| ColorFLUX (arXiv 2603.28162) | `build_colorize`, `build_ddcolor` | No public weights or ComfyUI node | Monitor for weights release |
+| MiM-DiT (arXiv 2603.02710) | `build_supir` | No public weights | Monitor for HF model card |
+| Ideogram v4 Fast/Instant (fal API) | `build_txt2img` | API-only, no local weights | Evaluate licence; cloud dependency |
+
+---
+
+## Already-known items (from PR #124–127 baselines — not re-surfaced as novel)
+
+| Item | Prior PR | Status |
+|---|---|---|
+| HyperSwap 1a/1b/1c (256 px) in ReActor | PR #124 Tier 1, PR #127 Tier 1 | Bug #226 (black artifact) still active — hold for fix |
+| ComfyUI v0.28.0 — native SeedVR2 | PR #127 Tier 1 | Ship after ComfyUI upgrade |
+| NVIDIA PiD v1.5 / PixelDiT 1300M | PR #127 Tier 1 | NSCLv1 non-commercial — benchmark only |
+| SAM 3.1 (facebook/sam3.1) | PR #124/#127 Tier 1 | Gated — request Meta licence at hf.co/facebook/sam3.1 |
+| DA3-LARGE-1.1 | PR #127 Tier 1 | Checkpoint swap ready |
+| LTX-2.3 Foley LoRA (Lightricks) | PR #127 Tier 1 | Ready to add as LoRA variant in build_ltx_video |
+| Comfy-Org/BiRefNet refresh (Jul 14) | PR #125 Tier 1 | Update model file |
+| ComfyUI v0.28.0 — int4 quant for video DiT | PR #125/#127 Tier 1 | Use int4 checkpoints for VRAM headroom on WAN/LTX/Hunyuan |
+| Seedance 2.5 API (Jul 16) | PR #125 Tier 3 | Cloud-only, no local weights |
+| FaceFusion 3.7.1 (Jul 5) | PR #127 Tier 1 | Separate node ecosystem — not drop-in for ReActor |
+| Wan-Dancer-14B (24 GB BF16) | PR #127 Tier 3 | Await kijai GGUF quants |
+| LingBot-Video 1.3B | PR #124 Tier 2 | Pending local evaluation |
+| xocialize Klein 4B LoRA suite | PR #125 Tier 2 | Pending local evaluation |
+| ComfyUI v0.28.0 — MediaPipe face detection | PR #125/#127 Tier 1 | Ships with ComfyUI upgrade |
+
+---
+
+## No-finds (verified)
+
+The following builders were checked and no new models, nodes, or substantial updates were found in the July 11–18, 2026 window:
+
+`build_inpaint` · `build_inpaint_fooocus` · `build_outpaint` · `build_controlnet_gen` · `build_iclight` (IC-Light V2 still current) · `build_lama_remove` · `build_style_transfer` · `build_normal_map` · `build_lut` · `build_color_match` · `build_ddcolor` (DDColor unchanged) · `build_klein_color_match` · `build_hunyuan_video` (HunyuanVideo 1.5 still current) · `build_mochi_video` · `build_cogvideo_video` · `build_framepack_video` · `build_wan_animate_video` · `build_wan_flf` · `build_wan_video_blockswap` · `build_wan_video_blockswap_t2v` · `build_video_reactor` · `build_wavespeed_upscale` · `build_upscale_blend` · `build_frame_assembly` · `build_faceid_img2img` · `build_pulid_flux` (no PuLID update since Mar 2026) · `build_layer_blend` · `build_upscale` · `build_2d_to_sbs` · `build_generate_anything` · `build_klein_*` (no new Klein 4B/9B checkpoint this week) · `build_colorize` (no DDColor update; ColorFLUX has no weights)


### PR DESCRIPTION
## What does this change?\n\nDaily SOTA audit for **2026-W29** (2026-07-18). Baseline: PR #127 (`daily-sota-review/2026-07-17`).\nHardware budget: RTX 5060 Ti, 16 GB VRAM.\nFiles added: `_dev_docs/upgrade_research/2026-W29.md` · `_dev_docs/upgrade_research/2026-W29.json` (18 records).\n\n## Type of change\n\n- [x] Docs only\n\n## Checklist\n\n- [x] **No personal data in the diff.** No real IPs, no `C:\\Users\\...` paths, no email addresses, no tokens.\n- [x] **No NSFW content in the public repo.**\n- [x] **`spellcaster_core/` stays in sync.** Research-only PR — no code changes.\n- [ ] **Tested locally** — research PR only; no ComfyUI changes.\n\n---\n\n## Summary\n\nDaily incremental review on top of PR #127. Three Tier-1 items that were **missed in yesterday's run** (all stem from ComfyUI v0.28.0, Jul 15):\n\n| Tier | Count |\n|---|---|\n| Tier 1 — drop-in supersessions (ship soon) | **3** |\n| Tier 2 — additive new builders (needs node-pack install) | **3** |\n| Tier 3 — monitor / not wire-ready | **8** |\n| Already known (flagged, from PR #124–127) | **4** |\n| No-finds (verified) | **33 builders** |\n\n### Tier 1 highlights (new vs PR #127 baseline)\n\n| # | Item | Affects | Action |\n|---|---|---|---|\n| 1 | **Boogu-Image-0.1-Edit-Turbo fp8** — weights pushed **today (Jul 18)** | `build_qwen_edit`, `build_img2img` | Install ComfyUI-Boogu; benchmark vs build_qwen_edit. FP8 ~10 GB / GGUF Q4 ~5-6 GB. Apache-2.0. |\n| 2 | **ComfyUI 0.28.0 — Save 3D / Save Splat / Save Point Cloud + obj optional** | `build_hunyuan_3d_mesh`, `build_hunyuan_3d_textured` | Free after ComfyUI upgrade (already Tier 1 from #127). Fixes workflow failures. |\n| 3 | **ComfyUI 0.28.0 — LTXV Audio VAE native** (distinct from Foley LoRA) | `build_ltx_video` | Download Audio VAE; add optional audio-conditioning path. Ships with 0.28.0 upgrade. |\n\n### Tier 2 highlights\n\n| # | Item | New builder | VRAM |\n|---|---|---|---|\n| 4 | **Boogu-Image-0.1-Edit + Turbo** (weights confirmed) | `build_boogu_edit`, `build_boogu_txt2img` | FP8 ~10 GB / GGUF Q4 ~5-6 GB |\n| 5 | **ComfyUI-LongCat-Avatar v1.5** (Jul 11) — **missed in all prior W29 reviews** | `build_longcat_avatar` | Q4 GGUF ~12-14 GB |\n| 6 | **LTXv Spatial Upscaler 0.9.7** (Lightricks, latent-domain) | additive to `build_ltx_video` | compact |\n\n### Items already known (not re-surfaced)\n\nHyperSwap 1a/1b/1c (bug #226 active), ComfyUI 0.28.0 SeedVR2 native, PiD v1.5 (NSCLv1), SAM 3.1 (gated), DA3-LARGE-1.1, LTX Foley LoRA, BiRefNet Jul 14, int4 quant support, Seedance 2.5, FaceFusion 3.7.1 — all on PR #124–127 punch lists.\n\n---\n\n> **Note for the reviewer:** The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically. Implementation upgrades listed above require local node-pack installation on the RTX 5060 Ti — they cannot be applied in this automated review run. **Do not merge without human review.**\n\n---\n_Generated by [Claude Code](https://claude.ai/code)_"

---
_Generated by [Claude Code](https://claude.ai/code/session_017mZ1PDKuCr39ufXD7vu9fr)_