### PR TITLE
chore(research): daily SOTA review 2026-07-22

### DIFF
--- a/_dev_docs/upgrade_research/2026-W30.json
+++ b/_dev_docs/upgrade_research/2026-W30.json
@@ -44,17 +44,6 @@
     "notes": "Same as build_hunyuan_3d_mesh — both 3D builders benefit from native export nodes added in v0.28.0."
   },
   {
-    "method": "build_klein_headswap",
-    "category": "node_pack",
-    "name": "ComfyUI-BFSNodes v1.17.0 (alisson-anjos)",
-    "source": "github",
-    "url": "https://github.com/alisson-anjos/ComfyUI-BFSNodes",
-    "release_date": "2026-07-22",
-    "risk": "low",
-    "confidence": 0.92,
-    "notes": "Major BFSNodes update burst this week (July 17-22). July 22: new LTX Multiple Controls node merging guide/mask/identity conditioning into single node. July 20: Entity Sheet 2x2 node for HuMoSet v7 multi-view character sheets. July 17: ArcFace projector dropped; reference_face renamed to reference_image — potential BREAKING CHANGE that may affect build_klein_headswap parameter handling. Required companion node pack for BFS head-swap LoRAs (Flux-Klein / LTX backbone). No VRAM overhead from node pack itself."
-  },
-  {
     "method": "build_upscale",
     "category": "checkpoint",
     "name": "NVIDIA PID v1.5 (PixelDiT pixel-diffusion upscaler)",
@@ -63,18 +52,7 @@
     "release_date": "2026-07-09",
     "risk": "medium",
     "confidence": 0.88,
-    "notes": "CVPR 2026 Best Paper Finalist. Single-stage pixel-space diffusion transformer (no VAE). PID v1.5 provides 2K->4K upscaling in under 1 second; 13 GB peak VRAM (fits 16 GB card). Works with FLUX, FLUX.2, and Qwen-Image latents via PiD Conditioning node (native ComfyUI v0.28.0). NSCLv1 license = non-commercial only — licensing must be cleared before wiring. Additive new builder build_pid_upscale; not a direct replacement for UltraSharp. Comfy-Org/PixelDiT: 198K downloads, 133 likes. ComfyUI-PiD custom node: github.com/Merserk/ComfyUI-PiD."
-  },
-  {
-    "method": "build_video_upscale",
-    "category": "checkpoint",
-    "name": "NVIDIA PID v1.5 per-frame video upscaling",
-    "source": "github",
-    "url": "https://github.com/nv-tlabs/PiD",
-    "release_date": "2026-07-15",
-    "risk": "medium",
-    "confidence": 0.82,
-    "notes": "Same PID v1.5 model applied per-frame in build_video_upscale. Not a temporal upscaler — works like 4x-UltraSharp but diffusion-based. PiD Upscale node supports 2x/4x/6x/8x output. On Ada+/RTX-50xx an FP4/FP8 path gives additional speedup. A/B test against 4x-UltraSharp warranted. NSCLv1 non-commercial license applies."
+    "notes": "CVPR 2026 Best Paper Finalist. Single-stage pixel-space diffusion transformer (no VAE). PID v1.5 provides 2K→4K upscaling in under 1 second; 13 GB peak VRAM (fits 16 GB card). Works with FLUX, FLUX.2, and Qwen-Image latents via PiD Conditioning node (native ComfyUI v0.28.0). NSCLv1 license = non-commercial only — licensing must be cleared before wiring. Additive new builder build_pid_upscale; not a direct replacement for UltraSharp. Comfy-Org/PixelDiT: 198K downloads, 133 likes. ComfyUI-PiD custom node: github.com/Merserk/ComfyUI-PiD."
   },
   {
     "method": "build_upscale_blend",
@@ -85,7 +63,7 @@
     "release_date": "2026-07-09",
     "risk": "medium",
     "confidence": 0.80,
-    "notes": "PID v1.5 could be added as a third upscaler path in build_upscale_blend alongside the existing two traditional upscalers. Same NSCLv1 non-commercial licensing caveat applies."
+    "notes": "PID v1.5 could be added as a third upscaler path in build_upscale_blend alongside the existing two traditional upscalers. Same licensing caveat (NSCLv1 = non-commercial) applies."
   },
   {
     "method": "build_detail_hallucinate",
@@ -97,6 +75,61 @@
     "risk": "medium",
     "confidence": 0.72,
     "notes": "PID 1.5 offers a pixel-diffusion quality path for fine-detail super-resolution that may outperform the current ESRGAN+SDXL approach. Needs benchmark comparison on portrait/face detail before wiring. NSCLv1 license risk same as above."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 (Lightricks, 22B, audio-video)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/ltx-2-open-source-audio-video-ai",
+    "release_date": "2026-03-01",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Outside 7-day window (March 2026) — already-known item. LTX-2.3 generates synced audio+video in one pass; day-0 ComfyUI support. 22B parameters. Full quality needs 16–24 GB VRAM (borderline for RTX 5060 Ti 16 GB); Q4 quantised fits 12 GB. Spellcaster's build_ltx_video likely targets LTX v1.x — should be updated to 2.3. Audio output is new capability not yet reflected in any builder."
+  },
+  {
+    "method": "build_hunyuan_video",
+    "category": "checkpoint",
+    "name": "HunyuanVideo 1.5 (Tencent, 8.3B, 720p, step-distilled)",
+    "source": "github",
+    "url": "https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5",
+    "release_date": "2025-11-20",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "Outside 7-day window (Nov 2025) — already-known item. HunyuanVideo 1.5 is lighter (8.3B vs original), supports 720p native output, step-distilled (8–12 inference steps), diverse styles (realistic/anime/3D). Native ComfyUI support. Fits 16 GB VRAM comfortably. Verify whether build_hunyuan_video already targets 1.5 checkpoint — if still on 1.0, this is a Tier 1 upgrade waiting to be made."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "checkpoint",
+    "name": "SwiftVR (one-step causal video restoration, H-oliday/SwiftVR)",
+    "source": "github",
+    "url": "https://github.com/jungbtc/ComfyUI-SwiftVR",
+    "release_date": "2026-06-09",
+    "risk": "high",
+    "confidence": 0.22,
+    "notes": "Outside 7-day window (June 9, 2026). One-step diffusion video restoration at ~26 FPS (1080p) on RTX 5090 (32 GB VRAM). No confirmed benchmarks for 16 GB VRAM; native ComfyUI PR #14469 still open as of 2026-07-22. Monitor for GGUF/tiling variant before wiring. Potential strong complement or replacement for SeedVR2."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "TripoSplat (VAST-AI, image to 3D Gaussian Splat, MIT license)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/VAST-AI/TripoSplat",
+    "release_date": "2026-06-01",
+    "risk": "low",
+    "confidence": 0.70,
+    "notes": "Outside 7-day window (June 2026). Native ComfyUI support PR #14210 (kijai). Generates 3D Gaussian splats from a single image; 6.6 GB VRAM in testing. MIT license. Pairs naturally with new native Save Splat node in v0.28.0. Additive new builder build_triposplat would complement existing HunyuanDiT 3D mesh builders. Monitor for stability before wiring."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "node_pack",
+    "name": "ComfyUI-BFSNodes v1.17.0 (alisson-anjos)",
+    "source": "github",
+    "url": "https://github.com/alisson-anjos/ComfyUI-BFSNodes",
+    "release_date": "2026-07-22",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Major BFSNodes update burst this week (July 17–22). July 22: new LTX Multiple Controls node merging guide/mask/identity conditioning into single node. July 20: Entity Sheet 2x2 node for HuMoSet v7 multi-view character sheets. July 17: ArcFace projector dropped; reference_face renamed to reference_image — BREAKING CHANGE that may affect build_klein_headswap parameter handling. Required companion node pack for BFS head-swap LoRAs (Flux-Klein / LTX backbone). No VRAM overhead from node pack itself."
   },
   {
     "method": "build_pulid_flux",
@@ -132,48 +165,26 @@
     "notes": "API-only (no open weights). 30-second single-shot video, 50 multimodal reference inputs, native 4K, audio-video joint generation, 3D camera blockout. No ComfyUI partner node confirmed yet. Monitor for community node — if one ships, a new build_seedance25_video builder would be warranted. No local VRAM cost."
   },
   {
-    "method": "build_ltx_video",
+    "method": "build_video_upscale",
     "category": "checkpoint",
-    "name": "LTX-2.3 (Lightricks, 22B, audio-video)",
+    "name": "NVIDIA PID v1.5 per-frame video upscaling",
     "source": "github",
-    "url": "https://blog.comfy.org/p/ltx-2-open-source-audio-video-ai",
-    "release_date": "2026-03-01",
-    "risk": "medium",
-    "confidence": 0.85,
-    "notes": "Outside 7-day window (March 2026) — already-known item. LTX-2.3 generates synced audio+video in one pass; day-0 ComfyUI support. 22B parameters. Full quality needs 16-24 GB VRAM (borderline for RTX 5060 Ti 16 GB); Q4 quantised fits 12 GB. build_ltx_video likely targets LTX v1.x — should be updated to 2.3. Community MXFP8 quantisation (Swarzox, July 10) may unlock 16 GB compatibility; unverified."
-  },
-  {
-    "method": "build_hunyuan_video",
-    "category": "checkpoint",
-    "name": "HunyuanVideo 1.5 (Tencent, 8.3B, 720p, step-distilled)",
-    "source": "github",
-    "url": "https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5",
-    "release_date": "2025-11-20",
+    "url": "https://github.com/nv-tlabs/PiD",
+    "release_date": "2026-07-15",
     "risk": "low",
     "confidence": 0.82,
-    "notes": "Outside 7-day window (Nov 2025) — already-known item. HunyuanVideo 1.5 is lighter (8.3B vs original), supports 720p native output, step-distilled (8-12 inference steps), diverse styles (realistic/anime/3D). Native ComfyUI support. Fits 16 GB VRAM comfortably. Verify whether build_hunyuan_video already targets 1.5 checkpoint — if still on 1.0, this is a Tier 1 upgrade."
+    "notes": "Same PID v1.5 model as the image upscale entry but applied per-frame in build_video_upscale. Not a temporal upscaler — works like 4x-UltraSharp but diffusion-based. PiD Upscale node supports 2x/4x/6x/8x output. On Ada+/RTX-50xx an FP4/FP8 path gives additional speedup. A/B test against 4x-UltraSharp warranted — diffusion-based decoding should outperform ESRGAN on fine texture and hair. NSCLv1 non-commercial license applies."
   },
   {
-    "method": "build_seedvr2_video_upscale",
+    "method": "build_ltx_video",
     "category": "checkpoint",
-    "name": "SwiftVR (one-step causal video restoration, H-oliday/SwiftVR)",
-    "source": "github",
-    "url": "https://github.com/jungbtc/ComfyUI-SwiftVR",
-    "release_date": "2026-06-09",
-    "risk": "high",
-    "confidence": 0.22,
-    "notes": "Outside 7-day window (June 9, 2026). One-step diffusion video restoration at ~26 FPS (1080p) on RTX 5090 (32 GB VRAM). No confirmed benchmarks for 16 GB VRAM; native ComfyUI PR #14469 still open as of 2026-07-22. Monitor for GGUF/tiling variant before wiring. Potential strong complement or replacement for SeedVR2."
-  },
-  {
-    "method": "build_hunyuan_3d_mesh",
-    "category": "checkpoint",
-    "name": "TripoSplat (VAST-AI, image to 3D Gaussian Splat, MIT license)",
+    "name": "LTX-2.3-22b-distilled MXFP8 community quantisation (Swarzox)",
     "source": "huggingface",
-    "url": "https://huggingface.co/VAST-AI/TripoSplat",
-    "release_date": "2026-06-01",
-    "risk": "low",
-    "confidence": 0.70,
-    "notes": "Outside 7-day window (June 2026). Native ComfyUI support PR #14210 (kijai). Generates 3D Gaussian splats from a single image; 6.6 GB VRAM in testing. MIT license. Pairs naturally with new native Save Splat node in v0.28.0. Additive new builder build_triposplat would complement existing HunyuanDiT 3D mesh builders. Monitor for stability before wiring."
+    "url": "https://huggingface.co/Swarzox/LTX2.3-22b-distilled-video-only-MXFP8",
+    "release_date": "2026-07-10",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "Borderline window (July 10, five days before window start). Experimental MXFP8 community quantisation of LTX-2.3 22B distilled (video-only; audio stripped). Could get 44 GB BF16 footprint under 16 GB with tiling; RTX 5060 Ti supports FP8 but ComfyUI MXFP8 path unverified. If VRAM confirmed, enables build_ltx_video upgrade to 2.3 quality. Labeled experimental. Monitor for community VRAM reports."
   },
   {
     "method": "build_lama_remove",
@@ -185,5 +196,38 @@
     "risk": "low",
     "confidence": 0.75,
     "notes": "Outside 7-day window (April 2026, ComfyUI PR #13403 merged May 6). Two-pass temporal video inpainting: Pass 1 base inpaint + Pass 2 optical-flow warp for consistency. Pairs with SAM3 masks for automated object selection. Not a stills replacement for LaMa — video-specific additive builder build_void_remove would be the right approach. Monitor for VRAM data; no 16 GB benchmark found."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "JoyAI-Image-Edit 16.3B (instruction-based image editor, Apache 2.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/joyAI-labs/JoyAI-Image-Edit",
+    "release_date": "2026-07-21",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "In-window (July 21). 16.3B instruction-based image editor with day-0 ComfyUI node (ComfyUI-JoyAI-Image-Edit). Plus variant (July 17) adds multi-image cross-composition. Apache 2.0 license — no commercial friction. Different architecture from build_qwen_edit (instruction-based vs VLM-based); additive new-builder candidate (build_joyai_edit). FP8-quantizable; 16.3B FP8 ≈ 16 GB peak — borderline for RTX 5060 Ti 16 GB. Monitor for tiling/GGUF variant before wiring. URL unverified — confirm HF repo before download."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Anima aesthetic-v1.1 / CyberRealistic Anima v6.0 (Cosmos-Predict2-2B image model)",
+    "source": "huggingface",
+    "url": "",
+    "release_date": "2026-07-16",
+    "risk": "low",
+    "confidence": 0.60,
+    "notes": "In-window: Anima aesthetic-v1.1 (July 16) and CyberRealistic Anima v6.0 (July 18, community fine-tune). Both based on Cosmos-Predict2-2B — primarily a video-gen architecture adapted to still-image synthesis. At 2B parameters this does not compete with Klein 4B/9B or Flux 1 Dev for portrait/cinematic quality. Very low VRAM (~2–4 GB). Not a supersession of any current builder; additive fast/low-VRAM option only. Monitor for ComfyUI node and quality benchmarks before evaluating further. Confidence low — sub-agent report; no confirmed HF URL."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "checkpoint",
+    "name": "Qwen-Image ControlNet Union + Z-Image ControlNet Union FP8",
+    "source": "huggingface",
+    "url": "",
+    "release_date": "2026-07-17",
+    "risk": "low",
+    "confidence": 0.40,
+    "notes": "In-window: Qwen-Image ControlNet Union (July 17) and Z-Image ControlNet Union FP8 (July 21). Unified multi-condition ControlNet adapters (canny+depth+pose+normal in one pass) for Qwen-Image and Z-Image-Turbo backbones respectively. Neither has a confirmed ComfyUI node as of 2026-07-22. Low confidence — reported by image-gen sub-agent; HF URLs unverified. If confirmed, would extend build_controlnet_gen to Qwen/Z-Image paths. Monitor."
   }
 ]

--- a/_dev_docs/upgrade_research/2026-W30.json
+++ b/_dev_docs/upgrade_research/2026-W30.json
@@ -1,0 +1,189 @@
+[
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "node_pack",
+    "name": "SeedVR2 native ComfyUI nodes (v0.28.0)",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "release_date": "2026-07-15",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "ComfyUI v0.28.0 (July 15) promotes SeedVR2 to native built-in nodes. Spellcaster currently depends on numz/ComfyUI-SeedVR2_VideoUpscaler custom pack. Switching drops the external dependency with no model change. Node signatures must be audited before wiring. FP8/BlockSwap variant required on 16 GB VRAM — full FP16 wants ~24 GB."
+  },
+  {
+    "method": "build_seedv2r",
+    "category": "node_pack",
+    "name": "SeedVR2 native ComfyUI nodes (v0.28.0)",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "release_date": "2026-07-15",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Same as build_seedvr2_video_upscale — both builders share the SeedVR2 dependency. Both should be audited and migrated to native nodes together."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "node_pack",
+    "name": "Save 3D Advanced / Save Splat / Save Point Cloud (ComfyUI v0.28.0 PRs #14190, #14194)",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "release_date": "2026-07-15",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "v0.28.0 adds native GAUSSIAN type and three output nodes: Save 3D Advanced (GLB/OBJ/PLY with vertex colours/textures), Save Splat (.ply/.splat/.spz/.ksplat), Save Point Cloud. Replaces community pack nodes needed for 3D export in hunyuan_3d workflows. No model change; VRAM impact negligible. Drop-in workflow simplification."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "node_pack",
+    "name": "Save 3D Advanced / Save Splat / Save Point Cloud (ComfyUI v0.28.0 PRs #14190, #14194)",
+    "source": "github",
+    "url": "https://docs.comfy.org/changelog",
+    "release_date": "2026-07-15",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Same as build_hunyuan_3d_mesh — both 3D builders benefit from native export nodes added in v0.28.0."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "node_pack",
+    "name": "ComfyUI-BFSNodes v1.17.0 (alisson-anjos)",
+    "source": "github",
+    "url": "https://github.com/alisson-anjos/ComfyUI-BFSNodes",
+    "release_date": "2026-07-22",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Major BFSNodes update burst this week (July 17-22). July 22: new LTX Multiple Controls node merging guide/mask/identity conditioning into single node. July 20: Entity Sheet 2x2 node for HuMoSet v7 multi-view character sheets. July 17: ArcFace projector dropped; reference_face renamed to reference_image — potential BREAKING CHANGE that may affect build_klein_headswap parameter handling. Required companion node pack for BFS head-swap LoRAs (Flux-Klein / LTX backbone). No VRAM overhead from node pack itself."
+  },
+  {
+    "method": "build_upscale",
+    "category": "checkpoint",
+    "name": "NVIDIA PID v1.5 (PixelDiT pixel-diffusion upscaler)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+    "release_date": "2026-07-09",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "CVPR 2026 Best Paper Finalist. Single-stage pixel-space diffusion transformer (no VAE). PID v1.5 provides 2K->4K upscaling in under 1 second; 13 GB peak VRAM (fits 16 GB card). Works with FLUX, FLUX.2, and Qwen-Image latents via PiD Conditioning node (native ComfyUI v0.28.0). NSCLv1 license = non-commercial only — licensing must be cleared before wiring. Additive new builder build_pid_upscale; not a direct replacement for UltraSharp. Comfy-Org/PixelDiT: 198K downloads, 133 likes. ComfyUI-PiD custom node: github.com/Merserk/ComfyUI-PiD."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "checkpoint",
+    "name": "NVIDIA PID v1.5 per-frame video upscaling",
+    "source": "github",
+    "url": "https://github.com/nv-tlabs/PiD",
+    "release_date": "2026-07-15",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Same PID v1.5 model applied per-frame in build_video_upscale. Not a temporal upscaler — works like 4x-UltraSharp but diffusion-based. PiD Upscale node supports 2x/4x/6x/8x output. On Ada+/RTX-50xx an FP4/FP8 path gives additional speedup. A/B test against 4x-UltraSharp warranted. NSCLv1 non-commercial license applies."
+  },
+  {
+    "method": "build_upscale_blend",
+    "category": "checkpoint",
+    "name": "NVIDIA PID v1.5 (PixelDiT pixel-diffusion upscaler)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+    "release_date": "2026-07-09",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "PID v1.5 could be added as a third upscaler path in build_upscale_blend alongside the existing two traditional upscalers. Same NSCLv1 non-commercial licensing caveat applies."
+  },
+  {
+    "method": "build_detail_hallucinate",
+    "category": "checkpoint",
+    "name": "NVIDIA PID v1.5 (PixelDiT pixel-diffusion upscaler)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/PixelDiT",
+    "release_date": "2026-07-09",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "PID 1.5 offers a pixel-diffusion quality path for fine-detail super-resolution that may outperform the current ESRGAN+SDXL approach. Needs benchmark comparison on portrait/face detail before wiring. NSCLv1 license risk same as above."
+  },
+  {
+    "method": "build_pulid_flux",
+    "category": "lora",
+    "name": "LTX-Best-Face-ID Character Sheet v1.0 LoRA (Alissonerdx)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/LTX-Best-Face-ID",
+    "release_date": "2026-07-17",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "1.31 GB identity-preserving character-sheet LoRA for LTX-2.3 22B. Extends face-ID consistency to full-body appearance via 4-panel reference (face close-up + front/side/back body). Coordinated with BFSNodes v1.17 API change (ArcFace projector removal). Adds clothing/build consistency beyond what PuLID-Flux provides for stills. Blocked by LTX-2.3 22B VRAM: raw fp16 needs ~44 GB; NF4/Q8 quantised variants needed for 16 GB card. Monitor for GGUF/Q4 release."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "inswapper_128.fp16.onnx + VQFR_v2 + xseg community bundle (brianknight144)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/brianknight144/facerestoration",
+    "release_date": "2026-07-17",
+    "risk": "low",
+    "confidence": 0.68,
+    "notes": "Community bundle: inswapper_128.fp16.onnx (277 MB FP16 vs ~500 MB fp32 — less VRAM at swap time for build_faceswap), VQFR_v2.onnx (334 MB VQ-based face restorer, CodeFormer drop-in for build_face_restore), xseg.onnx (70 MB FaceFusion face-segment mask). Not new architectures. Author provenance unverified — validate checksums before integrating into any production workflow."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "ByteDance Seedance 2.5 (cloud API, July 16 public launch)",
+    "source": "github",
+    "url": "https://www.cined.com/bytedance-seedance-2-5-api-goes-live-30-second-single-shot-clips-50-reference-inputs-and-3d-camera-blockouts/",
+    "release_date": "2026-07-16",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "API-only (no open weights). 30-second single-shot video, 50 multimodal reference inputs, native 4K, audio-video joint generation, 3D camera blockout. No ComfyUI partner node confirmed yet. Monitor for community node — if one ships, a new build_seedance25_video builder would be warranted. No local VRAM cost."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 (Lightricks, 22B, audio-video)",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/ltx-2-open-source-audio-video-ai",
+    "release_date": "2026-03-01",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Outside 7-day window (March 2026) — already-known item. LTX-2.3 generates synced audio+video in one pass; day-0 ComfyUI support. 22B parameters. Full quality needs 16-24 GB VRAM (borderline for RTX 5060 Ti 16 GB); Q4 quantised fits 12 GB. build_ltx_video likely targets LTX v1.x — should be updated to 2.3. Community MXFP8 quantisation (Swarzox, July 10) may unlock 16 GB compatibility; unverified."
+  },
+  {
+    "method": "build_hunyuan_video",
+    "category": "checkpoint",
+    "name": "HunyuanVideo 1.5 (Tencent, 8.3B, 720p, step-distilled)",
+    "source": "github",
+    "url": "https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5",
+    "release_date": "2025-11-20",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "Outside 7-day window (Nov 2025) — already-known item. HunyuanVideo 1.5 is lighter (8.3B vs original), supports 720p native output, step-distilled (8-12 inference steps), diverse styles (realistic/anime/3D). Native ComfyUI support. Fits 16 GB VRAM comfortably. Verify whether build_hunyuan_video already targets 1.5 checkpoint — if still on 1.0, this is a Tier 1 upgrade."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "checkpoint",
+    "name": "SwiftVR (one-step causal video restoration, H-oliday/SwiftVR)",
+    "source": "github",
+    "url": "https://github.com/jungbtc/ComfyUI-SwiftVR",
+    "release_date": "2026-06-09",
+    "risk": "high",
+    "confidence": 0.22,
+    "notes": "Outside 7-day window (June 9, 2026). One-step diffusion video restoration at ~26 FPS (1080p) on RTX 5090 (32 GB VRAM). No confirmed benchmarks for 16 GB VRAM; native ComfyUI PR #14469 still open as of 2026-07-22. Monitor for GGUF/tiling variant before wiring. Potential strong complement or replacement for SeedVR2."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "TripoSplat (VAST-AI, image to 3D Gaussian Splat, MIT license)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/VAST-AI/TripoSplat",
+    "release_date": "2026-06-01",
+    "risk": "low",
+    "confidence": 0.70,
+    "notes": "Outside 7-day window (June 2026). Native ComfyUI support PR #14210 (kijai). Generates 3D Gaussian splats from a single image; 6.6 GB VRAM in testing. MIT license. Pairs naturally with new native Save Splat node in v0.28.0. Additive new builder build_triposplat would complement existing HunyuanDiT 3D mesh builders. Monitor for stability before wiring."
+  },
+  {
+    "method": "build_lama_remove",
+    "category": "checkpoint",
+    "name": "VOID (Netflix, video object inpainting + deletion)",
+    "source": "github",
+    "url": "https://github.com/Netflix/void-model",
+    "release_date": "2026-04-07",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Outside 7-day window (April 2026, ComfyUI PR #13403 merged May 6). Two-pass temporal video inpainting: Pass 1 base inpaint + Pass 2 optical-flow warp for consistency. Pairs with SAM3 masks for automated object selection. Not a stills replacement for LaMa — video-specific additive builder build_void_remove would be the right approach. Monitor for VRAM data; no 16 GB benchmark found."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W30.md
+++ b/_dev_docs/upgrade_research/2026-W30.md
@@ -1,0 +1,220 @@
+# Spellcaster daily SOTA review — 2026-07-22
+
+ISO week: `2026-W30`. Baseline: *(first run — no prior file)*.
+
+> **Audit window:** 2026-07-15 → 2026-07-22 (past 7 days).
+> **Hardware budget:** RTX 5060 Ti, 16 GB VRAM.
+> Anything requiring > 16 GB at full precision is flagged risk=high unless a quantised variant fits.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / addition (if not) | Source URL | Risk | Notes |
+|--------|-----------------|-------------|----------------------------------|-----------|------|-------|
+| `build_txt2img` | SDXL / Flux 1 Dev / Klein | ✅ Yes | — | — | low | No new open-weight T2I checkpoint released this week that outclasses current stack. FLUX.2-dev (Nov 2025) remains the open-weight ceiling; already wired via Klein builders. |
+| `build_img2img` | SDXL / Flux / Klein | ✅ Yes | — | — | low | Same as txt2img. |
+| `build_inpaint` | SDXL / Flux / Klein | ✅ Yes | — | — | low | No inpaint-specific release this week. |
+| `build_outpaint` | SDXL / Klein | ✅ Yes | — | — | low | No outpaint model this week. |
+| `build_inpaint_fooocus` | SDXL | ✅ Yes | — | — | low | Fooocus inpaint unchanged. |
+| `build_controlnet_gen` | SDXL / Flux | ✅ Yes | — | — | low | No new ControlNet checkpoints this week. |
+| `build_generate_anything` | SDXL | ✅ Yes | — | — | low | — |
+| `build_style_transfer` | SDXL | ✅ Yes | — | — | low | — |
+| `build_klein_*` (15 methods) | Klein / Flux2 4B/9B + Qwen3 CLIP | ✅ Yes | — | — | low | Klein 9B/4B still current distilled Flux2. PID 1.5 (see Tier 2) can be chained as post-processor. |
+| `build_pulid_flux` | PuLID + Flux 1 Dev | ✅ Yes | — | — | low | No PuLID update this week. |
+| `build_lumina2_txt2img` | Lumina2 | ✅ Yes | — | — | low | No Lumina update this week. |
+| `build_qwen_edit` | Qwen2.5-VL (VLM editing) | ✅ Yes | — | — | low | Note: Qwen-Image-2.0 (Feb 2026) is a *separate* image-gen model that also supports editing; not a drop-in replacement for this VLM-based pipeline. |
+| `build_iclight` | IC-Light V1 | ✅ Yes | — | — | low | IC-Light V2 (fal.ai hosted, May 2025) not a local option. No local update this week. |
+| `build_layer_blend` | Node-only | ✅ Yes | — | — | low | Node, no model. |
+| `build_magic_eraser` | SAM3 + LaMa | ✅ Yes | — | — | low | VOID (Netflix, May 2026) could replace LaMa for video; for stills, LaMa remains fine. Already-known item. |
+| `build_lama_remove` | LaMa | ✅ Yes | — | — | low | — |
+| `build_wan_video` | WAN 2.1 | ✅ Yes | — | — | low | WAN 2.2 TI2V already has a builder (`build_wan22_t2v`). No WAN 2.3 released this week. |
+| `build_wan22_t2v` | WAN 2.2 TI2V 5B | ✅ Yes | — | — | low | No WAN 2.3 this week. WAN 2.7 cloud-only (partner node, no open weights). |
+| `build_wan_flf` | WAN 2.1 FLF | ✅ Yes | — | — | low | — |
+| `build_wan_animate_video` | WAN 2.1 | ✅ Yes | — | — | low | — |
+| `build_wan_video_blockswap` | WAN 2.1 + BlockSwap | ✅ Yes | — | — | low | — |
+| `build_wan_video_blockswap_t2v` | WAN 2.2 + BlockSwap | ✅ Yes | — | — | low | — |
+| `build_ltx_video` | LTX Video (v1.x) | ⚠️ Behind | LTX-2.3 (March 2026, 22B, audio+video) | https://blog.comfy.org/p/ltx-2-open-source-audio-video-ai | medium | LTX-2.3 day-0 ComfyUI support; generates synced audio+video in one pass. 22B model needs 16–24 GB, borderline for 16 GB constraint (Q4 quantised fits on 12 GB). Already-known item (>7 days). |
+| `build_hunyuan_video` | HunyuanVideo 1.0 | ⚠️ Behind | HunyuanVideo 1.5 (Nov 2025, 8.3B, 720p native) | https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5 | low | HunyuanVideo 1.5 native ComfyUI support, 8.3B params, 720p, step-distilled variant (8–12 steps). Already-known item (>7 days). VRAM-safe. |
+| `build_mochi_video` | Mochi 1 | ✅ Yes | — | — | low | No Mochi update this week. |
+| `build_cogvideo_video` | CogVideoX | ✅ Yes | — | — | low | No CogVideo update this week. |
+| `build_framepack_video` | FramePack | ✅ Yes | — | — | low | No FramePack update this week. |
+| `build_frame_assembly` | Node-only | ✅ Yes | — | — | low | — |
+| `build_video_upscale` | 4x-UltraSharp | ⚠️ Additive | NVIDIA PID v1.5 per-frame diffusion upscaler | https://huggingface.co/Comfy-Org/PixelDiT | medium | **In-window (July 15).** PiD works per-frame (like UltraSharp, not temporal). Diffusion-based quality should outperform ESRGAN on fine detail. 13 GB peak VRAM, fits 16 GB. NSCLv1 (non-commercial). Additive option, not a replacement. |
+| `build_seedvr2_video_upscale` | SeedVR2 (custom node) | 🔄 Upgrade | SeedVR2 now **native** in ComfyUI v0.28.0 | https://docs.comfy.org/changelog | low | **In-window (July 15).** Custom node dependency can be dropped. Node signatures may differ — builder needs audit before next release. |
+| `build_video_reactor` | ReActor (video) | ✅ Yes | — | — | low | No ReActor update this week. |
+| `build_wavespeed_upscale` | WaveSpeed | ✅ Yes | — | — | low | PID 1.5 is complementary, not a replacement. |
+| `build_upscale` | Real-ESRGAN / UltraSharp | ⚠️ Additive | NVIDIA PID v1.5 (pixel diffusion upscaler) | https://huggingface.co/Comfy-Org/PixelDiT | medium | **In-window (July 15, native v0.28.0).** PID 1.5 is a diffusion-based 2K→4K upscaler; 13 GB peak VRAM, fits 16 GB. NSCLv1 (non-commercial) license. New `build_pid_upscale` builder would be additive. |
+| `build_upscale_blend` | Two upscalers blended | ⚠️ Additive | PID v1.5 as third upscaler option | https://huggingface.co/Comfy-Org/PixelDiT | medium | Same as above. |
+| `build_seedv2r` | SeedVR2 (custom node) | 🔄 Upgrade | SeedVR2 now **native** in ComfyUI v0.28.0 | https://docs.comfy.org/changelog | low | **In-window (July 15).** Mirrors `build_seedvr2_video_upscale` finding above. |
+| `build_faceswap` | ReActor + inswapper_128 | ✅ Yes | — | — | low | No ReActor or inswapper update this week. |
+| `build_faceswap_model` | ReActor | ✅ Yes | — | — | low | — |
+| `build_faceswap_mtb` | MTB face swap | ✅ Yes | — | — | low | No MTB update this week. |
+| `build_klein_headswap` | Klein / Flux2 | ⚠️ Audit needed | BFSNodes v1.17.0 API rename: `reference_face` → `reference_image` | https://github.com/alisson-anjos/ComfyUI-BFSNodes | low | **In-window (July 17–22).** BFSNodes v1.17.0 dropped ArcFace projector and renamed `reference_face` → `reference_image`. If `build_klein_headswap` addresses this parameter directly, it needs a one-line fix. New `LTX Multiple Controls` node (July 22) simplifies guide+mask+identity into one node. |
+| `build_klein_face_detail` | Klein / Flux2 | ✅ Yes | — | — | low | — |
+| `build_photobooth` | SDXL + frame reference | ✅ Yes | — | — | low | — |
+| `build_save_face_model` | ReActor | ✅ Yes | — | — | low | — |
+| `build_faceid_img2img` | IP-Adapter FaceID | ✅ Yes | — | — | low | No FaceID update this week. |
+| `build_face_restore` | CodeFormer | ✅ Yes | — | — | low | Community VQFR_v2.onnx drop-in surfaced this week (see Tier 3); unverified provenance. |
+| `build_photo_restore` | UltraSharp + CodeFormer | ✅ Yes | — | — | low | — |
+| `build_detail_hallucinate` | UltraSharp + SDXL | ⚠️ Additive | PID v1.5 as diffusion-quality alternative | https://huggingface.co/Comfy-Org/PixelDiT | medium | PID 1.5 offers a pixel-diffusion upscale path that may outperform UltraSharp on fine detail. Needs benchmarking. NSCLv1 license. |
+| `build_supir` | SUPIR + SDXL | ✅ Yes | — | — | low | No SUPIR update this week. |
+| `build_color_match` | Node-based | ✅ Yes | — | — | low | — |
+| `build_klein_color_match` | Klein | ✅ Yes | — | — | low | — |
+| `build_colorize` | Klein + DDColor | ✅ Yes | — | — | low | No DDColor update this week. |
+| `build_ddcolor` | DDColor | ✅ Yes | — | — | low | — |
+| `build_lut` | Node-only | ✅ Yes | — | — | low | — |
+| `build_rembg` | U2Net | ✅ Yes | — | — | low | — |
+| `build_rembg_birefnet` | BiRefNet | ✅ Yes | — | — | low | BiRefNet went native in ComfyUI PR #12747 (May 2026). Custom node can be dropped. Already-known. |
+| `build_rembg_v3` | RMBG-2.0 | ✅ Yes | — | — | low | No RMBG update this week. |
+| `build_sam3_segment` | SAM3 | ✅ Yes | — | — | low | No SAM update this week. |
+| `build_sam3_mask` | SAM3 | ✅ Yes | — | — | low | — |
+| `build_sam3_extract` | SAM3 | ✅ Yes | — | — | low | — |
+| `build_normal_map` | DepthPro / Marigold | ✅ Yes | — | — | low | No new normal map model this week. |
+| `build_depth_map_v3` | Depth Anything v3 | ✅ Yes | — | — | low | No DA update this week. |
+| `build_hunyuan_3d_mesh` | HunyuanDiT 3D | ✅ Yes | New native Save3D/Splat nodes available | https://docs.comfy.org/changelog | low | **In-window (July 15).** Native Save 3D Advanced / Save Splat / Save Point Cloud nodes added in v0.28.0 can replace community pack nodes for 3D export. No model change; workflow simplification only. |
+| `build_hunyuan_3d_textured` | HunyuanDiT 3D | ✅ Yes | New native Save3D/Splat nodes available | https://docs.comfy.org/changelog | low | Same as above. |
+| `build_seedv2r` | SeedVR2 | 🔄 Upgrade | Native in ComfyUI v0.28.0 | https://docs.comfy.org/changelog | low | Already covered above. |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+### 1. SeedVR2: Drop custom-node dependency (`build_seedvr2_video_upscale` and `build_seedv2r`)
+
+**Release:** ComfyUI v0.28.0, 2026-07-15
+**Source:** https://docs.comfy.org/changelog
+
+ComfyUI v0.28.0 promotes SeedVR2 to a first-class native node set covering both still-image and video upscaling. Spellcaster's two SeedVR2 builders currently rely on the `numz/ComfyUI-SeedVR2_VideoUpscaler` custom node pack. Switching to native nodes removes a dependency and guarantees a stable API.
+
+**Action:** Audit the new native node class signatures against the current `build_seedvr2_video_upscale` and `build_seedv2r` workflows. Update node references to native equivalents. This requires only a local node-graph change, not a model download.
+
+**VRAM note:** FP16 full quality wants ~24 GB; FP8 / BlockSwap fits 12–16 GB. The RTX 5060 Ti 16 GB sits at the boundary. GGUF Q4 is confirmed to work at 6–8 GB if the FP8 variant OOMs.
+
+---
+
+### 2. Hunyuan 3D: Use native Save3D / Save Splat / Save Point Cloud nodes (`build_hunyuan_3d_mesh`, `build_hunyuan_3d_textured`)
+
+**Release:** ComfyUI v0.28.0, 2026-07-15 (PRs #14190, #14194)
+**Source:** https://docs.comfy.org/changelog
+
+v0.28.0 adds three output nodes (Save 3D Advanced, Save Splat, Save Point Cloud) that replace community pack nodes previously needed to export GLB/OBJ/PLY and Gaussian splat files. No model change, no VRAM impact — purely a workflow simplification.
+
+**Action:** Replace third-party 3D export nodes in `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured` with the new native nodes.
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install or model download)
+
+### 3. BFSNodes v1.17.0 — `build_klein_headswap` parameter audit + new Entity Sheet capability
+
+**Released:** 2026-07-17 → 2026-07-22 (active development burst this week)
+**Source:** https://github.com/alisson-anjos/ComfyUI-BFSNodes
+**VRAM:** No node-level overhead; runtime cost is the underlying LTX/Klein model
+
+BFSNodes is the required companion pack for head-swap LoRAs on the Flux-Klein / LTX-2.3 backbone. This week's updates directly affect `build_klein_headswap`:
+
+- **July 22 (today):** `LTX Multiple Controls` node — merges guide, mask, and identity conditioning into a single node, replacing a 3-node chain.
+- **July 20:** `Entity Sheet 2x2` node — generates 4-panel multi-view character sheets following the HuMoSet v7 semantic-grid convention. Enables a new `build_entity_sheet` type builder.
+- **July 17:** ArcFace projector dropped from identity pipeline; `reference_face` parameter renamed to `reference_image`; stacked dual-reference support added. **Potential breaking change**: `build_klein_headswap` may need a one-line parameter-name update.
+
+**Action:** Audit `build_klein_headswap` against the July 17 API rename. Update `reference_face → reference_image` if needed.
+
+---
+
+### 4. NVIDIA PixelDiT / PID v1.5 → new `build_pid_upscale`
+
+**Released:** PID v1.5 checkpoints 2026-07-09; native ComfyUI support v0.28.0, 2026-07-15
+**Source:** https://huggingface.co/Comfy-Org/PixelDiT | https://github.com/nv-tlabs/PiD | https://github.com/Merserk/ComfyUI-PiD
+**VRAM:** 13 GB peak (fits RTX 5060 Ti 16 GB)
+**License:** NSCLv1 (non-commercial only)
+
+NVIDIA's PixelDiT is a CVPR 2026 Best Paper Finalist. It eliminates the VAE entirely: a dual-level diffusion transformer generates directly in pixel space (global DiT for semantics + pixel DiT for texture). PID v1.5 ships a 2K→4K upscaling mode that plugs into FLUX, FLUX.2, and Qwen-Image latents via "PiD Conditioning" nodes.
+
+At 13 GB peak, it fits the 16 GB budget with ~3 GB headroom. The NSCLv1 license prohibits commercial use — this must be cleared against Spellcaster's licensing model before wiring. If cleared, a new `build_pid_upscale` builder would offer a diffusion-quality alternative to `build_upscale` / `build_detail_hallucinate`, and the existing `build_upscale_blend` could add PID as a third blend path. PID also works per-frame in `build_video_upscale`.
+
+Comfy-Org hosts weights at `Comfy-Org/PixelDiT` (198 K downloads, 133 likes as of 2026-07-22).
+
+**Action (if license cleared):** Download `Comfy-Org/PixelDiT`; add `build_pid_upscale(image_filename, target_res="4K")` method using native PiD Conditioning nodes; expose in GIMP plugin upscale dialog as an option.
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+### 5. LTX-Best-Face-ID Character Sheet v1.0 LoRA (Alissonerdx, July 17)
+
+**Released:** 2026-07-17
+**Source:** https://huggingface.co/Alissonerdx/LTX-Best-Face-ID
+**VRAM:** LTX-2.3 22B base — needs NF4/Q8 quantisation to fit 16 GB
+
+Identity-preserving character-sheet LoRA for LTX-2.3 video. The v1.0 checkpoint (1.31 GB) extends face-ID consistency to full-body appearance (clothing, build) via a 4-panel reference image (face close-up + front/side/back body). Coordinated release with BFSNodes v1.17 API changes. **Blocked by LTX-2.3 22B VRAM constraint** — monitor for Q4/GGUF variant.
+
+### 6. ByteDance Seedance 2.5 — 30-second single-shot video API (July 16)
+
+**Released:** 2026-07-16 (public API)
+**Source:** https://www.cined.com/bytedance-seedance-2-5-api-goes-live-30-second-single-shot-clips-50-reference-inputs-and-3d-camera-blockouts/
+**VRAM:** N/A (cloud API only; no open weights)
+
+ByteE Dance opened public API access (via BytePlus) on July 16. Continuous 30-second single-shot clips, up to 50 multimodal reference inputs, native 4K, audio-video joint generation, 3D camera blockout. No ComfyUI partner node yet. Monitor for a community node — if one ships, a new `build_seedance25_video` builder would be warranted.
+
+### 7. inswapper_128.fp16.onnx + VQFR_v2 community bundle (July 17)
+
+**Released:** 2026-07-17
+**Source:** https://huggingface.co/brianknight144/facerestoration
+**VRAM:** Reduced vs fp32 (277 MB vs ~500 MB at swap time)
+
+Community bundle: `inswapper_128.fp16.onnx` (FP16 variant, less VRAM at swap time), `VQFR_v2.onnx` (VQ-based face restorer, drop-in CodeFormer alternative), `xseg.onnx` (FaceFusion face mask). Not new architectures. **Author provenance unverified — validate checksums before integrating.**
+
+### 8. LTX-2.3 (Lightricks, March 2026) — Audio + Video in one pass
+
+**Released:** March 2026
+**Source:** https://blog.comfy.org/p/ltx-2-open-source-audio-video-ai
+**VRAM:** 16–24 GB recommended; Q4 quantised fits 12 GB
+**Status:** Outside 7-day window; already known to community.
+
+LTX-2.3 is the only open-weight model generating synced audio+video in one pass. 22B parameters. VRAM borderline for 16 GB — a community MXFP8 quantisation (Swarzox, July 10) may unlock it; unverified on RTX 50xx. Monitor for quantisation improvements.
+
+### 9. SwiftVR — One-step real-time video restoration (June 2026)
+
+**Released:** 2026-06-09
+**Source:** https://github.com/jungbtc/ComfyUI-SwiftVR | https://huggingface.co/H-oliday/SwiftVR
+**VRAM:** ~24 GB at 1080p on RTX 5090; no 16 GB benchmarks confirmed
+
+Causal chunk-wise one-step diffusion model for video restoration. No tiling or GGUF variant confirmed for 16 GB cards. Monitor for quantised release.
+
+### 10. HunyuanVideo 1.5 (Tencent, Nov 2025)
+
+**Source:** https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5
+**Status:** Outside 7-day window; already known. Verify `build_hunyuan_video` targets the 1.5 checkpoint — if still on 1.0, this is a Tier 1 upgrade.
+
+### 11. TripoSplat (VAST-AI, June 2026) — Image to 3D Gaussian Splat
+
+**Source:** https://github.com/VAST-AI-Research/TripoSplat | https://huggingface.co/VAST-AI/TripoSplat
+**VRAM:** 6.6 GB (MIT license)
+**Status:** Outside 7-day window. Native ComfyUI PR #14210. Pairs naturally with new native Save Splat node in v0.28.0. Additive `build_triposplat` builder is feasible and VRAM-safe; monitor for stability.
+
+### 12. VOID (Netflix, May 2026) — Video Object Inpainting & Deletion
+
+**Source:** https://github.com/Netflix/void-model | PR #13403
+**Status:** Outside 7-day window. Native ComfyUI via PR #13403. Two-pass temporal consistency. Relevant to `build_lama_remove` and `build_magic_eraser` for video use cases.
+
+---
+
+## No-finds (verified)
+
+The following families were explicitly searched for the 2026-07-15 → 2026-07-22 window and returned no significant new checkpoints, node packs, or architecture changes:
+
+- **Image-gen / ControlNet:** No new SDXL, Flux, or Klein checkpoint this week. No new ControlNet adapters.
+- **Video-gen (WAN, Mochi, CogVideo, FramePack):** No successors or substantial in-window updates. WAN 2.7 is cloud-only (no open weights).
+- **Face swap / restoration:** No new ReActor, MTB, CodeFormer, PuLID, or FaceID architecture this week.
+- **Background removal / segmentation:** No BiRefNet, RMBG, or SAM update this week.
+- **Depth / normal map:** No Depth Anything, Marigold, or equivalent update this week.
+- **Colorization:** No DDColor update this week.
+- **IC-Light / relighting:** No local model update this week.
+- **SUPIR:** No update this week.
+- **LaMa / Magic Eraser:** No update this week.
+
+---
+
+*Report generated 2026-07-22 by automated daily SOTA review agent.*
+*Local nightly export (`tools/export_comfyui_workflows.py`) runs at 03:30 and refreshes ComfyUI workflow snapshots automatically — no manual action needed for snapshot updates.*

--- a/_dev_docs/upgrade_research/2026-W30.md
+++ b/_dev_docs/upgrade_research/2026-W30.md
@@ -17,19 +17,19 @@ ISO week: `2026-W30`. Baseline: *(first run — no prior file)*.
 | `build_inpaint` | SDXL / Flux / Klein | ✅ Yes | — | — | low | No inpaint-specific release this week. |
 | `build_outpaint` | SDXL / Klein | ✅ Yes | — | — | low | No outpaint model this week. |
 | `build_inpaint_fooocus` | SDXL | ✅ Yes | — | — | low | Fooocus inpaint unchanged. |
-| `build_controlnet_gen` | SDXL / Flux | ✅ Yes | — | — | low | No new ControlNet checkpoints this week. |
+| `build_controlnet_gen` | SDXL / Flux | ⚠️ Monitor | Qwen-Image ControlNet Union (July 17) + Z-Image ControlNet Union FP8 (July 21) | — | low | Both arrived in-window; low confidence — neither has a confirmed ComfyUI node as of 2026-07-22. See Tier 3. |
 | `build_generate_anything` | SDXL | ✅ Yes | — | — | low | — |
 | `build_style_transfer` | SDXL | ✅ Yes | — | — | low | — |
 | `build_klein_*` (15 methods) | Klein / Flux2 4B/9B + Qwen3 CLIP | ✅ Yes | — | — | low | Klein 9B/4B still current distilled Flux2. PID 1.5 (see Tier 2) can be chained as post-processor. |
 | `build_pulid_flux` | PuLID + Flux 1 Dev | ✅ Yes | — | — | low | No PuLID update this week. |
 | `build_lumina2_txt2img` | Lumina2 | ✅ Yes | — | — | low | No Lumina update this week. |
-| `build_qwen_edit` | Qwen2.5-VL (VLM editing) | ✅ Yes | — | — | low | Note: Qwen-Image-2.0 (Feb 2026) is a *separate* image-gen model that also supports editing; not a drop-in replacement for this VLM-based pipeline. |
+| `build_qwen_edit` | Qwen2.5-VL (VLM editing) | ✅ Yes | JoyAI-Image-Edit 16.3B additive option (July 21, Apache 2.0) | — | low | JoyAI-Image-Edit 16.3B instruction editor landed July 21 with a day-0 ComfyUI node. Different architecture (instruction-based vs VLM path); additive new-builder candidate. FP8-quantizable; borderline on 16 GB VRAM. See Tier 3. |
 | `build_iclight` | IC-Light V1 | ✅ Yes | — | — | low | IC-Light V2 (fal.ai hosted, May 2025) not a local option. No local update this week. |
 | `build_layer_blend` | Node-only | ✅ Yes | — | — | low | Node, no model. |
 | `build_magic_eraser` | SAM3 + LaMa | ✅ Yes | — | — | low | VOID (Netflix, May 2026) could replace LaMa for video; for stills, LaMa remains fine. Already-known item. |
 | `build_lama_remove` | LaMa | ✅ Yes | — | — | low | — |
 | `build_wan_video` | WAN 2.1 | ✅ Yes | — | — | low | WAN 2.2 TI2V already has a builder (`build_wan22_t2v`). No WAN 2.3 released this week. |
-| `build_wan22_t2v` | WAN 2.2 TI2V 5B | ✅ Yes | — | — | low | No WAN 2.3 this week. WAN 2.7 cloud-only (partner node, no open weights). |
+| `build_wan22_t2v` | WAN 2.2 TI2V 5B | ✅ Yes | — | — | low | No WAN 2.3 this week. |
 | `build_wan_flf` | WAN 2.1 FLF | ✅ Yes | — | — | low | — |
 | `build_wan_animate_video` | WAN 2.1 | ✅ Yes | — | — | low | — |
 | `build_wan_video_blockswap` | WAN 2.1 + BlockSwap | ✅ Yes | — | — | low | — |
@@ -55,7 +55,7 @@ ISO week: `2026-W30`. Baseline: *(first run — no prior file)*.
 | `build_photobooth` | SDXL + frame reference | ✅ Yes | — | — | low | — |
 | `build_save_face_model` | ReActor | ✅ Yes | — | — | low | — |
 | `build_faceid_img2img` | IP-Adapter FaceID | ✅ Yes | — | — | low | No FaceID update this week. |
-| `build_face_restore` | CodeFormer | ✅ Yes | — | — | low | Community VQFR_v2.onnx drop-in surfaced this week (see Tier 3); unverified provenance. |
+| `build_face_restore` | CodeFormer | ✅ Yes | — | — | low | PMRF (2024 HF model) is a monitored alternative; no new release this week. |
 | `build_photo_restore` | UltraSharp + CodeFormer | ✅ Yes | — | — | low | — |
 | `build_detail_hallucinate` | UltraSharp + SDXL | ⚠️ Additive | PID v1.5 as diffusion-quality alternative | https://huggingface.co/Comfy-Org/PixelDiT | medium | PID 1.5 offers a pixel-diffusion upscale path that may outperform UltraSharp on fine detail. Needs benchmarking. NSCLv1 license. |
 | `build_supir` | SUPIR + SDXL | ✅ Yes | — | — | low | No SUPIR update this week. |
@@ -80,7 +80,7 @@ ISO week: `2026-W30`. Baseline: *(first run — no prior file)*.
 
 ## Tier 1 — Drop-in supersessions (ship soon)
 
-### 1. SeedVR2: Drop custom-node dependency (`build_seedvr2_video_upscale` and `build_seedv2r`)
+### 1. SeedVR2: Drop custom-node dependency (both `build_seedvr2_video_upscale` and `build_seedv2r`)
 
 **Release:** ComfyUI v0.28.0, 2026-07-15
 **Source:** https://docs.comfy.org/changelog
@@ -106,7 +106,7 @@ v0.28.0 adds three output nodes (Save 3D Advanced, Save Splat, Save Point Cloud)
 
 ## Tier 2 — Additive new builders (needs node-pack install or model download)
 
-### 3. BFSNodes v1.17.0 — `build_klein_headswap` parameter audit + new Entity Sheet capability
+### 3. ComfyUI-BFSNodes v1.17.0 — LTX Multiple Controls + Entity Sheet 2x2
 
 **Released:** 2026-07-17 → 2026-07-22 (active development burst this week)
 **Source:** https://github.com/alisson-anjos/ComfyUI-BFSNodes
@@ -116,7 +116,7 @@ BFSNodes is the required companion pack for head-swap LoRAs on the Flux-Klein / 
 
 - **July 22 (today):** `LTX Multiple Controls` node — merges guide, mask, and identity conditioning into a single node, replacing a 3-node chain.
 - **July 20:** `Entity Sheet 2x2` node — generates 4-panel multi-view character sheets following the HuMoSet v7 semantic-grid convention. Enables a new `build_entity_sheet` type builder.
-- **July 17:** ArcFace projector dropped from identity pipeline; `reference_face` parameter renamed to `reference_image`; stacked dual-reference support added. **Potential breaking change**: `build_klein_headswap` may need a one-line parameter-name update.
+- **July 17:** ArcFace projector dropped from identity pipeline; `reference_face` parameter renamed to `reference_image`; stacked dual-reference support added. **Breaking change**: `build_klein_headswap` may need parameter-name update if it addresses `reference_face` directly.
 
 **Action:** Audit `build_klein_headswap` against the July 17 API rename. Update `reference_face → reference_image` if needed.
 
@@ -131,7 +131,7 @@ BFSNodes is the required companion pack for head-swap LoRAs on the Flux-Klein / 
 
 NVIDIA's PixelDiT is a CVPR 2026 Best Paper Finalist. It eliminates the VAE entirely: a dual-level diffusion transformer generates directly in pixel space (global DiT for semantics + pixel DiT for texture). PID v1.5 ships a 2K→4K upscaling mode that plugs into FLUX, FLUX.2, and Qwen-Image latents via "PiD Conditioning" nodes.
 
-At 13 GB peak, it fits the 16 GB budget with ~3 GB headroom. The NSCLv1 license prohibits commercial use — this must be cleared against Spellcaster's licensing model before wiring. If cleared, a new `build_pid_upscale` builder would offer a diffusion-quality alternative to `build_upscale` / `build_detail_hallucinate`, and the existing `build_upscale_blend` could add PID as a third blend path. PID also works per-frame in `build_video_upscale`.
+At 13 GB peak, it fits the 16 GB budget with ~3 GB headroom. The NSCLv1 license prohibits commercial use — this must be cleared against Spellcaster's licensing model before wiring. If cleared, a new `build_pid_upscale` builder would offer a diffusion-quality alternative to `build_upscale` / `build_detail_hallucinate`, and the existing `build_upscale_blend` could add PID as a third blend path.
 
 Comfy-Org hosts weights at `Comfy-Org/PixelDiT` (198 K downloads, 133 likes as of 2026-07-22).
 
@@ -141,62 +141,99 @@ Comfy-Org hosts weights at `Comfy-Org/PixelDiT` (198 K downloads, 133 likes as o
 
 ## Tier 3 — Monitor / not wire-ready
 
-### 5. LTX-Best-Face-ID Character Sheet v1.0 LoRA (Alissonerdx, July 17)
+### 5. LTX-Best-Face-ID Character Sheet v1.0 LoRA (Alissonerdx)
 
 **Released:** 2026-07-17
 **Source:** https://huggingface.co/Alissonerdx/LTX-Best-Face-ID
 **VRAM:** LTX-2.3 22B base — needs NF4/Q8 quantisation to fit 16 GB
 
-Identity-preserving character-sheet LoRA for LTX-2.3 video. The v1.0 checkpoint (1.31 GB) extends face-ID consistency to full-body appearance (clothing, build) via a 4-panel reference image (face close-up + front/side/back body). Coordinated release with BFSNodes v1.17 API changes. **Blocked by LTX-2.3 22B VRAM constraint** — monitor for Q4/GGUF variant.
+Identity-preserving character-sheet LoRA for LTX-2.3 video. The v1.0 checkpoint (1.31 GB) extends face-ID consistency to full-body appearance (clothing, build) via a 4-panel reference image (face close-up + front/side/back body). Coordinated release with BFSNodes v1.17 API changes (ArcFace projector removal). Potential to enhance `build_pulid_flux`-style identity consistency in video output. **Blocked by LTX-2.3 22B VRAM constraint** — monitor for Q4/GGUF variant.
 
-### 6. ByteDance Seedance 2.5 — 30-second single-shot video API (July 16)
+### 6. ByteDance Seedance 2.5 — 30-second single-shot video API
 
 **Released:** 2026-07-16 (public API)
 **Source:** https://www.cined.com/bytedance-seedance-2-5-api-goes-live-30-second-single-shot-clips-50-reference-inputs-and-3d-camera-blockouts/
 **VRAM:** N/A (cloud API only; no open weights)
 
-ByteE Dance opened public API access (via BytePlus) on July 16. Continuous 30-second single-shot clips, up to 50 multimodal reference inputs, native 4K, audio-video joint generation, 3D camera blockout. No ComfyUI partner node yet. Monitor for a community node — if one ships, a new `build_seedance25_video` builder would be warranted.
+ByteDance opened public API access (via BytePlus) on July 16. Key capabilities: continuous 30-second single-shot clips, up to 50 multimodal reference inputs, native 4K, audio-video joint generation, 3D camera blockout. No ComfyUI partner node yet confirmed (Seedance 2.0 node exists). Monitor for a ComfyUI node — if one ships, a new `build_seedance25_video` builder would be warranted. Not directly wirable now.
 
-### 7. inswapper_128.fp16.onnx + VQFR_v2 community bundle (July 17)
+### 7. inswapper_128.fp16.onnx community bundle (brianknight144)
 
 **Released:** 2026-07-17
 **Source:** https://huggingface.co/brianknight144/facerestoration
 **VRAM:** Reduced vs fp32 (277 MB vs ~500 MB at swap time)
 
-Community bundle: `inswapper_128.fp16.onnx` (FP16 variant, less VRAM at swap time), `VQFR_v2.onnx` (VQ-based face restorer, drop-in CodeFormer alternative), `xseg.onnx` (FaceFusion face mask). Not new architectures. **Author provenance unverified — validate checksums before integrating.**
+Community repo bundling three ONNX models: `inswapper_128.fp16.onnx` (FP16 variant of ReActor's model — lower VRAM at swap time), `VQFR_v2.onnx` (VQ-based face restorer, drop-in alternative to CodeFormer for `build_face_restore`), and `xseg.onnx` (FaceFusion face-segment mask). Not new architectures, but the FP16 inswapper could reduce VRAM spikes in `build_faceswap`. **Author provenance unverified — validate checksums before integrating.** Hold for community trust assessment.
 
-### 8. LTX-2.3 (Lightricks, March 2026) — Audio + Video in one pass
+### 8. LTX-2.3 MXFP8 community quantisation (Swarzox, borderline window)
 
-**Released:** March 2026
+**Released:** 2026-07-10 (five days before window)
+**Source:** https://huggingface.co/Swarzox/LTX2.3-22b-distilled-video-only-MXFP8
+**VRAM:** Potentially under 16 GB with tiling (unverified)
+
+Experimental MXFP8 quantisation of LTX-2.3 22B distilled (video-only; audio weights stripped). MXFP8 (microscaling FP8) could get the 44 GB BF16 footprint under 16 GB. RTX 5060 Ti supports FP8 compute but ComfyUI diffusers MXFP8 path is unverified. If confirmed to fit, this unlocks `build_ltx_video` upgrade to 2.3 quality without hardware change. Monitor for VRAM confirmation reports.
+
+### 9. LTX-2.3 (Lightricks) — Audio + Video in one pass
+
+**Released:** March 2026 (day-0 ComfyUI support)
 **Source:** https://blog.comfy.org/p/ltx-2-open-source-audio-video-ai
 **VRAM:** 16–24 GB recommended; Q4 quantised fits 12 GB
-**Status:** Outside 7-day window; already known to community.
+**Status:** Outside 7-day window; **already known to community** but not yet wired in Spellcaster.
 
-LTX-2.3 is the only open-weight model generating synced audio+video in one pass. 22B parameters. VRAM borderline for 16 GB — a community MXFP8 quantisation (Swarzox, July 10) may unlock it; unverified on RTX 50xx. Monitor for quantisation improvements.
+LTX-2.3 is the only open-weight model generating synced audio+video in one pass. 22B parameters. The borderline VRAM situation (full quality exceeds 16 GB) makes this a medium-risk wiring until GGUF/FP8 variants stabilise. Monitor for quantisation improvements.
 
-### 9. SwiftVR — One-step real-time video restoration (June 2026)
+### 10. SwiftVR — One-step real-time video restoration
 
-**Released:** 2026-06-09
+**Released:** 2026-06-09 (ComfyUI custom node mid-June)
 **Source:** https://github.com/jungbtc/ComfyUI-SwiftVR | https://huggingface.co/H-oliday/SwiftVR
 **VRAM:** ~24 GB at 1080p on RTX 5090; no 16 GB benchmarks confirmed
+**Status:** Outside 7-day window; **high VRAM risk** for RTX 5060 Ti 16 GB.
 
-Causal chunk-wise one-step diffusion model for video restoration. No tiling or GGUF variant confirmed for 16 GB cards. Monitor for quantised release.
+Causal chunk-wise one-step diffusion model for video restoration at ~26 FPS (1080p, RTX 5090). No tiling or GGUF variant confirmed for 16 GB cards. Monitor for quantised release before wiring as `build_seedvr2_video_upscale` companion/replacement.
 
-### 10. HunyuanVideo 1.5 (Tencent, Nov 2025)
+### 11. HunyuanVideo 1.5 (Tencent, Nov 2025)
 
 **Source:** https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5
-**Status:** Outside 7-day window; already known. Verify `build_hunyuan_video` targets the 1.5 checkpoint — if still on 1.0, this is a Tier 1 upgrade.
+**VRAM:** 8–16 GB (8.3B, step-distilled 8–12 steps)
+**Status:** Outside 7-day window; **already known**. The existing `build_hunyuan_video` should be audited to confirm it targets the 1.5 checkpoint; if still on 1.0, this is a Tier 1 upgrade.
 
-### 11. TripoSplat (VAST-AI, June 2026) — Image to 3D Gaussian Splat
+### 12. TripoSplat (VAST-AI, June 2026) — Image to 3D Gaussian Splat
 
 **Source:** https://github.com/VAST-AI-Research/TripoSplat | https://huggingface.co/VAST-AI/TripoSplat
-**VRAM:** 6.6 GB (MIT license)
-**Status:** Outside 7-day window. Native ComfyUI PR #14210. Pairs naturally with new native Save Splat node in v0.28.0. Additive `build_triposplat` builder is feasible and VRAM-safe; monitor for stability.
+**VRAM:** 6.6 GB in testing (MIT license)
+**Status:** Outside 7-day window. Native ComfyUI support (PR #14210, kijai). ComfyUI v0.28.0 added Save Splat nodes which pair naturally with TripoSplat. An additive `build_triposplat` builder is feasible and VRAM-safe; monitor for stability.
 
-### 12. VOID (Netflix, May 2026) — Video Object Inpainting & Deletion
+### 13. VOID (Netflix, May 2026) — Video Object Inpainting & Deletion
 
 **Source:** https://github.com/Netflix/void-model | PR #13403
-**Status:** Outside 7-day window. Native ComfyUI via PR #13403. Two-pass temporal consistency. Relevant to `build_lama_remove` and `build_magic_eraser` for video use cases.
+**Status:** Outside 7-day window. Native ComfyUI via PR #13403. Two-pass temporal consistency (Pass 1: base inpaint; Pass 2: optical-flow warp). Relevant to `build_lama_remove` and `build_magic_eraser` — VOID would be a video-specific addition, not a stills replacement.
+
+### 14. JoyAI-Image-Edit 16.3B — Instruction-based image editor (in-window)
+
+**Released:** 2026-07-21 (base + ComfyUI node); JoyAI-Image-Edit-Plus multi-image variant 2026-07-17
+**License:** Apache 2.0
+**VRAM:** 16.3B model; FP8 ≈ 16 GB peak — borderline on RTX 5060 Ti 16 GB
+**Confidence:** 0.75 (image-gen sub-agent survey; URL unverified)
+
+JoyAI-Image-Edit is a 16.3B text-instruction image-editing model with a day-0 ComfyUI node pack (ComfyUI-JoyAI-Image-Edit). The Plus variant (July 17) adds multi-image cross-composition (blend multiple reference images coherently). Apache 2.0 license removes all licensing friction. The architecture is instruction-based rather than VLM-based, making it an additive complement to `build_qwen_edit` rather than a direct replacement. At FP8 the model sits at ~16 GB peak, leaving no headroom on a 16 GB card — monitor for GGUF/tiling variant or per-tile inference support before wiring.
+
+**Action:** Verify ComfyUI node repository and confirm VRAM footprint with tiling before creating a `build_joyai_edit` builder.
+
+### 15. Anima aesthetic-v1.1 / CyberRealistic Anima v6.0 — Cosmos-Predict2-2B image model
+
+**Released:** Anima aesthetic-v1.1: 2026-07-16; CyberRealistic Anima v6.0: 2026-07-18
+**License:** Unknown
+**VRAM:** ~2–4 GB (2B base model)
+**Confidence:** 0.60 (image-gen sub-agent survey; new architecture)
+
+Anima aesthetic-v1.1 is based on Cosmos-Predict2-2B (NVIDIA, primarily video-gen but adapted to still-image synthesis). CyberRealistic Anima v6.0 is a community aesthetic fine-tune on the same base. At 2B parameters this is far smaller than Klein 4B/9B or Flux 1 Dev — overall quality ceiling is not expected to compete with the current Spellcaster stack for portrait/cinematic work. Relevant as a fast, very low-VRAM option only. Does not supersede any current builder; monitor for a community ComfyUI node and quality benchmarks before evaluating further.
+
+### 16. Qwen-Image ControlNet Union + Z-Image ControlNet Union FP8 (low confidence)
+
+**Released:** Qwen-Image ControlNet Union: 2026-07-17; Z-Image ControlNet Union FP8: 2026-07-21
+**Confidence:** 0.40 (image-gen sub-agent survey; no confirmed ComfyUI node as of 2026-07-22)
+
+Both arrived in-window but confidence is low — no confirmed ComfyUI node or HuggingFace repo found as of today. A Qwen-Image ControlNet Union adapter would allow unified multi-condition control (canny + depth + pose + normal in one pass) on the Qwen-Image backbone and could extend `build_controlnet_gen`. Z-Image ControlNet Union FP8 would be the same for Z-Image-Turbo builders. Monitor for confirmed releases and ComfyUI integration before acting.
 
 ---
 
@@ -204,15 +241,15 @@ Causal chunk-wise one-step diffusion model for video restoration. No tiling or G
 
 The following families were explicitly searched for the 2026-07-15 → 2026-07-22 window and returned no significant new checkpoints, node packs, or architecture changes:
 
-- **Image-gen / ControlNet:** No new SDXL, Flux, or Klein checkpoint this week. No new ControlNet adapters.
-- **Video-gen (WAN, Mochi, CogVideo, FramePack):** No successors or substantial in-window updates. WAN 2.7 is cloud-only (no open weights).
-- **Face swap / restoration:** No new ReActor, MTB, CodeFormer, PuLID, or FaceID architecture this week.
-- **Background removal / segmentation:** No BiRefNet, RMBG, or SAM update this week.
-- **Depth / normal map:** No Depth Anything, Marigold, or equivalent update this week.
-- **Colorization:** No DDColor update this week.
-- **IC-Light / relighting:** No local model update this week.
-- **SUPIR:** No update this week.
-- **LaMa / Magic Eraser:** No update this week.
+- **Image-gen:** No new SDXL, Flux, or Klein checkpoint superseding the current stack. Anima v1.1 (Cosmos-Predict2-2B) is new but too small to compete; JoyAI-Image-Edit 16.3B is additive (see Tier 3). ControlNet Union adapters reported (Qwen-Image + Z-Image FP8) but confidence is low — no confirmed ComfyUI nodes as of 2026-07-22 (see Tier 3).
+- **Video-gen (WAN, Mochi, CogVideo, FramePack):** No successors or substantial updates in window.
+- **Face swap / restoration:** No new ReActor, MTB, CodeFormer, PuLID, or FaceID release in window.
+- **Background removal / segmentation:** No BiRefNet, RMBG, or SAM update in window.
+- **Depth / normal map:** No Depth Anything, Marigold, or equivalent update in window.
+- **Colorization:** No DDColor update in window.
+- **IC-Light / relighting:** No local model update in window.
+- **SUPIR:** No update in window.
+- **LaMa / Magic Eraser:** No update in window.
 
 ---
 


### PR DESCRIPTION
## 2026-W30 daily SOTA review — 2026-07-22

Audit window: **2026-07-15 → 2026-07-22**. Hardware budget: RTX 5060 Ti 16 GB VRAM.
First automated run — no prior baseline file.

---

### Summary counts

| Tier | Count | Description |
|------|-------|-------------|
| Tier 1 — ship soon | **2** | Drop-in supersessions with low risk |
| Tier 2 — new builders | **2** | Additive builders / audit-required changes |
| Tier 3 — monitor | **12** | Not wire-ready; watch for VRAM / node / license blockers |
| No-finds (verified) | **9 families** | Explicitly searched; nothing significant in window |

---

### Tier 1 — Ship soon

| # | Builder(s) | What changed | Action |
|---|-----------|-------------|--------|
| 1 | `build_seedvr2_video_upscale`, `build_seedv2r` | SeedVR2 promoted to **native nodes** in ComfyUI v0.28.0 (2026-07-15) — drop `numz/ComfyUI-SeedVR2_VideoUpscaler` dependency | Audit native node class signatures; update builder node references |
| 2 | `build_hunyuan_3d_mesh`, `build_hunyuan_3d_textured` | **Save 3D Advanced / Save Splat / Save Point Cloud** added natively in v0.28.0 (PRs #14190, #14194) — replaces community pack 3D export nodes | Swap community pack nodes for native equivalents; no model download needed |

---

### Tier 2 — Additive / audit required

| # | Builder(s) | What | Risk | Blocker |
|---|-----------|------|------|---------|
| 3 | `build_klein_headswap` | **BFSNodes v1.17.0** (2026-07-17–22): `reference_face` → `reference_image` rename (breaking); new `LTX Multiple Controls` node; new `Entity Sheet 2x2` node | low | One-line parameter audit; potential breaking change if builder addresses param directly |
| 4 | `build_upscale`, `build_upscale_blend`, `build_detail_hallucinate`, `build_video_upscale` | **NVIDIA PixelDiT PID v1.5** (2026-07-15, CVPR 2026 Best Paper Finalist): diffusion-based 2K→4K; 13 GB peak VRAM (fits 16 GB); new `build_pid_upscale` builder | medium | **NSCLv1 non-commercial license** — must be cleared before wiring |

---

### Tier 3 — Monitor (selected highlights)

- **JoyAI-Image-Edit 16.3B** (2026-07-21, Apache 2.0, day-0 ComfyUI node) — additive `build_joyai_edit` candidate; VRAM borderline at FP8 16 GB; verify repo + tiling before wiring
- **LTX-Best-Face-ID LoRA v1.0** (2026-07-17) — identity+body consistency for LTX-2.3 video; blocked by 22B VRAM (monitor for Q4/GGUF)
- **Seedance 2.5 API** (2026-07-16) — 30-second single-shot 4K video; no ComfyUI node yet; monitor
- **inswapper_128.fp16.onnx bundle** (2026-07-17) — FP16 inswapper + VQFR_v2; provenance unverified — validate checksums first
- **LTX-2.3 22B** (March 2026, already known) + MXFP8 community quant (2026-07-10) — borderline VRAM; track quantisation progress
- **HunyuanVideo 1.5** (Nov 2025, already known) — audit whether `build_hunyuan_video` already targets 1.5; if not, Tier 1 upgrade
- **TripoSplat** (June 2026, MIT, 6.6 GB VRAM) — pairs with new native Save Splat node; monitor for stability
- **SwiftVR** (June 2026) — 1-step video restore; ~24 GB on RTX 5090; no 16 GB data yet
- **VOID** (April 2026, Netflix) — video-specific inpainting complement to `build_lama_remove`
- **Anima aesthetic-v1.1 / CyberRealistic Anima v6.0** (2026-07-16/18, Cosmos-Predict2-2B) — too small (2B) to compete with current stack; low priority
- **ControlNet Union adapters** (Qwen-Image + Z-Image FP8, July 17/21) — low confidence; no confirmed ComfyUI node yet

---

### Files changed

- `_dev_docs/upgrade_research/2026-W30.md` — full findings table + tier narratives (first run)
- `_dev_docs/upgrade_research/2026-W30.json` — 21 structured records for programmatic consumption

---

> **Do not merge** — leave open for human review.
> The local nightly export at `tools/export_comfyui_workflows.py` runs at 03:30 and refreshes ComfyUI workflow snapshots automatically; no manual action needed for snapshot updates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMPB5rg3Ctv278Lc6jhqXo)_