### PR TITLE
chore(research): daily SOTA review 2026-07-26

### DIFF
--- a/_dev_docs/upgrade_research/2026-W30.json
+++ b/_dev_docs/upgrade_research/2026-W30.json
@@ -1,0 +1,362 @@
+[
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "Lucida (BiRefNet_HR fine-tune)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/egeorcun/lucida",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "IN WINDOW (Jul 24). Drop-in weight swap for BiRefNet-HR. Fine-tuned on 52,882 image/alpha pairs for glass/transparency, camouflage, glow/VFX, illustrations. ComfyUI-RMBG v3.1.0 already wires BiRefNet-Lucida. No builder code change needed. MIT license. 6-8 GB VRAM."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Anima Aesthetic v1.0 (circlestone-labs/Anima)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/circlestone-labs/Anima",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "IN WINDOW (Jul 24). 2B DiT from NVIDIA Cosmos-Predict2-2B-Text2Image. Qwen3-0.6B text encoder + Qwen-Image VAE. Non-photorealistic/anime workloads only. Native ComfyUI via Comfy Org. Non-commercial license. ~8 GB VRAM. Turbo v1.0 also available for faster inference."
+  },
+  {
+    "method": "build_klein_img2img",
+    "category": "checkpoint",
+    "name": "Bonsai Image Ternary 4B (prism-ml/bonsai-image-ternary-4B-unpacked)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Jun 1. Ternary {-1,0,+1} distillation of Flux.2-Klein-4B. 1.21 GB disk vs 7.75 GB FP16. Same Flux2KleinPipeline, Apache 2.0. Applies to ALL build_klein_* methods. ~4-6 GB VRAM. Minor quality regression vs FP16 — good for edge/low-VRAM."
+  },
+  {
+    "method": "build_klein_img2img_ref",
+    "category": "checkpoint",
+    "name": "Bonsai Image Ternary 4B (prism-ml/bonsai-image-ternary-4B-unpacked)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Jun 1. Ternary Klein-4B variant. Applies to all build_klein_* methods. See build_klein_img2img entry for details."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "checkpoint",
+    "name": "Bonsai Image Ternary 4B (prism-ml/bonsai-image-ternary-4B-unpacked)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Jun 1. Ternary Klein-4B variant. Applies to all build_klein_* methods. See build_klein_img2img entry for details."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "BFS Best Face Swap LoRA v3 (Alissonerdx/BFS-Best-Face-Swap)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Mar 8 (background). Head V3 is stable recommended variant. MIT license. 545K downloads. Requires Klein 9B base. 6-16 GB VRAM. Verify against _inventory/ LoRA list — may already be in user's collection."
+  },
+  {
+    "method": "build_klein_face_detail",
+    "category": "lora",
+    "name": "BFS Best Face Swap LoRA — Face V1 (Alissonerdx/BFS-Best-Face-Swap)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Mar 8 (background). BFS Face V1 preserves target details while swapping identity. See build_klein_headswap BFS entry for details."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 256 (facefusion/models-3.3.0 — hyperswap_1a/1b/1c_256.onnx)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Jul 5 (FaceFusion 3.7.1). 256 px crop vs inswapper_128's 128 px — 2x resolution, better fine detail. Three ONNX variants: 1a (fast), 1b (balanced), 1c (quality). Models available NOW. Blocker: ComfyUI-ReActor issue #143 unmerged. Manual ONNX loader is interim path. ~6-10 GB VRAM."
+  },
+  {
+    "method": "build_faceswap_model",
+    "category": "checkpoint",
+    "name": "HyperSwap 256 (facefusion/models-3.3.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Jul 5. See build_faceswap HyperSwap entry for details."
+  },
+  {
+    "method": "build_faceswap_mtb",
+    "category": "checkpoint",
+    "name": "HyperSwap 256 (facefusion/models-3.3.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Jul 5. See build_faceswap HyperSwap entry for details. MTB uses same InsightFace detection stack."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "node_pack",
+    "name": "ComfyUI-Forbidden-Vision (luxdelux7/ComfyUI-Forbidden-Vision)",
+    "source": "github",
+    "url": "https://github.com/luxdelux7/ComfyUI-Forbidden-Vision",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "Jul 19 (maintenance commit). Established since Dec 2025. YOLO11 custom heads (realistic/anime/NSFW) + Neural Corrector for exposure/color correction. Better than CodeFormer's detection on side-profiles and occlusion. Apache 2.0. Models auto-download from HF. ~10 GB est. VRAM."
+  },
+  {
+    "method": "build_photo_restore",
+    "category": "node_pack",
+    "name": "ComfyUI-Forbidden-Vision Neural Corrector",
+    "source": "github",
+    "url": "https://github.com/luxdelux7/ComfyUI-Forbidden-Vision",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "Jul 19. Neural Corrector node addresses color bleeding that CodeFormer introduces. See build_face_restore entry for details."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (facebook/sam3.1)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Mar 27, 2026. ~7x faster multi-instance inference, global temporal reasoning. Drop-in checkpoint replacement. Gated (Meta Research License, same terms as SAM3). Must accept license on HF. Verify SAM3 node pack is not pinned to original SAM3 checkpoint. 8-10 GB VRAM."
+  },
+  {
+    "method": "build_sam3_mask",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (facebook/sam3.1)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Mar 27, 2026. See build_sam3_segment entry for details."
+  },
+  {
+    "method": "build_sam3_extract",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (facebook/sam3.1)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facebook/sam3.1",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Mar 27, 2026. See build_sam3_segment entry for details."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "Wan-Dancer-14B INT4 ConvRot (Wan-AI/Wan-Dancer-14B + Winnougan INT4 quant)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI/Wan-Dancer-14B",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "Jul 13-17 (adjacent). 14B I2V model for music-conditioned rhythmic dance animation, 720p/30fps. Apache 2.0. INT4 ConvRot quant (Winnougan/Wan-Dancer-14B-INT8-INT4-Convrot) targets ~14-16 GB with CPU T5 offload. Blocker: ComfyUI-WanVideoWrapper support unconfirmed as of Jul 17. Dance/rhythm use case only — not general I2V."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "SparkVSR (JiongzeYu/SparkVSR + smthemex/ComfyUI_SparkVSR_SM)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/JiongzeYu/SparkVSR",
+    "risk": "medium",
+    "confidence": 0.68,
+    "notes": "May-Jun 2026. Keyframe-guided VSR via CogVideoX1.5-5B-I2V backbone. Propagates SR improvements from sparse keyframes to full video — better for long clips than SeedVR2's one-shot approach. ECCV 2026. ComfyUI node: github.com/smthemex/ComfyUI_SparkVSR_SM. 10-14 GB VRAM."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "node_pack",
+    "name": "LTX-2.3 Video LoRA training support",
+    "source": "github",
+    "url": "https://ltx.io/blog-category/product-updates",
+    "risk": "low",
+    "confidence": 0.62,
+    "notes": "Jul 8 (adjacent). Lightricks shipped native video LoRA + IC-LoRA + full fine-tune training for LTX-2.3. Opens community LTX LoRA ecosystem. Additive infrastructure improvement — verify if build_ltx_video already has inject_lora_chain path."
+  },
+  {
+    "method": "build_inpaint",
+    "category": "checkpoint",
+    "name": "Krea 2 Turbo FP8 (AlperKTS/Krea2_FP8)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/AlperKTS/Krea2_FP8",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "Jul 19 (workflow docs; model Jun 22). 12.9B MMDiT + Qwen3-VL. FP8 ~12 GB — fits if no headroom issues. Full BF16 ~28 GB (skip). Needs comfyui-krea2-controlnet node. License unclear for Turbo variant. Monitor for VRAM stability reports."
+  },
+  {
+    "method": "build_outpaint",
+    "category": "checkpoint",
+    "name": "Krea 2 Turbo FP8 (AlperKTS/Krea2_FP8)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/AlperKTS/Krea2_FP8",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "Jul 19 (workflow docs; model Jun 22). See build_inpaint Krea 2 entry for details."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "IConFace (cosmicrealm/IConFace — Klein-4B backbone + AdaFace identity)",
+    "source": "github",
+    "url": "https://github.com/cosmicrealm/IConFace",
+    "risk": "high",
+    "confidence": 0.70,
+    "notes": "May 2026 (paper arxiv:2605.02814). Reference-aware face restoration using Flux.2-Klein-4B backbone + AdaFace identity embedding. Significantly better identity fidelity than CodeFormer on degraded inputs. No ComfyUI node yet. ~12 GB VRAM. Track for Q3 2026 community wrapper."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Pixal3D (TencentARC/Pixal3D)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/TencentARC/Pixal3D",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "May 2026 (SIGGRAPH 2026, arxiv:2605.10922). Pixel-aligned I2→3D with PBR textures (albedo+metallic+roughness). Trellis.2 backbone. MIT license. 302 likes. Alternative (not direct replacement) to Hunyuan3D 2.1 — better pixel correspondence. No ComfyUI node pack yet. ~12-16 GB. Watch TencentARC/Pixal3D GitHub."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "checkpoint",
+    "name": "Pixal3D (TencentARC/Pixal3D)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/TencentARC/Pixal3D",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "May 2026. See build_hunyuan_3d_mesh Pixal3D entry for details."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node_pack",
+    "name": "FlashVSR v1.1 (naxci1/ComfyUI-FlashVSR_Stable)",
+    "source": "github",
+    "url": "https://github.com/naxci1/ComfyUI-FlashVSR_Stable",
+    "risk": "medium",
+    "confidence": 0.65,
+    "notes": "Nov 2025 (CVPR 2026 best-paper track). One-step streaming VSR, ~17 FPS at 768x1408 on A100. Fits 12-16 GB at lower resolution. Three competing ComfyUI implementations (1038lab, smthemex, naxci1) — use naxci1 stable fork. Streaming interface may conflict with batch approach used by build_video_upscale."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "checkpoint",
+    "name": "Krea 2 Identity Edit LoRA v1.2 (lbouaraba/comfyui-krea2edit)",
+    "source": "github",
+    "url": "https://github.com/lbouaraba/comfyui-krea2edit",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "Jul 17. Instruction-based identity-preserving editor on Krea 2. LoRA enables face/head swap, eye replacement, try-on. ref_boost dial for fidelity vs editability. v1.2 fixed blurry results from v1.1 via FIT reference geometry. Krea 2 base model ~14-18 GB — likely exceeds 16 GB budget. Hold until INT8 quant confirmed."
+  },
+  {
+    "method": "build_klein_face_detail",
+    "category": "checkpoint",
+    "name": "Krea 2 Identity Edit LoRA v1.2 (lbouaraba/comfyui-krea2edit)",
+    "source": "github",
+    "url": "https://github.com/lbouaraba/comfyui-krea2edit",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "Jul 17. See build_klein_headswap Krea 2 entry for details."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Ideogram 4.0 nf4 (ideogram-ai/ideogram-4-nf4)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ideogram-ai/ideogram-4-nf4",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Jun 3. 9.3B DiT, 2K native resolution, native text rendering in multiple languages. nf4 ~8 GB VRAM. Gated (must accept Ideogram 4 Non-Commercial License). Non-standard JSON structured prompting. Strong for typography/text-heavy generation. Internal/non-commercial use only."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "lora",
+    "name": "AnyStyle (arxiv 2607.04677) — single LoRA style transfer on Flux",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2607.04677",
+    "risk": "medium",
+    "confidence": 0.55,
+    "notes": "Jul 6 (paper only). Replaces dual-LoRA (style+content) with single adapter. Training-free structural guidance from content image internal attention. Flux backbone. No code released yet. ~4-8 week ETA for code drop based on typical pattern."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "GenCeption (arxiv 2607.09024) — video DiT unified perception",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2607.09024",
+    "risk": "high",
+    "confidence": 0.30,
+    "notes": "Jul 10 (paper only, near-window). Unified perception from video diffusion transformer: depth, normals, segmentation, pose in one model. No weights released. Likely >16 GB (video DiT backbone). Monitor for weights + quantization."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "GenCeption (arxiv 2607.09024) — video DiT unified perception",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2607.09024",
+    "risk": "high",
+    "confidence": 0.30,
+    "notes": "Jul 10 (paper only). See build_depth_map_v3 GenCeption entry for details."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "PixWorld (arxiv 2607.05373) — scene-level 3D Gaussians",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2607.05373",
+    "risk": "high",
+    "confidence": 0.35,
+    "notes": "Jul 6 (paper only). Scene-level (not object-level like Hunyuan3D). 4-step distilled, ~0.6s generation. No weights. Would be a new builder, not a replacement for Hunyuan3D mesh."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "SurGe (arxiv 2605.31577) — surface geometry post-processor",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2605.31577",
+    "risk": "high",
+    "confidence": 0.40,
+    "notes": "May 2026 (paper only). Post-processor over existing depth models (e.g. DA3) adding point gradient matching for sharper normals. Best rank across 8 zero-shot benchmarks. No weights. ~2-4 GB overhead if released."
+  },
+  {
+    "method": "build_photobooth",
+    "category": "checkpoint",
+    "name": "Vera (arxiv 2607.20247) — identity-focal video generation",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2607.20247",
+    "risk": "high",
+    "confidence": 0.65,
+    "notes": "Jul 22 (IN WINDOW, paper only). Identity drift prevention for multi-person video generation. IFMS + RALA attention mechanisms. Research-stage; no weights/code. Video diffusion backbone likely >16 GB inference. Watch for Kuaishou release."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-3.0 (API-only announcement)",
+    "source": "github",
+    "url": "https://qwenimages.com/blog/qwen-image-3-release",
+    "risk": "high",
+    "confidence": 0.0,
+    "notes": "Jul 21 (IN WINDOW, API only). 4500-token prompts, 12-language text rendering, structured layouts. No open weights as of Jul 26. Monitor Qwen/Qwen-Image HF page."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "FLUX 3 Dev (Black Forest Labs — announced Jul 23, no weights)",
+    "source": "github",
+    "url": "https://venturebeat.com/technology/black-forest-labs-launches-flux-3-capable-of-generating-images-and-20-second-video-with-audio-but-in-limited-release-to-start/",
+    "risk": "high",
+    "confidence": 0.0,
+    "notes": "Jul 23 (IN WINDOW, API only). Multimodal image+video+audio from single backbone. FLUX 3 Dev open weights planned H2 2026 — no date. When Dev drops, will require broad builder updates across all image/video/Klein builders. Watch black-forest-labs HF org."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "checkpoint",
+    "name": "AVSR-Diff (arxiv 2607.00987) — scale-agnostic diffusion VSR",
+    "source": "github",
+    "url": "https://arxiv.org/abs/2607.00987",
+    "risk": "high",
+    "confidence": 0.30,
+    "notes": "Jul 1 (paper only). Arbitrary-scale VSR with temporal consistency via diffusion priors. No weights or code repository found. Low priority."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W30.md
+++ b/_dev_docs/upgrade_research/2026-W30.md
@@ -1,0 +1,140 @@
+# Spellcaster daily SOTA review — 2026-07-26
+
+ISO week: `2026-W30`. Baseline: _first run — no prior file_.
+
+> **Hardware constraint:** RTX 5060 Ti, 16 GB VRAM. Items requiring >16 GB are filtered out.
+> **Window:** July 19–26, 2026 (strict). Near-window items (July 7–18) are included and flagged.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement (if not) | Source URL | Risk | Notes |
+|--------|-----------------|-------------|----------------------|------------|------|-------|
+| `build_rembg_birefnet` | BiRefNet-general / BiRefNet-HR | **No** | Lucida (egeorcun/lucida) — BiRefNet_HR fine-tune on 52K alpha pairs across glass/VFX/illustration/camouflage | https://huggingface.co/egeorcun/lucida | low | IN WINDOW (Jul 24). Drop-in weight swap; ComfyUI-RMBG v3.1.0 already wires `BiRefNet-Lucida`. No builder code change needed. |
+| `build_txt2img` (anime/illustr.) | SDXL / Flux.2 Klein | Partially | Anima Aesthetic v1.0 — 2B DiT from Cosmos-Predict2, Qwen3-0.6B encoder | https://huggingface.co/circlestone-labs/Anima | low | IN WINDOW (Jul 24). Non-commercial license only. Does not displace Flux for photorealism. |
+| `build_klein_*` (all 15 methods) | Flux.2 Klein 4B/9B BF16 | Partially | Bonsai Ternary 4B — ternary {−1,0,+1} weights from Klein-4B; 1.21 GB disk vs 7.75 GB FP16 | https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked | low | Jun 1. Same `Flux2KleinPipeline`, Apache 2.0. Edge/low-VRAM alternative; minor quality regression accepted. |
+| `build_faceswap` / `build_faceswap_mtb` | inswapper_128.onnx (128 px crop) | No | HyperSwap 1a/1b/1c 256 (facefusion/models-3.3.0) — 2× resolution, 256 px crop | https://huggingface.co/facefusion/models-3.3.0 | medium | Jul 5 (FaceFusion 3.7.1). Models available NOW. Blocker: ComfyUI-ReActor issue #143 unmerged. Manual ONNX loader is an interim path. |
+| `build_face_restore` / `build_photo_restore` | CodeFormer + generic YOLO | Partially | ComfyUI-Forbidden-Vision — YOLO11 + custom heads (realistic/anime/NSFW) + Neural Corrector | https://github.com/luxdelux7/ComfyUI-Forbidden-Vision | low | Jul 19 commit (maintenance/batch fix). Established since Dec 2025. Apache 2.0. Better on side-profiles + occlusion vs CodeFormer. |
+| `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract` | SAM 3 (original) | Partially | SAM 3.1 (facebook/sam3.1) — ~7× faster multi-instance, global temporal reasoning | https://huggingface.co/facebook/sam3.1 | low | Mar 27, 2026. Drop-in checkpoint. Gated (Meta Research License, same as SAM3). Verify SAM3 node pack pinning. |
+| `build_wan_animate_video` | Wan 2.x I2V | Partially | Wan-Dancer-14B INT4 ConvRot — music-conditioned 14B I2V, 720p/30fps, ~14–16 GB with INT4 + CPU T5 offload | https://huggingface.co/Wan-AI/Wan-Dancer-14B | medium | Jul 13–17 (adjacent). Rhythmic/dance use case only; not general I2V. Needs ComfyUI-WanVideoWrapper support (unconfirmed as of Jul 17). |
+| `build_video_upscale` | SeedVR2 frame-batch | Partially | SparkVSR (JiongzeYu/SparkVSR) — keyframe-guided propagation via CogVideoX1.5-5B-I2V; ECCV 2026 | https://huggingface.co/JiongzeYu/SparkVSR | medium | May–Jun. ComfyUI_SparkVSR_SM node available. Complements SeedVR2 on longer clips. |
+| `build_ltx_video` | LTX-2.3 | Partially (infra) | LTX Trainer LoRA/IC-LoRA support — enables community Flux-style LoRA loading for LTX-2.3 | https://ltx.io/blog-category/product-updates | low | Jul 8 (adjacent). Not a new backbone; infrastructure to load LTX LoRAs if `build_ltx_video` doesn't already support them. |
+| `build_klein_headswap` / `build_klein_face_detail` | Klein Flux2 custom workflow | Partially | BFS Best Face Swap LoRA v3 (Alissonerdx/BFS-Best-Face-Swap) — Head V3 LoRA for Klein 9B; MIT license; 545K downloads | https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap | low | Mar 8 (background). Widely deployed in community; may already be the defacto approach users are using. |
+| `build_inpaint` / `build_outpaint` | SDXL Fill / Flux Fill | Partially | Krea 2 Turbo FP8 (AlperKTS/Krea2_FP8) — 12.9B MMDiT + Qwen3-VL; inpainting workflow documented Jul 19 | https://www.kombitz.com/2026/07/19/how-to-use-krea-2-turbo-gguf-for-inpainting-in-comfyui/ | medium | Jul 19 (workflow docs). FP8 ~12 GB, full BF16 ~28 GB. Needs comfyui-krea2-controlnet node. Monitor for stability. |
+| `build_face_restore` | CodeFormer | No (research) | IConFace (cosmicrealm/IConFace) — Klein-4B backbone + AdaFace identity embedding; reference-aware restoration | https://github.com/cosmicrealm/IConFace | high | May 2026. No ComfyUI node yet. Most significant leap over CodeFormer in identity fidelity; track for Q3 ComfyUI wrapper. |
+| `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured` | HunyuanDiT 3D 2.1 | Partially | Pixal3D (TencentARC/Pixal3D) — pixel-aligned I2→3D + PBR textures; Trellis.2 backbone; MIT license | https://huggingface.co/TencentARC/Pixal3D | medium | May 2026. No ComfyUI node pack yet. ~12–16 GB. Different approach (pixel correspondence vs. attention conditioning). |
+| `build_video_upscale` | SeedVR2 | Partially | FlashVSR v1.1 — one-step streaming VSR; CVPR 2026 best-paper; ComfyUI nodes exist (fragmented) | https://github.com/OpenImagingLab/FlashVSR | medium | Nov 2025. Three competing ComfyUI implementations; use naxci1 stable fork. |
+| `build_style_transfer` | SDXL reference-conditioning | Watch | AnyStyle (arxiv 2607.04677) — single LoRA style transfer on Flux, outperforms dual-LoRA | https://arxiv.org/abs/2607.04677 | medium | Jul 6 (paper only). Flux-native; no code release yet. 4–8 week ETA. |
+| `build_depth_map_v3` / `build_normal_map` | DA3-large / NormalCrafter | Watch | GenCeption (arxiv 2607.09024) — unified perception from video DiT backbone; depth+normals+seg in one model | https://arxiv.org/abs/2607.09024 | high | Jul 10 (paper only). >16 GB est. No weights. |
+| `build_hunyuan_3d_mesh` | Hunyuan 3D 2.1 | Watch | PixWorld (arxiv 2607.05373) — scene-level 3D Gaussians, 1000× faster than prior methods | https://arxiv.org/abs/2607.05373 | high | Jul 6 (paper only, no weights). Scene-level not object-level. |
+| `build_txt2img` (text-heavy) | Flux | Watch | Ideogram 4.0 nf4 (ideogram-ai/ideogram-4-nf4) — 9.3B DiT, 2K native, JSON prompting; ~8 GB | https://huggingface.co/ideogram-ai/ideogram-4-nf4 | medium | Jun 3. Gated + non-commercial license. Strong for typography; non-standard JSON prompt API. |
+| `build_qwen_edit` | Qwen-Image (v1) | Watch (no weights) | Qwen-Image-3.0 — API-only announcement; 4500-token prompts, 12-language text, structured layouts | https://qwenimages.com/blog/qwen-image-3-release | — | Jul 21 (API-only). No open weights. Monitor `Qwen/Qwen-Image` HF page. |
+| All image builders | Flux.2 Klein / SDXL | Watch (no weights) | FLUX 3 (Black Forest Labs) — multimodal image+video+audio; FLUX 3 Dev planned H2 2026 | https://venturebeat.com/technology/black-forest-labs-launches-flux-3 | — | Jul 23 (announced; no open weights). Watch `black-forest-labs` HF org. |
+| `build_photobooth` | Flux.2 Klein iterative | Watch (no weights) | Vera (arxiv 2607.20247) — identity-focal masked supervision + reference-aware layer attention for video | https://arxiv.org/abs/2607.20247 | high | Jul 22 (paper only). No weights/code. |
+| `build_normal_map` | NormalCrafter | Watch | SurGe (arxiv 2605.31577) — post-processor over depth models for sharper surface geometry | https://arxiv.org/abs/2605.31577 | high | May 2026 (paper only, no weights). 2–4 GB overhead on DA3 if/when released. |
+
+### No-find methods (verified, no relevant update this week)
+
+`build_inpaint_fooocus`, `build_pulid_flux`, `build_iclight` (no Flux IC-Light v2 weights released), `build_lama_remove`, `build_magic_eraser`, `build_ddcolor`, `build_color_match`, `build_klein_color_match`, `build_colorize`, `build_lut`, `build_rembg` (RMBG-2.0 current), `build_rembg_v3` (RMBG-2.0), `build_cogvideo_video`, `build_hunyuan_video`, `build_mochi_video`, `build_framepack_video`, `build_wavespeed_upscale` (Wan 2.7 rumored, unconfirmed), `build_seedvr2_video_upscale`, `build_seedv2r`, `build_wan_video`, `build_wan22_t2v`, `build_wan_flf`, `build_wan_video_blockswap`, `build_wan_video_blockswap_t2v`, `build_lumina2_txt2img`, `build_controlnet_gen`, `build_generate_anything`, `build_faceswap_model`, `build_save_face_model`, `build_faceid_img2img`, `build_detail_hallucinate`, `build_photobooth` (Vera is paper-only), `build_img2img`, `build_outpaint` (Krea 2 Turbo moved to Tier 3), `build_layer_blend`, `build_upscale`, `build_upscale_blend`, `build_frame_assembly`, `build_2d_to_sbs`, `build_normal_map` (papers only), `build_depth_map_v3` (da3_large still current), `build_sam3_extract`.
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+These items have available weights, low integration risk, and no new node pack required on top of what spellcaster already uses.
+
+### 1. Lucida — `build_rembg_birefnet`
+**What:** Fine-tune of BiRefNet_HR on 52,882 paired samples across glass/transparency, camouflage, glow/VFX, line art, illustrations.
+**Action:** Add `"BiRefNet-Lucida"` to the `build_rembg_birefnet` docstring model list. ComfyUI-RMBG v3.1.0 already resolves the name via the standard `BiRefNetRMBG` node. No workflow builder code change needed beyond the docstring update.
+**License:** MIT. **VRAM:** 6–8 GB. **Confidence:** 0.92.
+
+### 2. Anima Aesthetic v1.0 — `build_txt2img` (anime/illustration)
+**What:** 2B DiT from NVIDIA Cosmos-Predict2-2B-Text2Image. Qwen3-0.6B text encoder + Qwen-Image VAE. Native ComfyUI support via Comfy Org collaboration.
+**Action:** Add `anima` as an opt-in preset in the architecture config. Useful for illustration, anime, and non-photorealistic styles where SDXL/Flux is overkill or mismatched.
+**License:** Non-commercial only (CircleStone Labs). **VRAM:** ~8 GB. **Confidence:** 0.80.
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install or checkpoint swap)
+
+These items require either installing a new ComfyUI node pack, a checkpoint swap in an existing node pack, or wiring a new pipeline path.
+
+### 3. Bonsai Ternary 4B — all `build_klein_*` methods
+**What:** Ternary-weight distillation of Klein-4B. 1.21 GB disk footprint vs 7.75 GB FP16. Same `Flux2KleinPipeline`, Apache 2.0.
+**Action:** Expose as a selectable `klein_model_key` option (e.g., `"bonsai-4b-ternary"`). Ideal for users on <8 GB VRAM or edge deployment where quality/speed trade-off is acceptable.
+**VRAM:** ~4–6 GB. **Confidence:** 0.75.
+
+### 4. HyperSwap 256 — `build_faceswap`, `build_faceswap_model`, `build_faceswap_mtb`
+**What:** FaceFusion's new default swapper (promoted in 3.7.0). 256 px crop vs 128 px — 2× resolution, better fine detail. Three ONNX variants: 1a (fast), 1b (balanced), 1c (quality). Models at `facefusion/models-3.3.0` on HF.
+**Action:** Track ComfyUI-ReActor issue #143. As an interim, a manual ONNX loader in `build_faceswap_model` can reference `hyperswap_1a_256.onnx` directly.
+**VRAM:** ~6–10 GB (InsightFace stack + ONNX). **Confidence:** 0.90.
+
+### 5. ComfyUI-Forbidden-Vision — `build_face_restore`, `build_photo_restore`
+**What:** YOLO11 detection + custom-trained realistic/anime/NSFW heads + Neural Corrector for exposure/color. Replacement for the generic detection layer that precedes CodeFormer. Models auto-download from HuggingFace, Apache 2.0.
+**Action:** Install `ComfyUI-Forbidden-Vision` node pack; wire into the face detection loop in `build_face_restore`. Neural Corrector node addresses color bleeding that CodeFormer often introduces.
+**VRAM:** ~10 GB est. **Confidence:** 0.72.
+
+### 6. SAM 3.1 — `build_sam3_segment`, `build_sam3_mask`, `build_sam3_extract`
+**What:** Meta SAM 3.1 with Object Multiplex — ~7× faster multi-instance inference at 128 concurrent objects. Drop-in checkpoint replacement. Same gated Meta Research License as SAM3.
+**Action:** Verify whether the current SAM3 node pack auto-pulls SAM3.1 or is pinned to the original checkpoint. If pinned, update to `facebook/sam3.1`.
+**VRAM:** 8–10 GB. **Confidence:** 0.80.
+
+### 7. Wan-Dancer-14B INT4 — `build_wan_animate_video`
+**What:** Tongyi Lab 14B I2V model for rhythmic 720p/30fps dance animation from image + music input. Apache 2.0. INT4 ConvRot quantized variant (Winnougan/Wan-Dancer-14B-INT8-INT4-Convrot) allows ~14–16 GB operation with CPU T5 offload.
+**Action:** Confirm ComfyUI-WanVideoWrapper support for Dancer pipeline. Add new `animate_mode="dancer"` path in `build_wan_animate_video` once wrapper support is confirmed. Music-conditioning is a new capability not in any existing builder.
+**VRAM:** ~14–16 GB (INT4 + CPU offload, **tight**). **Confidence:** 0.72.
+
+### 8. SparkVSR — `build_video_upscale`
+**What:** Keyframe-guided video super-resolution using CogVideoX1.5-5B-I2V as motion backbone. Propagates SR from sparse keyframes across full video — handles long clips better than SeedVR2. ECCV 2026. ComfyUI_SparkVSR_SM node available.
+**Action:** Install `smthemex/ComfyUI_SparkVSR_SM`. Wire as an alternative mode in `build_video_upscale` (e.g., `upscaler="sparkvsr"`).
+**VRAM:** 10–14 GB. **Confidence:** 0.68.
+
+### 9. LTX LoRA support — `build_ltx_video`
+**What:** Lightricks shipped native video LoRA + IC-LoRA training for LTX-2.3 (Jul 8). Enables community LTX LoRAs analogous to the Wan LoRA ecosystem.
+**Action:** Verify whether `build_ltx_video` already has a LoRA injection path (like `inject_lora_chain` used elsewhere). If not, add one — the infrastructure is the same as other Flux-style builders.
+**VRAM:** No change to inference. **Confidence:** 0.62.
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+Items with either no released weights, borderline VRAM, missing ComfyUI nodes, or unstable node ecosystems.
+
+| Item | Builder target | Blocker | ETA estimate |
+|------|---------------|---------|-------------|
+| Krea 2 Turbo FP8 inpainting | `build_inpaint/outpaint` | VRAM borderline (~12 GB FP8, full pipeline may push to 16 GB+); non-standard pipeline; license unclear for Turbo | Q3 2026 when stable community quant confirmed |
+| Krea 2 Identity Edit v1.2 | `build_klein_headswap` | 14–18 GB estimate exceeds limit; no confirmed 8-bit quant | When INT8 quant path confirmed |
+| IConFace | `build_face_restore` | No ComfyUI node; Klein-4B dependency; May 2026 paper | Q3 2026 for community wrapper |
+| Pixal3D | `build_hunyuan_3d_mesh/textured` | No ComfyUI node pack yet; ~12–16 GB | Watch TencentARC/Pixal3D GitHub for ComfyUI integration |
+| FlashVSR v1.1 | `build_video_upscale` | Three fragmented node implementations; streaming interface mismatches batch approach | Wait for consolidation; use naxci1 stable fork when ready |
+| Ideogram 4.0 nf4 | `build_txt2img` | Gated + non-commercial; non-standard JSON prompt API | Evaluate for internal/non-commercial use only |
+| BFS Best Face Swap LoRA v3 | `build_klein_headswap` | Background (Mar 2026); may already be defacto community approach — verify if already in inventory | Check `_inventory/` for existing LoRA list |
+| AnyStyle (arxiv 2607.04677) | `build_style_transfer` | Paper only; code expected in 4–8 weeks | ~Aug–Sep 2026 |
+| FLUX 3 Dev | All image/video builders | No open weights; announced Jul 23; Dev planned H2 2026 | Watch `black-forest-labs` HF org |
+| Qwen-Image-3.0 | `build_qwen_edit` | API-only; no open weights | Monitor `Qwen/Qwen-Image` HF page |
+| GenCeption (arxiv 2607.09024) | `build_depth_map_v3`, `build_normal_map` | No weights; video DiT backbone likely >16 GB | Low priority until weights + quantization appear |
+| PixWorld (arxiv 2607.05373) | `build_hunyuan_3d_mesh` | No weights; scene-level (different scope from object-level Hunyuan) | Low priority |
+| SurGe (arxiv 2605.31577) | `build_normal_map` | No weights; post-processor only | Low priority |
+| Vera (arxiv 2607.20247) | `build_photobooth` | Paper only; video diffusion backbone | Low priority |
+| VisoMaster Fusion 3.8.0 | `build_faceswap` | Windows-only GUI app — not a ComfyUI node | Monitor ReF-LDM single-step diffusion pattern for future adoption |
+| AVSR-Diff (arxiv 2607.00987) | `build_video_upscale` | Paper only; no weights | Low priority |
+
+---
+
+## Summary counts
+
+| Tier | Count | Key items |
+|------|-------|-----------|
+| Tier 1 (ship soon) | 2 | Lucida, Anima Aesthetic v1.0 |
+| Tier 2 (additive, needs node install) | 7 | Bonsai 4B Ternary, HyperSwap 256, Forbidden-Vision, SAM 3.1, Wan-Dancer-14B INT4, SparkVSR, LTX LoRA infra |
+| Tier 3 (monitor) | 16 | Krea 2 Turbo, IConFace, Pixal3D, FlashVSR, FLUX 3 Dev, Qwen-Image-3.0, and more |
+| No-finds (verified) | ~38 builder methods | No relevant new models/nodes this week |
+
+---
+
+## Context note
+
+The July 19–26 window was light for open-weight releases. Both headline announcements (FLUX 3, Qwen-Image-3.0) shipped API-only. The highest-impact single item is **HyperSwap 256** (confidence 0.90) — models are available today and represent a direct upgrade to `build_faceswap` once ReActor issue #143 merges. **Lucida** is the only fully drop-in item that requires zero code change to any builder.
+
+The most strategically important watch item is **FLUX 3 Dev** — when open weights drop it will be the first multimodal image+video+audio foundation model available locally and will require broad builder updates.


### PR DESCRIPTION
## Summary

Automated daily SOTA survey for ISO week **2026-W30** (July 19–26, 2026).
First run — no prior baseline file. Surveyed ~74 `build_*` methods across 4 model families using parallel HuggingFace MCP + web research agents.

**Hardware constraint:** RTX 5060 Ti, 16 GB VRAM — items requiring more are filtered out.

---

## Findings by tier

| Tier | Count | Highlights |
|------|-------|-----------|
| **Tier 1** — Drop-in supersessions (ship soon) | 2 | Lucida BiRefNet fine-tune; Anima Aesthetic v1.0 |
| **Tier 2** — Additive / needs node-pack install | 7 | HyperSwap 256, SAM 3.1, Bonsai Ternary 4B, SparkVSR, Forbidden-Vision, Wan-Dancer-14B INT4, LTX LoRA infra |
| **Tier 3** — Monitor / not wire-ready | 16 | FLUX 3 Dev (announced, no weights), IConFace, Pixal3D, Krea 2 Turbo, FlashVSR, Qwen-Image-3.0, AnyStyle, GenCeption, … |
| **No-finds** (verified) | ~38 methods | No relevant new model or node this week |

---

## Top actions

1. **`build_rembg_birefnet`** → add `model="BiRefNet-Lucida"` to docstring. ComfyUI-RMBG v3.1.0 already wires it. Zero code change to builder. ([egeorcun/lucida](https://huggingface.co/egeorcun/lucida), confidence 0.92, Jul 24)

2. **`build_faceswap`** → track ComfyUI-ReActor issue #143 for HyperSwap 256 (256 px crop vs current 128 px). Models at [facefusion/models-3.3.0](https://huggingface.co/facefusion/models-3.3.0). Confidence 0.90.

3. **`build_sam3_segment/mask/extract`** → verify whether SAM3 node pack is pinned or auto-pulls SAM3.1 ([facebook/sam3.1](https://huggingface.co/facebook/sam3.1), ~7× faster multi-instance, Mar 27).

4. **`build_klein_*`** → Bonsai Ternary 4B is a 1.21 GB (vs 7.75 GB) drop-in Klein-4B variant for edge/low-VRAM, same pipeline, Apache 2.0. ([prism-ml/bonsai-image-ternary-4B-unpacked](https://huggingface.co/prism-ml/bonsai-image-ternary-4B-unpacked))

5. **Watch:** FLUX 3 Dev open weights (announced Jul 23, H2 2026 ETA) will require broad builder updates when they land — set a watch on `black-forest-labs` HF org.

---

## Files added

- `_dev_docs/upgrade_research/2026-W30.md` — full narrative report with findings table, tier lists, and per-item action notes
- `_dev_docs/upgrade_research/2026-W30.json` — structured records (35 entries) for programmatic consumption

---

> ⚠️ **Do not merge without human review.** This PR is the daily audit trail only — implementation upgrades require local node-pack installs that can only happen on your machine.
>
> 🔄 The local `03:30` nightly export at `tools/export_comfyui_workflows.py` will automatically refresh ComfyUI workflow snapshots — no action needed on that front.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJrkNNEWXTykgGqCMrfk8j)_