### PR TITLE
chore(research): daily SOTA review 2026-07-25

### DIFF
--- a/_dev_docs/upgrade_research/2026-W30.json
+++ b/_dev_docs/upgrade_research/2026-W30.json
@@ -1,0 +1,302 @@
+[
+  {
+    "method": "build_sam3_segment / build_sam3_mask / build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1 Object Multiplex",
+    "source": "meta",
+    "url": "https://ai.meta.com/blog/segment-anything-model-3/",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Drop-in checkpoint swap over SAM 3. Shared-memory joint multi-object tracking, ~7x faster, ~50% less GPU memory, zero API changes. Checkpoints on HuggingFace. ComfyUI tutorial at docs.comfy.org/tutorials/utility/video-segment-sam3. Released Mar 27 2026. Tier 1."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "Depth Anything 3 (DA3-Large)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/Depth-Anything-3",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Replaces DA2. +35.7% camera pose accuracy, +23.6% geometric accuracy vs VGGT. DA3-Base (4 GB), DA3-Large (8 GB), DA3-Streaming (<=12 GB). Official Comfy-Org model pack + tutorial. Community node ComfyUI-DepthAnythingV3 (PozzettiAndrea). ICLR 2026. Released Nov 14 2025. Tier 1."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "node_pack",
+    "name": "Native SeedVR2 in ComfyUI v0.28.0",
+    "source": "github",
+    "url": "https://comfyui-wiki.com/en/news/2026-07-15-comfyui-v0-28-0",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Model unchanged. numz/ComfyUI-SeedVR2_VideoUpscaler external node no longer required after ComfyUI v0.28.0 (Jul 15 2026). Migrate to native nodes to reduce maintenance risk. Also adds 10-bit video support. Tier 1."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "face_swap_model",
+    "name": "HyperSwap 256 (1a/1b/1c variants)",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/releases/tag/v0.6.2",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "ONNX swapper at 256px (2x inswapper_128 resolution). Three quality variants. Drop into ComfyUI/models/hyperswap/. Bundled in ReActor v0.6.2. ReActor v0.6.2 also adds Restore Face Advanced node (restores only swapped region). LICENSE: OpenRAIL-AS (non-commercial — must verify before shipping). Released Apr 25 2026. Tier 1."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-Flash (NVIDIA DMD2-distilled, GGUF Q4_K_M)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/nvidia/Qwen-Image-Flash",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "4-step DMD2-distilled student of 20.4B Qwen-Image. Same architecture. FP8 ~16 GB (tight), GGUF Q4_K_M ~14 GB. Apache 2.0. Reduces inference from 20+ steps to 4. Validate editing fidelity on inpaint/replace tasks before making default. Released Jul 23 2026 (strictly in window). Tier 1."
+  },
+  {
+    "method": "build_supir / build_txt2img / build_klein_*",
+    "category": "node_pack",
+    "name": "NVIDIA PiD v1.5 PixelDiT",
+    "source": "huggingface",
+    "url": "https://huggingface.co/nvidia/PiD",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "Replaces VAE decoder with 4-step pixel-space diffusion upsampler (4x or 8x output). Supports FLUX, FLUX.2, Z-Image, SD3, DINOv2. Peak ~13 GB VRAM on FLUX; fits RTX 5060 Ti 16 GB. ComfyUI-PiD node (Merserk/ComfyUI-PiD). ComfyUI 0.28.0+ required. RTX 50 series: NVFP4 2.5x faster, 60% less VRAM. Additive post-processing stage. Released May 22 2026. Tier 2."
+  },
+  {
+    "method": "build_klein_inpaint / build_klein_auto_inpaint / build_klein_sam3_inpaint / build_inpaint / build_inpaint_fooocus",
+    "category": "node_pack",
+    "name": "LanPaint + Krea 2 Turbo GGUF",
+    "source": "github",
+    "url": "https://github.com/scraed/LanPaint",
+    "risk": "medium",
+    "confidence": 0.68,
+    "notes": "TMLR-accepted training-free inpaint (asymptotically exact conditional sampling). Krea 2 Turbo support added Jun 2026; also supports Flux2 Klein, SDXL, SD3.5, Qwen-Image. Krea2 Turbo GGUF FP8 ~12 GB. Nodes: LanPaint KSampler, LanPaint KSampler Advanced, LanPaint Mask Blend. Krea2 GGUF: realrebelai/KREA-2_GGUFs. Medium risk: different architecture from Flux.2 Klein. Tutorial published Jul 19 2026 (in window). Tier 2."
+  },
+  {
+    "method": "build_wan_video / build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "LingBot-Video MoE 30B-A3B (GGUF community pack)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/realrebelai/LingBot-30B-3B_GGUF_ComfyUI",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "MoE: 30B total, ~3B active per forward pass. GGUF community pack peaks ~8 GB VRAM (weights memmap'd to system RAM). Tops open-source RBench (0.620). Apache 2.0. WIP native ComfyUI PR from comfyanonymous. GGUF pack: ComfyUI_Rebels_LingBot. INTEGRATION CAVEAT: requires structured JSON captions, not prose prompts. Released Jul 9 2026. Tier 2."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "checkpoint",
+    "name": "LTX-2.3 Spatial Upscaler x2 (ltx-2.3-spatial-upscaler-x2-1.1)",
+    "source": "huggingface",
+    "url": "https://ltx.io/model/ltx-2-3",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "~1 GB model, 4 GB VRAM standalone. Doubles spatial resolution in latent space before VAE decode, adds model-generated detail. 18M+ downloads. Does not require LTX-2.3 22B base for spatial upscaling. Standalone node. Released Mar 2026. Tier 2."
+  },
+  {
+    "method": "build_video_upscale / build_wavespeed_upscale",
+    "category": "node_pack",
+    "name": "NVIDIA RTX Video Super Resolution (Comfy-Org/Nvidia_RTX_Nodes_ComfyUI)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "Hardware-accelerated tensor-core video upscaling up to 4x, up to 30x faster than traditional. Zero VRAM overhead. RTX 5060 Ti fully supported; RTX 50 series gets 2.5x speedup vs RTX 40. Provides artifact reduction + scale (not generative). ComfyUI Manager: search 'RTX'. Fast first-pass complement to AI upscalers. Updated Mar 2026. Tier 2."
+  },
+  {
+    "method": "build_qwen_edit / build_txt2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image 8B (MIT, FP8 community quant)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image",
+    "risk": "medium",
+    "confidence": 0.60,
+    "notes": "Pixel-level Unified Transformer: T2I + instruction editing + subject-driven personalization, up to 2048x2048. FP8 community quant ~10 GB VRAM. ComfyUI workflow templates at runcomfy.com. Ranked #8 T2I Arena Jun 2026. MIT license. Limitation: 8B ceiling may lose on complex prompts vs 20B Qwen-Image. Released May 8 2026. Tier 2."
+  },
+  {
+    "method": "build_klein_headswap / build_faceid_img2img",
+    "category": "lora",
+    "name": "BFS Best Face Swap LoRA (Alissonerdx, Flux2 Klein)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "Diffusion-based face/head swap LoRA for Flux2 Klein 4B/9B or Qwen-Image-Edit-2511. Focus Faces (identity transfer) + Focus Head (full head including hair). Klein 4B ~10 GB (use 4B on 16 GB; 9B borderline). Multiple community forks confirm active ecosystem. Last updated Mar 8 2026. Tier 2."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh / build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "TRELLIS 2 (Microsoft Research, 4B)",
+    "source": "github",
+    "url": "https://trellis2.app/blog/comfyui-3d-model-generator-microsoft",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "4B image-to-3D diffusion. 6 GB min (512^3), 12-16 GB for 1024^3 — fits RTX 5060 Ti. Much lower VRAM than HunyuanVideo3D 2.x (which needs 29 GB for textured). ComfyUI integration documented. Better VRAM:quality tradeoff on 16 GB hardware. Released Dec 2025. Tier 2."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh (human figures)",
+    "category": "node_pack",
+    "name": "SAM 3D Body (Meta AI)",
+    "source": "github",
+    "url": "https://github.com/facebookresearch/sam-3d-body",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "Full-body human mesh recovery (pose + hands + feet) from single image via MHR parametric representation. ~3 GB VRAM. ComfyUI-SAM3DBody wrapper (PozzettiAndrea). Fast SAM 3D Body (arXiv 2603.15603, ECCV 2026) provides 10x speedup. Paper Jul 13 2026. New builder opportunity. Tier 2."
+  },
+  {
+    "method": "build_seedv2r",
+    "category": "node_pack",
+    "name": "SwiftVR one-step video restoration",
+    "source": "github",
+    "url": "https://github.com/jungbtc/ComfyUI-SwiftVR",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "One-step diffusion video restoration using mask-free shifted-window attention + lightweight restoration-aware autoencoder. 26 FPS at 1080p on RTX 5090. 1080p should fit 16 GB with queue_size tuning (tested on RTX 4090 24 GB). ComfyUI-SwiftVR node available. Accepts standard ComfyUI VIDEO input. Released Jun 9 2026. Tier 2."
+  },
+  {
+    "method": "build_photo_restore / build_detail_hallucinate",
+    "category": "checkpoint",
+    "name": "SeedVR2 3B (now native in ComfyUI 0.28.0) for image upscale",
+    "source": "github",
+    "url": "https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "3B upscaler, 6.8 GB peak VRAM, good face fidelity at 4x upscale. Image upscale also supported. Built into ComfyUI 0.28.0. Candidate to replace or augment both build_photo_restore and build_detail_hallucinate. GGUF Q4_K_M variants available. Tier 2 (may qualify Tier 1 after testing)."
+  },
+  {
+    "method": "build_txt2img / build_img2img / build_klein_* (future)",
+    "category": "checkpoint",
+    "name": "FLUX 3 Image (Black Forest Labs)",
+    "source": "huggingface",
+    "url": "https://venturebeat.com/technology/black-forest-labs-launches-flux-3-capable-of-generating-images-and-20-second-video-with-audio-but-in-limited-release-to-start",
+    "risk": "high",
+    "confidence": 0.25,
+    "notes": "Unified multimodal model (image + 20s video + audio). Announced Jul 23 2026 (STRICTLY IN WINDOW). CURRENTLY UNAVAILABLE: API Early Access only, no open weights. BFL committed to open FLUX 3 Dev later in 2026. Watch bfl.ai/models/flux-3. Tier 3."
+  },
+  {
+    "method": "build_wan_video (future)",
+    "category": "checkpoint",
+    "name": "FLUX 3 Video (Black Forest Labs)",
+    "source": "github",
+    "url": "https://venturebeat.com/technology/black-forest-labs-launches-flux-3-capable-of-generating-images-and-20-second-video-with-audio-but-in-limited-release-to-start",
+    "risk": "high",
+    "confidence": 0.35,
+    "notes": "20s video + synchronized audio from same FLUX 3 multimodal model. API Early Access only. No local weights. Watch for open-weight release Q3-Q4 2026. Announced Jul 23 2026 (in window). Tier 3."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "RealRestorer (9 degradation types)",
+    "source": "github",
+    "url": "https://github.com/yfyang007/RealRestorer",
+    "risk": "high",
+    "confidence": 0.72,
+    "notes": "Generalizable real-world restoration. ComfyUI node exists (StartHua). BLOCKER: 34 GB peak VRAM at 1024x1024 BF16. Infeasible on RTX 5060 Ti 16 GB. Monitor for FP8 variant. Released Mar 2026. Tier 3."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "checkpoint",
+    "name": "V-RMBG 3.0 (Bria AI, video background removal)",
+    "source": "github",
+    "url": "https://www.prnewswire.com/news-releases/bria-launches-v-rmbg-3-0-state-of-the-art-video-background-removal-model-302796516.html",
+    "risk": "high",
+    "confidence": 0.50,
+    "notes": "Temporal-aware video BG removal, 63% win rate, 9x faster, eliminates flickering. BLOCKER: commercial API only, no HuggingFace weights, no ComfyUI node. Monitor for open-source release. Released Jun 10 2026. Tier 3."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh (alternative)",
+    "category": "checkpoint",
+    "name": "SAM 3D Objects (Meta AI)",
+    "source": "github",
+    "url": "https://github.com/facebookresearch/sam-3d-objects",
+    "risk": "high",
+    "confidence": 0.75,
+    "notes": "Foundation model for 3D shape + texture + layout from single image. ComfyUI-SAM3DObjects wrapper exists. VRAM BLOCKER: community reports OOM on 20 GB GPUs at default settings; hard limit on 16 GB. Monitor for low-VRAM community fork. Released Jun 1 2026. Tier 3."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "Wan-Dancer-14B (Alibaba, audio-driven dance video)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI/Wan-Dancer-14B",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "Generates 720p/30fps dance videos from music + reference image. 5 genres, up to 1 minute. Official: 24 GB. INT4/INT8 ConvRot quantisations may bring to 16 GB — unconfirmed. Apache 2.0. ComfyUI support confirmed. Released Jul 13 2026. Tier 3 until 16 GB viability confirmed."
+  },
+  {
+    "method": "build_video_reactor / build_wan_animate_video",
+    "category": "lora",
+    "name": "BFS Best Face Swap Video / Bernini-R S2V (N0vice fork Jul 19 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap-Video",
+    "risk": "high",
+    "confidence": 0.52,
+    "notes": "IC-LoRA on ByteDance Bernini-R (Wan2.2 finetune) for video head-swap. N0vice fork created Jul 19 2026 (strictly in window). Full stack VRAM: 24 GB comfortable; at 16 GB needs blocks_to_swap=20 (slow). Requires ComfyUI-BerniniR + separate Bernini-R weights ~5 GB. Tier 3."
+  },
+  {
+    "method": "build_qwen_edit / build_inpaint (monitor)",
+    "category": "checkpoint",
+    "name": "Boogu-Image-0.1-Edit FP8 (hotfix-1k5-20260708)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-fp8",
+    "risk": "medium",
+    "confidence": 0.55,
+    "notes": "10B unified T2I + instruction editing. Fits 16 GB FP8. ComfyUI-Boogu nodes in ComfyUI core. Supports object insert/remove/replace/style transfer. Revision hotfix-1k5-20260708 (Jul 8 2026) addresses severe quality regressions. Ongoing instability — monitor for stable v1.0. Best at <=1K resolution. Tier 3."
+  },
+  {
+    "method": "build_colorize",
+    "category": "lora",
+    "name": "LTX-2.3 IC-LoRA Colorization (Lightricks)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Colorization",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Restores natural color to grayscale/desaturated video while preserving identity and geometry. Validated at 960x544 24fps. Base model LTX-2.3 22B — 16 GB VRAM with tiling unverified. Video-focused only (no static-image colorization path). Released Jun 17 2026. Tier 3 until VRAM confirmed."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "RefIPFR reference-guided identity-preserving face restoration",
+    "source": "github",
+    "url": "https://github.com/cdluminate/RefIPFR",
+    "risk": "high",
+    "confidence": 0.50,
+    "notes": "Uses reference face (exactly like build_save_face_model output) to guide blind restoration via Composite Context fusion + Hard Example Identity Loss. Outperforms CodeFormer on identity fidelity. Code on GitHub. NO ComfyUI node yet. Requires custom wrapper. Paper May 2025. Tier 3."
+  },
+  {
+    "method": "build_supir (iterative)",
+    "category": "checkpoint",
+    "name": "RAR (Restore, Assess, Repeat) CVPR 2026",
+    "source": "github",
+    "url": "https://github.com/saic-fi/RAR",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "Iterative quality-aware restoration using VLM quality model + flow-matching generative prior. Accepted CVPR 2026. Code on GitHub. No ComfyUI node. VRAM unspecified. Monitor for community node. Tier 3."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "lora",
+    "name": "W-Switch / W-Composite multi-LoRA composition (arXiv 2606.03792)",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2606.03792",
+    "risk": "medium",
+    "confidence": 0.48,
+    "notes": "Prompt-aware importance weighting for composing multiple LoRA adapters at inference time, no retraining. Spatial patch-based cosine similarity weighting. No ComfyUI node as of Jul 25 2026. Requires custom node authoring. Tier 3."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "controlnet",
+    "name": "Krea-2-depth-controlnet (community, Tanmay Patil)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Patil/Krea-2-depth-controlnet",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "862 MB ControlNet-LoRA for Krea 2 (Raw or Turbo). Depth-Anything-V2 conditioning. Depth consistency 0.99 Pearson. Relevant only if Krea 2 base model is integrated into the stack. Community release (not official krea-ai). Tier 3 pending Krea2 base integration."
+  },
+  {
+    "method": "build_outpaint",
+    "category": "lora",
+    "name": "krea2-outpaint LoRA + ComfyUI-Rebels-Krea2-Outpaint",
+    "source": "huggingface",
+    "url": "https://huggingface.co/yijunwang2/krea2-outpaint",
+    "risk": "low",
+    "confidence": 0.55,
+    "notes": "Rank-32 LoRA trained on Krea 2 Raw for canvas extension/outpainting. Dedicated ComfyUI node set by RealRebelAI. VRAM: Krea2 Turbo FP8 ~12 GB + small LoRA, fits 16 GB. Relevant only if Krea 2 base model is integrated into the stack. Tier 3 pending Krea2 base integration."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W30.md
+++ b/_dev_docs/upgrade_research/2026-W30.md
@@ -1,0 +1,144 @@
+# Spellcaster daily SOTA review — 2026-07-25
+
+ISO week: `2026-W30`. Baseline: *(first review — no prior file)*.
+
+Hardware budget: RTX 5060 Ti, 16 GB VRAM.
+Survey window: July 18–25, 2026 (items outside the window are included only where they newly became relevant to the Spellcaster stack and were not previously known).
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement / Addition | Source URL | Risk | Notes |
+|--------|-----------------|-------------|----------------------|------------|------|-------|
+| `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract` | SAM 3 | **No** | SAM 3.1 Object Multiplex | https://ai.meta.com/blog/segment-anything-model-3/ | low | Drop-in checkpoint swap; shared-memory multi-object tracking, ~7× faster, ~50% less VRAM. Zero API changes. Released Mar 27 2026. |
+| `build_depth_map_v3` | Depth Anything 2 (da2_large) | **No** | Depth Anything 3 (DA3) | https://github.com/bytedance-seed/depth-anything-3 | low | +35.7% camera pose accuracy, +23.6% geometric accuracy. Four variants; DA3-Large = 8 GB VRAM. Comfy-Org model pack + tutorial available. ICLR 2026, Nov 2025. |
+| `build_seedvr2_video_upscale` | numz/ComfyUI-SeedVR2 (external node) | **Same model, improved path** | Native SeedVR2 in ComfyUI 0.28.0 | https://comfyui-wiki.com/en/news/2026-07-15-comfyui-v0-28-0 | low | No model change; external node dependency eliminated. Migrate to native nodes to reduce maintenance risk. Jul 15 2026. |
+| `build_faceswap` | inswapper_128.onnx | **No** | HyperSwap 256 (variants 1a/1b/1c) | https://github.com/Gourieff/ComfyUI-ReActor/releases/tag/v0.6.2 | low | 256px ONNX swapper (2× resolution of inswapper_128). Already in ReActor v0.6.2 (Apr 25 2026). OpenRAIL-AS (non-commercial — verify licensing). |
+| `build_qwen_edit` | Qwen-Image (20.4B base) | **Partial** | Qwen-Image-Flash (DMD2, 4-step) | https://huggingface.co/nvidia/Qwen-Image-Flash | low | Same architecture, 4-step distilled. FP8 ≈16 GB (tight), GGUF Q4_K_M ≈14 GB. Apache 2.0. Test editing fidelity before making default. Jul 23 2026. |
+| `build_txt2img` / `build_img2img` / `build_klein_*` | Flux2/Klein / SDXL | **Watch** | FLUX 3 Image (BFL) | https://venturebeat.com/technology/black-forest-labs-launches-flux-3-capable-of-generating-images-and-20-second-video-with-audio-but-in-limited-release-to-start | high | Announced Jul 23 — API Early Access only. No open weights yet. BFL has committed to open FLUX 3 Dev "later in 2026". Watch bfl.ai/models/flux-3. |
+| `build_wan_video` / `build_wan22_t2v` | WAN 2.1 / 2.2 | **Partial** | LingBot-Video MoE 30B-A3B (GGUF) | https://huggingface.co/robbyant/lingbot-video-moe-30b-a3b | medium | MoE: 30B total, ~3B active. GGUF peak VRAM ~8 GB (community pack). Tops open RBench (0.620). Apache 2.0. WIP native ComfyUI PR open. Requires structured JSON captions. Integration work needed. Jul 9 2026. |
+| `build_wan_animate_video` | WAN 2.1 animate | **Additive** | Wan-Dancer-14B | https://huggingface.co/Wan-AI/Wan-Dancer-14B | medium | Audio-driven dance video (5 genres, 720p/30fps). Official: 24 GB; INT4/INT8 quantisations may fit 16 GB — untested. Jul 13 2026. |
+| `build_video_upscale` | 4x-UltraSharp.pth | **No** | LTX-2.3 Spatial Upscaler ×2 | https://ltx.io/model/ltx-2-3 | low | ~1 GB, only 4 GB VRAM standalone. Doubles spatial resolution in latent space. 18 M+ HF downloads. Mar 2026. |
+| `build_video_upscale` / `build_wavespeed_upscale` | Software upscalers | **Additive** | NVIDIA RTX Video Super Resolution | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | low | Hardware-accelerated tensor-core upscaling. Zero VRAM overhead. RTX 50xx best case (2.5× faster). Fast first-pass complement to SeedVR2. Mar 2026. |
+| `build_supir` / `build_seedv2r` | SUPIR SDXL decoder / SeedVR2 | **Additive** | NVIDIA PiD v1.5 PixelDiT | https://huggingface.co/nvidia/PiD | medium | Replaces VAE decoder with 4-step pixel-space diffusion upsampler (4×). Peak ~13 GB VRAM on FLUX. ComfyUI-PiD node. ComfyUI 0.28.0+ required. RTX 50 series: NVFP4 2.5× faster. May 22 2026. |
+| `build_klein_inpaint` / `build_inpaint` | Flux2 Klein KSampler / SDXL fooocus | **Additive** | LanPaint + Krea 2 Turbo GGUF | https://github.com/scraed/LanPaint | medium | TMLR-accepted training-free inpaint. Krea 2 Turbo FP8 = ~12 GB. Supports Klein, SDXL, SD3.5, Qwen-Image, HiDream. New dedicated KSampler nodes. Jul 19 2026 (tutorial). |
+| `build_qwen_edit` / `build_txt2img` | Qwen-Image / SDXL | **Additive** | HiDream-O1-Image (8B, MIT) | https://huggingface.co/HiDream-ai/HiDream-O1-Image | medium | Pixel-level UiT: T2I + instruction editing + personalization. FP8 community quant ≈10 GB. ComfyUI templates available. Ranked #8 T2I Arena (Jun 2026). May 8 2026. |
+| `build_klein_headswap` / `build_faceid_img2img` | Klein headswap workflow | **Additive** | BFS Best Face Swap LoRA (Alissonerdx) | https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap | medium | Flux2 Klein 4B/9B diffusion LoRA. Focus Faces (identity transfer) + Focus Head (full head swap) modes. Klein 4B ≈10 GB. Mar 8 2026. |
+| `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured` | HunyuanVideo 3D (29 GB+) | **No (VRAM)** | TRELLIS 2 (Microsoft, 4B) | https://trellis2.app/blog/comfyui-3d-model-generator-microsoft | medium | Image-to-3D. 6 GB min (512³), 12–16 GB for 1024³. Much better VRAM fit than HunyuanVideo3D on 16 GB card. ComfyUI integration documented. Dec 2025. |
+| `build_hunyuan_3d_mesh` (human figures) | HunyuanVideo 3D mesh | **Additive** | SAM 3D Body (Meta) | https://github.com/facebookresearch/sam-3d-body | medium | Full-body human mesh recovery (pose + hands + feet). ~3 GB VRAM. ComfyUI-SAM3DBody wrapper available. Fast SAM 3D Body (ECCV 2026) = 10× speedup. Jul 13 2026. |
+| `build_seedv2r` | SeedVR temporal consistency | **Additive** | SwiftVR one-step video restoration | https://github.com/jungbtc/ComfyUI-SwiftVR | medium | One-step diffusion VR, 26 FPS at 1080p on RTX 5090. 1080p should fit 16 GB with queue_size tuning. ComfyUI-SwiftVR node. Jun 9 2026. |
+| `build_rembg_v3` | RMBG-2.0 | **Watch** | V-RMBG 3.0 (Bria AI) | https://www.prnewswire.com/news-releases/bria-launches-v-rmbg-3-0-state-of-the-art-video-background-removal-model-302796516.html | high | API-only, no open weights. 63% win rate, 9× faster, temporal-aware. Monitor for open-source release. Jun 10 2026. |
+| `build_supir` (SDXL decode stage) | SDXL VAE | **Watch** | RealRestorer | https://github.com/yfyang007/RealRestorer | high | 9 degradation types, ComfyUI node exists. BLOCKER: 34 GB peak VRAM — infeasible on 16 GB without quantisation not yet available. Monitor for FP8. Mar 2026. |
+| `build_qwen_edit` / `build_inpaint` | Qwen-Image / SDXL fooocus | **Additive (monitor)** | Boogu-Image-0.1-Edit FP8 | https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-fp8 | medium | 10B T2I + editing unified. Fits 16 GB FP8. Use hotfix-1k5-20260708 revision. ComfyUI-Boogu nodes in core. Ongoing instability — watch before adopting. Jul 8 2026. |
+| `build_colorize` | Klein colorize workflow | **Additive** | LTX-2.3 IC-LoRA Colorization | https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Colorization | medium | Video-focused colorization. Base model 22B — 16 GB VRAM uncertain without tiling. Jun 17 2026. |
+| `build_face_restore` | CodeFormer | **Watch** | RefIPFR (reference-guided identity-preserving FR) | https://github.com/cdluminate/RefIPFR | high | Uses reference face (like build_save_face_model output) to guide blind restoration. Code on GitHub. No ComfyUI node yet. Better identity fidelity than CodeFormer. May 2025. |
+| `build_wan_video` (future) | WAN 2.x | **Watch** | FLUX 3 Video (BFL) | https://venturebeat.com/technology/black-forest-labs-launches-flux-3-capable-of-generating-images-and-20-second-video-with-audio-but-in-limited-release-to-start | high | 20s video + audio unified. API Early Access only. No local weights. Same FLUX 3 announcement as image column. |
+| `build_photo_restore` / `build_detail_hallucinate` | upscale + CodeFormer | **Partial** | SeedVR2 native (ComfyUI 0.28.0) | https://github.com/numz/ComfyUI-SeedVR2_VideoUpscaler | low | 3B upscaler, 6.8 GB peak VRAM, good face fidelity at 4×. Now built into ComfyUI 0.28.0. Jul 15 2026. |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+These are direct checkpoint or node swaps. No new builder code required. All fit RTX 5060 Ti 16 GB.
+
+1. **SAM 3.1 → `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract`**
+   HuggingFace checkpoints, drop-in over SAM 3. Zero API changes. ~7× faster inference, ~50% less GPU memory.
+   URL: https://ai.meta.com/blog/segment-anything-model-3/
+
+2. **Depth Anything 3 → `build_depth_map_v3`**
+   DA3-Base (4 GB) or DA3-Large (8 GB). Comfy-Org model pack ships with an official tutorial. Replace the `da3_large.safetensors` path in the builder.
+   URL: https://huggingface.co/Comfy-Org/Depth-Anything-3
+
+3. **Native SeedVR2 (ComfyUI 0.28.0) → `build_seedvr2_video_upscale`**
+   Model unchanged. Remove the dependency on `numz/ComfyUI-SeedVR2_VideoUpscaler` external node and wire to the native nodes that shipped in v0.28.0.
+   URL: https://comfyui-wiki.com/en/news/2026-07-15-comfyui-v0-28-0
+
+4. **HyperSwap 256 → `build_faceswap`**
+   Three ONNX variants (1a balanced / 1b quality / 1c high-quality) at 256px. Drop files into `ComfyUI/models/hyperswap/`. Already bundled in ReActor v0.6.2. **License check required: OpenRAIL-AS (non-commercial).**
+   URL: https://github.com/Gourieff/ComfyUI-ReActor/releases/tag/v0.6.2
+
+5. **Qwen-Image-Flash (GGUF Q4_K_M ≈14 GB) → `build_qwen_edit`**
+   4-step DMD2-distilled student of 20.4B Qwen-Image. Same weights path, same node. Reduces step count from ~20 to 4. Validate editing fidelity on inpaint/replace tasks before making default.
+   URL: https://huggingface.co/nvidia/Qwen-Image-Flash
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install)
+
+These require installing a new ComfyUI custom node pack and/or downloading a new base model. All fit RTX 5060 Ti 16 GB (some tightly).
+
+1. **NVIDIA PiD v1.5 PixelDiT** — post-processing 4× upscale stage after any generator. Replaces VAE decoder with 4-step pixel diffusion. ComfyUI-PiD node available. Peak ~13 GB on FLUX. Additive to `build_supir`, `build_txt2img`, `build_klein_*`.
+   URL: https://github.com/Merserk/ComfyUI-PiD
+
+2. **LanPaint + Krea 2 Turbo GGUF** — training-free inpaint via asymptotically exact conditional sampling. Krea 2 Turbo FP8 ≈12 GB. New dedicated KSampler + Mask Blend nodes. Enhances `build_klein_inpaint`, `build_klein_auto_inpaint`, `build_inpaint`, `build_inpaint_fooocus`.
+   URL: https://github.com/scraed/LanPaint
+
+3. **LingBot-Video MoE 30B-A3B (GGUF)** — 30B/3B-active MoE video model tops open-source RBench. GGUF community pack peaks at ~8 GB VRAM. WIP ComfyUI PR. **Caveat:** requires structured JSON captions (not prose prompts) — integration work needed. Could replace or augment `build_wan_video`, `build_wan22_t2v`.
+   URL: https://huggingface.co/realrebelai/LingBot-30B-3B_GGUF_ComfyUI
+
+4. **LTX-2.3 Spatial Upscaler ×2** — ~1 GB model, 4 GB VRAM standalone. Doubles spatial resolution in latent space (adds model-generated detail, not just interpolation). Direct add-on for `build_video_upscale`.
+   URL: https://ltx.io/model/ltx-2-3
+
+5. **NVIDIA RTX Video Super Resolution** (Comfy-Org/Nvidia_RTX_Nodes_ComfyUI) — hardware tensor-core upscaling, zero VRAM overhead. Fast first-pass complement to SeedVR2/WaveSpeed for `build_video_upscale`, `build_wavespeed_upscale`.
+   URL: https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI
+
+6. **HiDream-O1-Image 8B (MIT)** — pixel-level unified transformer for T2I + instruction editing. FP8 community quant ≈10 GB. ComfyUI workflow templates at runcomfy.com. Complementary option for `build_qwen_edit` and `build_txt2img`. Ranked #8 T2I Arena.
+   URL: https://huggingface.co/HiDream-ai/HiDream-O1-Image
+
+7. **BFS Best Face Swap LoRA (Alissonerdx)** — Flux2 Klein 4B/9B LoRA for diffusion-based face/head swap. Focus Faces + Focus Head modes. Klein 4B ≈10 GB. New builder option for `build_klein_headswap`, `build_faceid_img2img`.
+   URL: https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap
+
+8. **TRELLIS 2 (Microsoft 4B)** — image-to-3D. Fits 16 GB at 1024³. Much more VRAM-efficient than HunyuanVideo3D-2.x on 16 GB. Alternative backbone for `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured`.
+   URL: https://trellis2.app/blog/comfyui-3d-model-generator-microsoft
+
+9. **SAM 3D Body (Meta)** — full-body human mesh recovery from single image, ~3 GB VRAM. ComfyUI-SAM3DBody wrapper available. New builder opportunity for portrait figure work.
+   URL: https://github.com/facebookresearch/sam-3d-body
+
+10. **SwiftVR one-step video restoration** — 26 FPS at 1080p, 1080p should fit 16 GB with queue_size tuning. ComfyUI-SwiftVR node. Alternative one-step approach for `build_seedv2r`.
+    URL: https://github.com/jungbtc/ComfyUI-SwiftVR
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Blocker | Target method |
+|------|---------|---------------|
+| FLUX 3 Image + Video (BFL, Jul 23 2026) | API Early Access only, no open weights; timeline TBD | All image-gen + `build_wan_video` |
+| RealRestorer (Mar 2026) | 34 GB peak VRAM; FP8 variant not yet available | `build_supir` |
+| V-RMBG 3.0 (Bria AI, Jun 2026) | Commercial API only; no HuggingFace weights | `build_rembg_v3` |
+| SAM 3D Objects (Meta, Jun 2026) | Community reports OOM on 20 GB; hard limit on 16 GB | `build_hunyuan_3d_mesh` |
+| Wan-Dancer-14B (Jul 13 2026) | Official 24 GB; INT4/INT8 quants untested at 16 GB | `build_wan_animate_video` |
+| LTX-2.3 Temporal Upscaler (Mar 2026) | 16 GB marginal; 24 GB comfortable floor | `build_seedvr2_video_upscale` |
+| Bernini-R S2V (Jun 2026) | 24 GB comfortable; blocks_to_swap path slow at 16 GB | `build_video_reactor`, `build_wan_animate_video` |
+| BFS Face Swap Video / N0vice fork (Jul 19 2026) | Same VRAM issue as Bernini-R above | `build_faceswap_mtb`, `build_video_reactor` |
+| NVIDIA Cosmos3-Edge (Jul 20 2026, SIGGRAPH) | Robotics/simulation training data; not creative video | — |
+| Boogu-Image-0.1-Edit FP8 (Jul 8 2026) | Ongoing hotfix instability; monitor for v1.0 | `build_qwen_edit`, `build_inpaint` |
+| LTX-2.3 IC-LoRA Colorization (Jun 2026) | Base LTX 22B; 16 GB VRAM with tiling unverified | `build_colorize` |
+| RAR CVPR 2026 (Samsung AI) | No ComfyUI node; no VRAM spec | `build_supir` |
+| RefIPFR (May 2025) | No ComfyUI node; requires custom wrapper | `build_face_restore` |
+| NTIRE 2026 face restore winners (Apr 2026) | Winning weights confidential | `build_face_restore` |
+| PortraitGen arXiv 2606.26930 (Jun 2026) | No weights published | `build_photobooth` |
+| W-Switch / W-Composite multi-LoRA (arXiv Jun 2026) | No ComfyUI node | `build_style_transfer` |
+| Krea-2-depth-controlnet (Jul 3 2026) | Requires Krea 2 base not yet in Spellcaster stack | `build_controlnet_gen` |
+| krea2-outpaint LoRA (Jul 2026) | Requires Krea 2 base not yet in Spellcaster stack | `build_outpaint` |
+| FaceFusion 3.7.1 (Jul 5 2026) | Standalone GUI; no new model over ReActor v0.6.2 | `build_faceswap` |
+
+---
+
+## No-finds (verified)
+
+The following were explicitly searched and confirmed absent from the July 18–25 window:
+
+- **WAN 2.3** — does not exist; lineage went WAN 2.1 → 2.2 → 2.6 → 2.7. No new Wan release in window.
+- **LTX Video 2+** — LTX-2.3 (March 2026) is current; no new release in window.
+- **HunyuanVideo 2.0** — latest remains HunyuanVideo 1.5 (Nov 2025, 8.3B, ~14 GB); no update in window.
+- **FramePack 2 / update** — no new release or announcement found in window.
+- **New CodeFormer / GFPGAN successor with public weights** — no release in window.
+- **New PuLID / InstantID Flux update** — no release in window.
+- **New CogVideo update** — no release in window.
+- **New Mochi Video update** — no release in window.
+
+---
+
+*Report generated by automated daily SOTA review agent. Implementation work requires local node-pack installs on the user's machine. See `tools/export_comfyui_workflows.py` — the local 03:30 nightly export will refresh ComfyUI workflow snapshots automatically.*


### PR DESCRIPTION
## What does this change?

Adds the first automated daily SOTA review for ISO week `2026-W30` (July 18–25, 2026). No prior baseline. Survey covers 33 model/node candidates across four families; no implementation changes are included — human review required before any upgrade work.

Files added:
- `_dev_docs/upgrade_research/2026-W30.md` — full findings report with tiered upgrade list
- `_dev_docs/upgrade_research/2026-W30.json` — structured JSON, one record per candidate

## Type of change

- [x] Docs only

## Summary table

| Tier | Count | Items |
|------|-------|-------|
| **Tier 1** — Drop-in supersessions (ship soon) | 5 | SAM 3.1 checkpoints, Depth Anything 3, ComfyUI 0.28.0 native SeedVR2, HyperSwap 256 via ReActor v0.6.2, Qwen-Image-Flash GGUF |
| **Tier 2** — Additive new builders (node-pack install needed) | 10 | NVIDIA PiD v1.5, LanPaint + Krea2 Turbo, LingBot-Video MoE GGUF, LTX-2.3 Spatial Upscaler, NVIDIA RTX VSR, HiDream-O1-Image, BFS Face Swap LoRA, TRELLIS 2, SAM 3D Body, SwiftVR |
| **Tier 3** — Monitor / not wire-ready | 18 | FLUX 3 (API only), RealRestorer (34 GB VRAM), V-RMBG 3.0 (API only), SAM 3D Objects (32 GB OOM), Wan-Dancer-14B (24 GB official), and 13 more |
| **No-finds (verified)** | 8 | WAN 2.3, LTX Video 2+, HunyuanVideo 2.0, FramePack update, CodeFormer successor, PuLID/InstantID update, CogVideo update, Mochi Video update |

### Highest-priority Tier-1 actions

1. **SAM 3.1** → `build_sam3_*` — zero code change, checkpoint swap, ~7× faster, ~50% less VRAM
2. **Depth Anything 3** → `build_depth_map_v3` — DA3-Large 8 GB VRAM, Comfy-Org model pack
3. **ComfyUI 0.28.0 native SeedVR2** → `build_seedvr2_video_upscale` — remove external node dependency
4. **HyperSwap 256** → `build_faceswap` — 2× resolution ONNX via existing ReActor v0.6.2 ⚠️ verify OpenRAIL-AS license
5. **Qwen-Image-Flash GGUF Q4\_K\_M (14 GB)** → `build_qwen_edit` — 4-step distilled, validate editing fidelity first

### Key window find (strictly July 18–25)

- **FLUX 3** (BFL, Jul 23) — announced, API Early Access only, no open weights yet. Likely to supersede all image-gen + video builders when open weights land (estimated Q3–Q4 2026). Nothing actionable today.

## Checklist

- [x] **No personal data in the diff.** No real IPs, no `C:\Users\...` paths, no email addresses, no tokens.
- [x] **No NSFW content in the public repo.**
- [x] **`spellcaster_core/` stays in sync.** No `spellcaster_core/` files modified.
- [x] New ComfyUI custom nodes are **not** declared in this PR — no code changes. Node-pack installation must happen on the local machine when Tier-1/2 items are actioned.
- [x] No new GIMP procedures registered — docs-only PR.

## Test plan

Automated research agent — no local ComfyUI server test applies to this docs-only PR. Implementation work for Tier-1 items requires installing node packs on the user's local machine.

> **Reminder:** The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically. This PR only adds the research report; the nightly export handles workflow snapshot updates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL38ZbHzPoJVxVapKBtphK)_