### PR TITLE
chore(research): daily SOTA review 2026-07-30

### DIFF
--- a/_dev_docs/upgrade_research/2026-W31.json
+++ b/_dev_docs/upgrade_research/2026-W31.json
@@ -1,0 +1,342 @@
+[
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 1b_256.onnx",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor/releases",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Drop-in ONNX replacement for inswapper_128.onnx. 256 px native vs 128 px. ComfyUI-ReActor v0.6.2 (Apr 25 2026). Keep inswapper as fallback. Applies equally to build_faceswap_model and build_faceswap_mtb."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image-Dev (FP8)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "8B pixel-native architecture (no VAE), MIT. FP8 fits ~10 GB VRAM. Beats FLUX.2 Dev (32B) on 5 Arena benchmarks. Single checkpoint covers txt2img + instruction edit + subject personalization. ComfyUI node: Saganaki22/HiDream_O1-ComfyUI. FP8 quant: drbaph/HiDream-O1-Image-Dev-FP8. Needs new build_hidream_txt2img / build_hidream_edit builders + hidream arch registration. Released May 2026."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "Lucida v1.3",
+    "source": "huggingface",
+    "url": "https://huggingface.co/egeorcun/lucida",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "BiRefNet fine-tune (MIT) for glass/transparency/camouflage/VFX/logos/line art. Released Jul 23 2026 (IN WINDOW). Already packaged in ComfyUI-RMBG v3.1.0 (Jul 21). Add as optional model choice alongside BiRefNet-general. GitHub: https://github.com/egeorcun/lucida"
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "FeyNoBg (Feyn Labs)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/feyninc/FeyNobg",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "263M BiRefNet-architecture, MIT. S-measure 0.981 vs BiRefNet 0.957 on UHRSD-TE. Released ~Jul 27 2026 (IN WINDOW). No confirmed ComfyUI node yet. Monitor feyninc/nobg for node release. GitHub: https://github.com/feyninc/nobg"
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "checkpoint",
+    "name": "SeedVR2-1.4B distilled",
+    "source": "huggingface",
+    "url": "https://huggingface.co/lvladikov/SeedVR2-1.4B",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "One-step distilled 1.4B from SeedVR2-7B. ~4-6 GB VRAM vs 3B's ~8 GB. Released Jul 29 2026 (IN WINDOW). int4 ComfyUI bundle also available: dummy9996/seedvr2_1.4B_3b_7b_comfyUI_int4_convrot (Jul 30). Update build_seedvr2_video_upscale default dit_model."
+  },
+  {
+    "method": "build_klein_face_detail",
+    "category": "lora",
+    "name": "Portrait Engine FLUX / KLEIN V4 LoRA",
+    "source": "civitai",
+    "url": "https://civitai.com/models/2067704/portrait-engine-flux-flux-2-klein-z-image-detailed-skin-lora",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "158 MB safetensors LoRA for Klein 9B. Jun 2026. 174 Very Positive reviews. Drop-in for skin pores, hair strands, natural lighting. No VRAM overhead. Add to curated LoRA catalogue."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "InterLCM (ICLR 2025 / NTIRE 2026 winner)",
+    "source": "github",
+    "url": "https://github.com/sen-mao/InterLCM",
+    "risk": "medium",
+    "confidence": 0.78,
+    "notes": "4-step LCM blind face restoration. Beats CodeFormer on synthetic + real-world benchmarks (NTIRE 2026 Real-World Face Restoration Challenge, CVPR 2026). Research code only; no ComfyUI node. arXiv: 2502.02215. Watch for community ComfyUI wrapper. Applies also to build_photo_restore."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "BFS Head V1 LoRA (Klein 9B FP8)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/mr2along/BFS",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "Diffusion-native head/face swap LoRA for Klein 9B, MIT. 1.7K downloads. No ONNX dependency. Excels at expressive/angled faces per community reports. Integrates into existing Klein pipeline. Prompt engineering required. Validate on held-out test set first. Also available: BFS V5 for Qwen-Image-Edit-2511 (~18-20 GB, tight on 16 GB)."
+  },
+  {
+    "method": "build_style_transfer",
+    "category": "checkpoint",
+    "name": "Krea 2 Turbo (12.9B DiT)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/krea/Krea-2-Turbo",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "12.9B DiT, community commercial license. May 2026. 8-step turbo, 2K output, aesthetic/moodboard-first generation. FP8 ~10-12 GB; BF16 ~16 GB (borderline). Needs dedicated loader. Complement to FLUX photorealism track, not a replacement."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Boogu-Image-0.1-Edit-Turbo (FP8)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "10B unified model, Apache 2.0. 4-step instruction editing + 1 reference image. FP8 ~10-12 GB. Jul 16 2026 (adjacent to window). vLLM-Omni + NPU support Jul 22-23. arXiv: 2607.13125. FP8 quant: Boogu/Boogu-Image-0.1-Turbo-fp8. License upgrade over Kontext (non-commercial). Needs ComfyUI community wrapper."
+  },
+  {
+    "method": "build_hunyuan_video",
+    "category": "checkpoint",
+    "name": "HunyuanVideo 1.5 (8.3B active)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tencent/HunyuanVideo-1.5",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "Dec 2025 release. 805K downloads, 1024 likes. 8.3B active params (smaller/faster than original 13B). 14 GB VRAM tight on 16 GB — needs offload flag. 8- or 12-step distilled. T2V + I2V. GGUF: Bn53/HunyuanVideo-1.5_I2V_720p-GGUF (Jul 24 2026). Verify if local model files need refresh or separate checkpoint."
+  },
+  {
+    "method": "build_inpaint",
+    "category": "checkpoint",
+    "name": "Qwen-Image ControlNet Inpainting",
+    "source": "huggingface",
+    "url": "https://huggingface.co/InstantX/Qwen-Image-ControlNet-Inpainting",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "Sep 2025. 2.2K downloads, 116 likes. Apache 2.0. ControlNet-based inpainting conditioned on Qwen-Image-Edit. Extends build_qwen_edit with spatial-mask guidance. Needs diffusers QwenImageControlNetInpaintPipeline adapter."
+  },
+  {
+    "method": "build_klein_img2img",
+    "category": "lora",
+    "name": "Klein 4B SDR-to-HDR LoRA",
+    "source": "huggingface",
+    "url": "https://huggingface.co/LAXMAYDAY/flux2-klein4b-sdr2hdr-logc4-lora",
+    "risk": "medium",
+    "confidence": 0.60,
+    "notes": "Klein 4B LoRA for SDR→HDR (Log C4) conversion. Tagged comfyui. Released Jul 30 2026 (IN WINDOW). GATED — requires license approval. If accessible, could enable new build_klein_sdr2hdr pipeline."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "controlnet",
+    "name": "ControlNet for ZIT",
+    "source": "huggingface",
+    "url": "https://huggingface.co/anghellia/controlnet-zit",
+    "risk": "medium",
+    "confidence": 0.50,
+    "notes": "ControlNet for Z-Image-Turbo (ZIT) architecture. Released Jul 30 2026 (IN WINDOW). 0 downloads — no community validation yet. ZIT is registered in ARCHITECTURES. Could extend build_controlnet_gen to ZIT arch. Experimental."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX 2.3 (already in stack)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-Video",
+    "risk": "low",
+    "confidence": 1.0,
+    "notes": "ALREADY IN SPELLCASTER. Confirmed from workflows.py comment: '# CANONICAL LTX 2.3 BUILDER'. No action needed. Audio generation capability (added in LTX-2.3) not yet wired into spellcaster builders — potential Tier-2 addition. 9.8M downloads, 1721 likes."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "checkpoint",
+    "name": "SeedVR2 3B FP8 (already in stack)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/SeedVR2",
+    "risk": "low",
+    "confidence": 1.0,
+    "notes": "ALREADY IN SPELLCASTER. Confirmed from build_seedvr2_video_upscale default dit_model: seedvr2_ema_3b_fp8_e4m3fn.safetensors. No action needed. The 1.4B distilled is the upgrade path (see separate entry). Note: ComfyUI v0.28.0 (Jul 15) adds native SeedVR2 node — update ComfyUI to get it."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D 2.1 (already in stack)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tencent/Hunyuan3D-2.1",
+    "risk": "low",
+    "confidence": 1.0,
+    "notes": "ALREADY IN SPELLCASTER. Confirmed from architectures.py: 'Hunyuan3D 2.1 — image-to-3D mesh, 2025/2026 (Tencent)'. PBR texture synthesis (21 GB) exceeds 16 GB budget — mesh-only path is the right choice for this hardware."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "FLUX 3 (announced, no weights)",
+    "source": "github",
+    "url": "https://www.marktechpost.com/2026/07/26/black-forest-labs-releases-flux-3-a-multimodal-flow-model-for-image-video-audio-and-robot-action-prediction/",
+    "risk": "high",
+    "confidence": 0.55,
+    "notes": "WATCH ONLY. Announced Jul 23 2026 (IN WINDOW). Black Forest Labs multimodal: image + video (20 s + audio) + audio + robot actions. API-only; open weights (FLUX 3 Dev) targeted Q4 2026+. No param count or VRAM figure disclosed. Monitor BFL announcements."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "Bernini-R 1.3B (Wan2.1 fine-tune, ByteDance)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ByteDance/Bernini-R",
+    "risk": "high",
+    "confidence": 0.60,
+    "notes": "WATCH ONLY. Jun 2 2026. 14B DiT main model (too large for 16 GB raw). 1.3B Wan2.1-based fine-tune may fit 16 GB — needs VRAM benchmarking. Apache 2.0. Video editing + identity transfer. ComfyUI node early-stage."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "BFS-Best-Face-Swap-Video V3 (IC-LoRA, LTX-2.3)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/chfm/BFS-Best-Face-Swap-Video",
+    "risk": "high",
+    "confidence": 0.55,
+    "notes": "WATCH ONLY. Video identity transfer via IC-LoRA for LTX-2.3 / Bernini-R. Persistent template workflow. Multiple HF forks Jul 9-19 2026. VRAM for 768 px video inference likely >16 GB. ComfyUI-BFSNodes: https://github.com/alisson-anjos/ComfyUI-BFSNodes — early stage."
+  },
+  {
+    "method": "build_supir",
+    "category": "checkpoint",
+    "name": "LucidFlux (FLUX.1-dev-based restoration)",
+    "source": "github",
+    "url": "https://github.com/W2GenAI-Lab/LucidFlux",
+    "risk": "high",
+    "confidence": 0.65,
+    "notes": "WATCH ONLY. ICLR 2026. Outperforms SUPIR on all tested restoration benchmarks. FLUX.1-dev backbone, caption-free. Full model ~28 GB VRAM. Community wrapper claims 8-12 GB with offloading — unconfirmed on 16 GB hardware. arXiv: 2509.22414."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Object Multiplex)",
+    "source": "github",
+    "url": "https://github.com/facebookresearch/sam3",
+    "risk": "medium",
+    "confidence": 0.70,
+    "notes": "MONITOR. Mar 27 2026. Adds Object Multiplex (multi-object joint tracking, faster, no accuracy loss). Gated HF access required. Verify which SAM3 checkpoint is currently pinned in spellcaster — original vs 3.1. If original, a weight swap is a low-effort upgrade once access granted."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "Marigold-Normals LCM",
+    "source": "huggingface",
+    "url": "https://huggingface.co/prs-eth/marigold-normals-lcm-v0-1",
+    "risk": "low",
+    "confidence": 0.68,
+    "notes": "Pre-existing opportunity (not new this week). Competitive with GeoWizard (17.400 vs 17.673 mean error) at 8x lower latency (260 ms vs 2100 ms). If current normal map estimator is GeoWizard, evaluate swapping."
+  },
+  {
+    "method": "build_colorize",
+    "category": "checkpoint",
+    "name": "ColorFLUX (CVPR 2026)",
+    "source": "arxiv",
+    "url": "https://arxiv.org/abs/2603.28162",
+    "risk": "high",
+    "confidence": 0.60,
+    "notes": "WATCH ONLY. FLUX-based colorization, structure-color decoupling + Progressive DPO. CVPR 2026 publication. No public checkpoint yet — await post-proceedings release. Would supersede DDColor if weights drop."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "FLUX.2-small-decoder (62.4M, Apache 2.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/SwinliQ-AIs/FLUX.2-small-decoder",
+    "risk": "low",
+    "confidence": 0.55,
+    "notes": "IN WINDOW (Jul 30 2026). 62.4M params fast decoder for FLUX.2 pipeline. Apache 2.0. Experimental — no community validation yet. Potential decode speed improvement for Klein/Flux2 pipelines. Needs quality comparison vs standard VAE."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "WAN 2.7 (Alibaba, ModelScope)",
+    "source": "web",
+    "url": "https://blog.comfy.org/p/wan27-is-now-available-in-comfyui",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Apr 2026. Multimodal upgrade over WAN 2.2: audio I/O, vocal timbre reference, up to 5 reference-person images, 3x3 grid image gen, improved motion dynamics. Official weights on ModelScope (Chinese CDN); community GGUF Q4/Q5 on HuggingFace (~12-14 GB, similar to WAN 2.2 14B). ComfyUI via Partner Nodes. WARNING: WAN 3.0 'Apache 2.0' claims on SEO sites are fabricated — no open weights exist. Applies equally to build_wan_t2v."
+  },
+  {
+    "method": "build_wan_dancer",
+    "category": "checkpoint",
+    "name": "Wan-Dancer-14B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI/Wan-Dancer-14B",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Apache 2.0, Jul 13 2026 (adjacent to window). Music + reference image → 720p/30fps dance video up to ~60 s. Genres: Chinese Classical, K-Pop, Street, Tap, Latin. INT4 quantized (Winnougan/Wan-Dancer-14B-INT8-INT4-Convrot) fits well within 16 GB. Official ComfyUI tutorial: docs.comfy.org/tutorials/video/wan/wan-dancer. New build_wan_dancer builder needed. New capability class not currently in stack."
+  },
+  {
+    "method": "build_longcat_avatar",
+    "category": "checkpoint",
+    "name": "LongCat Video Avatar 1.5 (Meituan)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Meituan, May 2026. 13.6B DiT, AT2V + ATI2V + continuation in one model. Whisper-Large v1.5 audio encoder. FP8 runs on 12 GB (comfortable on 16 GB). 8-step distilled. 5+ min videos with consistent lip-sync and identity. Runs via Kijai WanVideoWrapper in ComfyUI. GGUF: vantagewithai/LongCat-Video-Avatar-1.5-GGUF-ComfyUI. New build_longcat_avatar builder needed. New capability class (audio-driven talking-head avatar + long video)."
+  },
+  {
+    "method": "build_seedvr2_video_upscale",
+    "category": "checkpoint",
+    "name": "FlashVSR V1.1 (Alibaba, CVPR 2026)",
+    "source": "web",
+    "url": "https://zhuang2002.github.io/FlashVSR/",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "Real-time streaming diffusion video super-resolution, 2x/4x upscale. ~8-16 GB VRAM. ComfyUI: 1038lab/ComfyUI-FlashVSR (Full/Tiny/Tiny-Long tiers). Complementary to SeedVR2 (not a replacement): use FlashVSR for streaming/live preview, SeedVR2 for batch quality finishing. arXiv: 2510.12747. Could also be a separate build_flashvsr_upscale builder."
+  },
+  {
+    "method": "build_video_upscale",
+    "category": "node",
+    "name": "RTX VSR ComfyUI node (Comfy-Org/Nvidia_RTX_Nodes)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Official Comfy-Org repo wrapping NVIDIA VFX SDK. RTX 5060 Ti explicitly supported. ~30x faster than diffusion upscalers at a fraction of VRAM. 4 modes: VSR (compressed), High Bitrate, Denoise, Deblur. No model file download needed. Windows only. New build_rtx_vsr_upscale builder as hardware-accelerated fast path alongside SeedVR2 and FlashVSR."
+  },
+  {
+    "method": "build_ltx_camera_control",
+    "category": "lora",
+    "name": "LTX-2.3 IC-LoRA Cameraman v1/v2 (Cseti)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Cseti/LTX2.3-22B_IC-LoRA-Cameraman_v1",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "In-context LoRA adapter for LTX-2.3 22B (already in stack). Transfers camera motion (pan, tilt, dolly, zoom, orbit) from a reference video clip. Text prompts: 'new camera angle: slightly left, higher.' Released May 2026, updated Jun-Jul 2026. New build_ltx_camera_control builder needed — minimal friction since LTX-2.3 already integrated."
+  },
+  {
+    "method": "build_hunyuanvideo_foley",
+    "category": "checkpoint",
+    "name": "HunyuanVideo-Foley (Tencent)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/tencent/HunyuanVideo-Foley",
+    "risk": "medium",
+    "confidence": 0.72,
+    "notes": "WATCH / TIER 3. Tencent, Aug 2025. Video + text → synchronized Foley audio. XL model: ~16 GB with offload mode (tight on 16 GB). XXL: 20 GB / 8 GB offload. ComfyUI nodes: ComfyUI-HunyuanVideo-Foley, aistudynow/Comfyui-HunyuanFoley (low VRAM variant). New build_hunyuanvideo_foley builder needed. Audio pipeline adds new Whisper/audio dependency chain — complexity warrants Tier 3 until community validates 16 GB path."
+  },
+  {
+    "method": "build_motifvideo",
+    "category": "checkpoint",
+    "name": "Motif-Video 2B (Motif-Technologies)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Motif-Technologies/Motif-Video-2B",
+    "risk": "low",
+    "confidence": 0.70,
+    "notes": "WATCH / TIER 3. Apr 14 2026. 2B params T2V + I2V. GGUF Q4 available (Motif-Technologies/Motif-Video-2B-GGUF). SageAttention 2x speedup. Claims highest open-source VBench Total Score across spatial relationship and semantic metrics. ComfyUI: ComfyUI-MotifVideo2B. New build_motifvideo builder. Useful as ultra-fast draft generation alternative — too small to rival WAN 2.2 5B quality for final output."
+  },
+  {
+    "method": "(none — new capability)",
+    "category": "checkpoint",
+    "name": "AlayaWorld (Shanda AI Research)",
+    "source": "arxiv",
+    "url": "https://arxiv.org/abs/2607.18367",
+    "risk": "high",
+    "confidence": 0.50,
+    "notes": "WATCH ONLY. Jul 10 2026. Long-horizon (>60 s) interactive world-video with real-time camera control. Full pipeline code released mid-July. No ComfyUI node, VRAM requirements unknown (likely >16 GB). Research grade. Monitor for ComfyUI integration and VRAM benchmarks."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W31.md
+++ b/_dev_docs/upgrade_research/2026-W31.md
@@ -1,0 +1,349 @@
+# Spellcaster daily SOTA review — 2026-07-30
+
+ISO week: `2026-W31`. Baseline: *(first report — no prior file)*.
+
+Audit window: 2026-07-23 → 2026-07-30. Hardware budget: RTX 5060 Ti, 16 GB VRAM.
+Research method: 4 parallel web/HF sub-agents + direct Hugging Face MCP searches + video-specialist sub-agent.
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement (if not) | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| build_faceswap / build_faceswap_model / build_faceswap_mtb | inswapper_128.onnx (ReActor/InsightFace) | **NO** | **HyperSwap 1b_256.onnx** | https://github.com/Gourieff/ComfyUI-ReActor/releases | LOW | 256 px native vs 128 px → visibly sharper swaps. Drop-in ONNX; ComfyUI-ReActor v0.6.2 (Apr 25 2026) already ships it. Keep inswapper as fallback. No VRAM penalty on 16 GB. |
+| build_txt2img / build_img2img / build_inpaint | FLUX 1 Dev / Klein 4B / SDXL | PARTIAL | **HiDream-O1-Image-Dev (FP8)** | https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev | LOW | 8B pixel-native (no VAE), MIT. FP8 ≈10 GB. Beats FLUX.2 Dev (32B) on 5 quality benchmarks at Arena. Single checkpoint covers txt2img + instruction edit + subject personalization. ComfyUI node: Saganaki22/HiDream_O1-ComfyUI. FP8 quant: drbaph/HiDream-O1-Image-Dev-FP8. Released May 2026; actively trending July 2026. |
+| build_rembg_birefnet | BiRefNet-general | PARTIAL | **Lucida v1.3** (BiRefNet fine-tune) | https://huggingface.co/egeorcun/lucida | LOW | MIT, Jul 23 2026 (in window). Specialises in glass/transparency, camouflage, text+logos, glow/VFX — exactly where BiRefNet-general fails. Already packaged in ComfyUI-RMBG v3.1.0 (Jul 21). Add as optional mode, don't remove general. |
+| build_rembg_birefnet / build_rembg_v3 | BiRefNet-general / RMBG-2.0 | PARTIAL | **FeyNoBg** (Feyn Labs, 263M) | https://huggingface.co/feyninc/FeyNobg | LOW | MIT, ~Jul 27 2026 (in window). S-measure 0.981 vs BiRefNet 0.957 on UHRSD-TE benchmark. No confirmed ComfyUI node yet — needs wrapping. |
+| build_seedvr2_video_upscale / build_wavespeed_upscale | SeedVR2 3B FP8 (already in stack) | PARTIAL | **SeedVR2-1.4B distilled** | https://huggingface.co/lvladikov/SeedVR2-1.4B | LOW | Jul 29 2026 (in window). One-step distillation of SeedVR2-7B. ≈4–6 GB VRAM vs 3B's ≈8 GB. Much faster per-frame inference. Drop-in once model file is available locally. |
+| build_style_transfer / build_txt2img (aesthetic) | SDXL / Flux 1 Dev | PARTIAL | **Krea 2 Turbo** (12.9B DiT) | https://huggingface.co/krea/Krea-2-Turbo | LOW-MED | May 2026. FP8 ≈10–12 GB; BF16 ≈16 GB (borderline). 8-step turbo, 2K output. Aesthetic/moodboard-first generation; different strength from FLUX photorealism. Needs dedicated loader. |
+| build_qwen_edit / build_inpaint_fooocus | Flux Kontext / Qwen-Image-Edit | PARTIAL | **Boogu-Image-0.1-Edit-Turbo (FP8)** | https://huggingface.co/Boogu/Boogu-Image-0.1-Edit-Turbo | LOW-MED | Jul 16 2026. 10B unified model, Apache 2.0. 4-step instruction editing + 1 reference image. FP8 ≈10–12 GB. vLLM-Omni + NPU support added Jul 22–23. arXiv: 2607.13125. |
+| build_klein_face_detail | Flux 2 Klein 9B base | PARTIAL | **Portrait Engine FLUX/KLEIN V4 LoRA** (158 MB) | https://civitai.com/models/2067704/portrait-engine-flux-flux-2-klein-z-image-detailed-skin-lora | LOW | Jun 2026, 174 Very Positive reviews. Drop-in LoRA for any Klein-based builder. Trained at high-res for skin pores, hair strands, natural lighting. No additional VRAM cost. |
+| build_face_restore / build_photo_restore | CodeFormer | **NO** | **InterLCM** (ICLR 2025, NTIRE 2026 winner) | https://github.com/sen-mao/InterLCM | MED | 4-step LCM blind face restoration, faster and better than CodeFormer on synthetic + real-world benchmarks (NTIRE 2026 Real-World Face Restoration Challenge). Research code only; no ComfyUI node yet. |
+| build_klein_headswap / build_photobooth | Klein inpaint path | PARTIAL | **BFS Head V1 LoRA** (Klein 9B FP8) | https://huggingface.co/mr2along/BFS | MED | MIT, 1.7K downloads. Diffusion-native head/face swap, no ONNX face detector. Excels at expressive/angled faces. Klein 9B FP8 fits 16 GB; integrates into existing Klein pipeline. |
+| build_hunyuan_video | HunyuanVideo 13B (original) | PARTIAL | **HunyuanVideo 1.5** (8.3B active) | https://huggingface.co/tencent/HunyuanVideo-1.5 | MED | Dec 2025. 805K downloads, 1024 likes. 8.3B active params, 14 GB VRAM (tight — needs offload flag). 8- or 12-step distilled. T2V + I2V. GGUF: Bn53/HunyuanVideo-1.5_I2V_720p-GGUF (Jul 24 2026). Current builder targets original 13B — verify if model files need refresh or separate checkpoint. |
+| build_ltx_video | LTX 2.3 | YES (already in stack) | — | — | — | Already in stack — confirmed from workflows.py (`# CANONICAL LTX 2.3 BUILDER`). Audio generation capability (added in LTX-2.3) not yet wired into spellcaster builders — potential Tier-2 addition. |
+| build_hunyuan_3d_mesh / build_hunyuan_3d_textured | Hunyuan3D 2.1 (already in stack per architectures.py) | YES (already in stack) | — | — | — | architectures.py comment confirms "Hunyuan3D 2.1 — image-to-3D mesh, 2025/2026 (Tencent)". PBR texture model (21 GB) exceeds 16 GB budget — mesh-only path already the right choice. |
+| build_supir | SUPIR (SDXL-based) | PARTIAL | **LucidFlux** (FLUX.1-dev, ICLR 2026) | https://github.com/W2GenAI-Lab/LucidFlux | HIGH | Outperforms SUPIR on all tested restoration benchmarks. Full model ≈28 GB VRAM. Community wrapper claims 8–12 GB with offloading — unconfirmed. Skip until empirically validated on 16 GB. |
+| build_sam3_segment / build_sam3_mask / build_sam3_extract | SAM3 | YES (current) | SAM 3.1 (upgrade) | https://github.com/facebookresearch/sam3 | MED | Mar 27 2026. Adds Object Multiplex (multi-object joint tracking, faster). Gated HF access. Verify which SAM3 checkpoint is currently pinned — if original, a weight swap to 3.1 is a low-effort upgrade once access granted. |
+| build_wan_video / build_wan22_t2v / build_wan_* | WAN 2.1 / 2.2 | PARTIAL | **WAN 2.7** (Apr 2026, ModelScope) | https://blog.comfy.org/p/wan27-is-now-available-in-comfyui | MED | Multimodal upgrade: audio I/O, vocal timbre reference, up to 5 reference-person images, 3×3 grid gen, improved motion dynamics. Weights on ModelScope (China CDN); community GGUF Q4/Q5 (~12–14 GB on HF). ComfyUI via Partner Nodes. ⚠️ WAN 3.0: Confirmed NO open weights — "Apache 2.0" claims on SEO sites are fabricated spam. |
+| NEW: build_wan_dancer | (none in stack) | n/a | **Wan-Dancer-14B** | https://huggingface.co/Wan-AI/Wan-Dancer-14B | LOW | Apache 2.0, Jul 13 2026. Music + reference image → 720p/30fps dance video up to ~60 s. Genres: Chinese Classical, K-Pop, Street, Tap, Latin. INT4 quantized (Winnougan) fits well within 16 GB. Official ComfyUI tutorial at docs.comfy.org/tutorials/video/wan/wan-dancer. New capability class. |
+| NEW: build_longcat_avatar | (none in stack) | n/a | **LongCat Video Avatar 1.5** | https://huggingface.co/meituan-longcat/LongCat-Video-Avatar-1.5 | LOW | Meituan, May 2026. 13.6B DiT, AT2V + ATI2V + continuation in one model. Whisper-Large audio encoder. FP8 runs on 12 GB. 8-step distilled. 5+ min videos with consistent lip-sync. Runs via Kijai WanVideoWrapper. GGUF: vantagewithai/LongCat-Video-Avatar-1.5-GGUF-ComfyUI. New capability class (talking-head avatar). |
+| build_seedvr2_video_upscale (alt path) | SeedVR2 / frame-by-frame | GOOD | **FlashVSR V1.1** (Alibaba, CVPR 2026) | https://zhuang2002.github.io/FlashVSR/ | LOW | Real-time streaming diffusion VSR, 2x/4x upscale. ~8–16 GB VRAM. ComfyUI: 1038lab/ComfyUI-FlashVSR (Full/Tiny/Tiny-Long tiers). Complementary — use for streaming/live preview; SeedVR2 remains best for batch quality finishing. Not a replacement. |
+| build_video_upscale (hardware path, Windows only) | SeedVR2 / frame-by-frame | GOOD | **RTX VSR (Comfy-Org/Nvidia_RTX_Nodes_ComfyUI)** | https://github.com/Comfy-Org/Nvidia_RTX_Nodes_ComfyUI | LOW | RTX 5060 Ti explicitly supported. Wraps NVIDIA VFX SDK. ~30x faster than diffusion upscalers. 4 modes: VSR, High Bitrate, Denoise, Deblur. No model file download needed. Windows only. Fast-path complement to SeedVR2. |
+| NEW: build_ltx_camera_control | (none in stack; LTX-2.3 is in stack) | n/a | **LTX-2.3 IC-LoRA Cameraman v1/v2** | https://huggingface.co/Cseti/LTX2.3-22B_IC-LoRA-Cameraman_v1 | LOW | Cseti, May 2026 (active, updated Jun–Jul 2026). Transfers camera motion from reference clip to LTX-2.3 generated video. Text prompts: "new camera angle: slightly left, higher." Requires LTX-2.3 (already in stack). |
+| NEW: build_hunyuanvideo_foley | (none in stack) | n/a | **HunyuanVideo-Foley** | https://huggingface.co/tencent/HunyuanVideo-Foley | MED | Tencent, Aug 2025. Video + text → synchronized Foley audio. XL: ~16 GB with offload (tight). ComfyUI: ComfyUI-HunyuanVideo-Foley, aistudynow/Comfyui-HunyuanFoley (low VRAM variant). Audio pipeline adds new dependency chain. |
+| NEW: build_motifvideo | (none — smallest is WAN 2.2 5B) | n/a | **Motif-Video 2B** | https://huggingface.co/Motif-Technologies/Motif-Video-2B | LOW | Apr 14 2026. 2B params T2V + I2V. GGUF Q4 available. SageAttention 2x speedup. Claims highest open-source VBench Total Score. ComfyUI: ComfyUI-MotifVideo2B. Useful as fast draft generation alternative. |
+| build_txt2img / all builders (watch) | FLUX 1 Dev / Klein | WATCH | **FLUX 3** (announced Jul 23 2026) | https://www.marktechpost.com/2026/07/26/black-forest-labs-releases-flux-3-a-multimodal-flow-model-for-image-video-audio-and-robot-action-prediction/ | HIGH | Multimodal: image + video (20 s + sync audio) + audio + robot actions. Open weights (FLUX 3 Dev) planned Q4 2026 at earliest. API-only now. No VRAM figure or param count disclosed. |
+| build_video_* (new capability) | n/a | n/a | **Bernini-R 14B + 1.3B** (ByteDance, Apache 2.0) | https://huggingface.co/ByteDance/Bernini-R | HIGH | Jun 2 2026. 14B DiT video renderer + editor. Face/head identity transfer documented use case. 1.3B variant (Wan2.1-1.3B fine-tune) may fit 16 GB — needs benchmarking. ComfyUI node early-stage. |
+| build_colorize / build_ddcolor | DDColor artistic | PARTIAL | **ColorFLUX** (CVPR 2026) | https://arxiv.org/abs/2603.28162 | HIGH | FLUX-based colorization, structure-color decoupling + Progressive DPO. No public checkpoint yet — await post-CVPR release. |
+| build_normal_map | (current estimator) | PARTIAL | **Marigold-Normals LCM** | https://huggingface.co/prs-eth/marigold-normals-lcm-v0-1 | LOW | Competitive with GeoWizard (17.400 vs 17.673 mean error) at 8× lower latency (260 ms). Pre-existing opportunity; no new release this week. |
+| build_framepack_video | FramePack (HY-based) | YES | — | — | LOW | No new FramePack release in past 7 days. Stable. FramePack-P1 on roadmap but no open weights yet. |
+| build_rembg / build_rembg_v3 | rembg / RMBG-2.0 | YES | — | — | LOW | No new rembg or RMBG-2.0 update found. |
+| build_depth_map_v3 | Depth Anything V3 large | YES | — | — | LOW | DA3 (Nov 2025) still SOTA for monocular depth. No displacement found this week. |
+| build_pulid_flux | PuLID Flux v0.9.1 | YES | — | — | LOW | No new PuLID release in 2026 to date. Still current. |
+| build_faceid_img2img | IP-Adapter FaceID Plus v2 | YES (for SD scope) | — | — | LOW | No Flux-native FaceID variant appeared. PuLID remains the Flux identity answer. |
+| build_lama_remove / build_magic_eraser | LaMa / SAM3 + LaMa | YES | — | — | LOW | No new LaMa or object-removal model found this week. |
+| build_ddcolor | DDColor artistic.pth | YES (best open option) | — | — | LOW | DDColor last updated Jun 12 2026; no new version or architecture. |
+| build_mochi_video | Mochi-1 (Genmo, 10B) | YES | — | — | LOW | No new Mochi release found. |
+| build_cogvideo_video | CogVideoX | YES | — | — | LOW | No new CogVideo release found this week. |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+### 1. HyperSwap 1b_256 → build_faceswap, build_faceswap_model, build_faceswap_mtb
+**Risk: LOW** | Released: Apr 25 2026 (ComfyUI-ReActor v0.6.2)
+
+`hyperswap_1b_256.onnx` is a 256-pixel-native face swap model from FaceFusion Labs, now
+supported in ComfyUI-ReActor v0.6.2. It replaces `inswapper_128.onnx` at 2× the native
+resolution, producing visibly sharper, more detailed swaps with no VRAM overhead on a 16 GB card.
+`hififace_256.onnx` ("high fidelity faces") is an available alternative. Keep inswapper as
+a fallback — it still ships by default.
+
+**Action:** Update default `swap_model` in `build_faceswap`, `build_faceswap_model`,
+`build_faceswap_mtb` from `"inswapper_128.onnx"` to `"hyperswap_1b_256.onnx"`.
+ComfyUI-ReActor v0.6.2 must be installed.
+
+---
+
+### 2. HiDream-O1-Image-Dev → new build_hidream_txt2img / build_hidream_edit
+**Risk: LOW** | Released: May 2026 | Trending: July 2026
+
+8B pixel-native architecture (no VAE, no separate CLIP stack). MIT license. Single checkpoint
+covers text-to-image, instruction-based editing, and subject personalization. FP8 quantized
+version (`drbaph/HiDream-O1-Image-Dev-FP8`) fits ≈10 GB VRAM on RTX 5060 Ti. Beats FLUX.2
+Dev (32B) on 5 Arena quality benchmarks. ComfyUI custom nodes exist
+(`Saganaki22/HiDream_O1-ComfyUI`). Architecturally distinct from existing FLUX/Klein stack —
+does not share loaders or nodes.
+
+**Action:** Add `build_hidream_txt2img` and `build_hidream_edit` builders using the HiDream
+ComfyUI node pack. Register `"hidream"` in architectures.py.
+
+---
+
+### 3. Lucida v1.3 → add mode to build_rembg_birefnet
+**Risk: LOW** | Released: Jul 23 2026 (in window)
+
+BiRefNet fine-tune (MIT) for glass/transparency, camouflage, text overlays, glow/VFX, and
+line art — exactly the failure cases of BiRefNet-general. Already distributed via
+ComfyUI-RMBG v3.1.0 (Jul 21 2026). Zero additional node installation required if RMBG node
+pack is updated.
+
+**Action:** Update ComfyUI-RMBG to v3.1.0+. Add `"Lucida"` as an optional model choice in
+`build_rembg_birefnet` alongside the existing `"BiRefNet-general"` default.
+
+---
+
+### 4. SeedVR2-1.4B distilled → update build_seedvr2_video_upscale default
+**Risk: LOW** | Released: Jul 29 2026 (in window)
+
+`lvladikov/SeedVR2-1.4B` is a one-step distilled 1.4B variant of SeedVR2-7B
+(knowledge-distilled; same quality target). Estimated ≈4–6 GB VRAM vs ≈8 GB for 3B FP8.
+Single-step inference = dramatically faster per-frame throughput. The int4 ComfyUI bundle
+(`dummy9996/seedvr2_1.4B_3b_7b_comfyUI_int4_convrot`, updated Jul 30) packages all three
+sizes (1.4B, 3B, 7B) as convrot int4 — usable as-is in ComfyUI without repackaging.
+
+**Action:** Add `"seedvr2_ema_1.4b_fp8.safetensors"` (or equivalent model name once confirmed)
+as the new `dit_model` default in `build_seedvr2_video_upscale`, keeping 3B as a fallback.
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+### 5. WAN 2.7 → upgrade path for build_wan22_t2v / build_wan_t2v
+**Risk: MED (weights on ModelScope only; GGUF path unvalidated on 16 GB)** | Released: Apr 2026
+
+WAN 2.7 (Alibaba) is a multimodal upgrade over WAN 2.2: adds audio input/output, vocal timbre
+reference, up to 5 reference-person images, 3×3 grid image generation, improved motion
+dynamics and stylization. Official weights distributed via ModelScope (Chinese CDN, requires
+account). Community GGUF Q4/Q5 builds are available on HuggingFace (~12–14 GB, similar to
+WAN 2.2 14B footprint). Available in ComfyUI via Partner Nodes.
+
+⚠️ **WAN 3.0 status:** Multiple SEO sites falsely claim open-weight "Apache 2.0" WAN 3.0 releases.
+All are fabricated. No open weights confirmed. Monitor only the Wan-AI HuggingFace org.
+
+**Action:** Evaluate community GGUF Q4 builds on 16 GB. If viable, update `build_wan22_t2v`
+to use WAN 2.7 weights. New audio conditioning path requires code changes.
+
+---
+
+### 6. FeyNoBg → new mode in build_rembg_birefnet / build_rembg_v3
+**Risk: LOW-MED (no ComfyUI node yet)** | Released: ~Jul 27 2026 (in window)
+
+Feyn Labs' 263M BiRefNet-architecture model, new SOTA on UHRSD-TE benchmark (S-measure
+0.981 vs BiRefNet 0.957). MIT. No confirmed ComfyUI node as of this audit; integration
+requires wrapping inference.
+
+**Action:** Monitor `feyninc/nobg` for a ComfyUI node. If none in 30 days, evaluate wrapping.
+
+---
+
+### 7. Portrait Engine FLUX / KLEIN V4 LoRA → enhance build_klein_face_detail
+**Risk: LOW** | Released: Jun 2026
+
+158 MB safetensors LoRA for Klein 9B (and Flux 2). 174 "Very Positive" Civitai reviews.
+Trained at high-res for skin pores, hair strands, natural lighting response. Drop-in for any
+Klein-based builder with no additional VRAM overhead.
+
+**Action:** Add LoRA path to the curated LoRA catalogue; expose in `build_klein_face_detail`
+as an optional `lora_skin_detail` parameter.
+
+---
+
+### 8. Boogu-Image-0.1-Edit-Turbo (FP8) → complement build_qwen_edit
+**Risk: LOW-MED** | Released: Jul 16 2026 (adjacent to window)
+
+10B unified model (Apache 2.0). 4-step Turbo instruction editing + 1 reference image. FP8
+(`Boogu/Boogu-Image-0.1-Turbo-fp8`) ≈10–12 GB. vLLM-Omni + NPU support added Jul 22–23
+2026. arXiv: 2607.13125. License upgrade over Flux Kontext (non-commercial). Needs dedicated
+inference nodes not yet in Comfy-Org.
+
+**Action:** Evaluate as alternative or complement to `build_qwen_edit`. Watch for ComfyUI
+community wrapper.
+
+---
+
+### 9. Krea 2 Turbo → new build_krea2_txt2img or enhance build_style_transfer
+**Risk: LOW-MED** | Released: May 2026
+
+12.9B DiT, community commercial license, LoRA fine-tuning supported. 8-step Turbo, 2K
+output, moodboard/aesthetic-first generation. FP8 ≈10–12 GB; BF16 ≈16 GB (borderline on
+RTX 5060 Ti — test before committing). Not a FLUX drop-in; needs dedicated loader.
+
+**Action:** Evaluate as a `build_style_transfer` backend with aesthetic tuning distinct from
+FLUX's photorealism track.
+
+---
+
+### 10. BFS Head V1 LoRA (Klein 9B FP8) → complement build_klein_headswap
+**Risk: MED** | Source: mr2along/BFS on HF (MIT, 1.7K downloads)
+
+Diffusion-native head/face swap LoRA. No ONNX face detector required. Prompts drive the swap.
+Community reports it exceeds inswapper on expressive/angled faces. Klein 9B FP8 fits 16 GB;
+integrates directly into the existing Klein pipeline.
+
+**Action:** Validate on a held-out test set before exposing to users. Prompt engineering
+required. Add as optional mode in `build_klein_headswap`.
+
+---
+
+### 11. HunyuanVideo 1.5 → update build_hunyuan_video
+**Risk: MED** | Released: Dec 2025 (805K DL, 1024 likes; inference providers: fal-ai, wavespeed)
+
+Current builder docstring reads "HunyuanVideo (Tencent 13B)" referencing the original (Dec
+2024) release. HunyuanVideo 1.5 is 8.3B active (smaller and faster), runs at 14 GB VRAM
+(tight on 16 GB — needs offload flag), with 8- or 12-step distilled inference for improved
+I2V quality. GGUF quantized variant available (`Bn53/HunyuanVideo-1.5_I2V_720p-GGUF`,
+Jul 24 2026). Verify whether local model files need refresh or a separate checkpoint.
+
+---
+
+### 12. FLUX.2-small-decoder (62.4M) → optional fast decode for Klein/Flux2
+**Risk: LOW-MED** | Released: Jul 30 2026 (in window)
+
+`SwinliQ-AIs/FLUX.2-small-decoder` — 62.4M parameters, Apache 2.0. Tagged as a complement
+to the standard FLUX.2 VAE decoder. Potential speed improvement for decode-heavy Klein
+pipelines. Experimental — needs empirical quality comparison.
+
+---
+
+### 13. Qwen-Image ControlNet Inpainting → extend build_qwen_edit
+**Risk: MED** | Source: InstantX/Qwen-Image-ControlNet-Inpainting (Sep 2025, 2.2K DL, 116 likes)
+
+ControlNet-based inpainting conditioned on Qwen-Image-Edit. Apache 2.0. Extends the current
+`build_qwen_edit` with spatial-mask guidance for precise region editing.
+
+---
+
+### 14. Klein 4B SDR→HDR LoRA → new build_klein_sdr2hdr
+**Risk: MED (gated)** | Released: Jul 30 2026 (in window)
+
+`LAXMAYDAY/flux2-klein4b-sdr2hdr-logc4-lora` — Klein 4B LoRA for SDR→HDR (Log C4) color
+space conversion. Tagged for ComfyUI. Gated — requires license approval. If accessible,
+could enable a new `build_klein_sdr2hdr` pipeline.
+
+---
+
+### 15. ControlNet for ZIT → extend build_controlnet_gen with ZIT arch
+**Risk: MED (brand new, no community validation)** | Released: Jul 30 2026 (in window)
+
+`anghellia/controlnet-zit` — ControlNet for Z-Image-Turbo architecture (ZIT is registered in
+spellcaster's ARCHITECTURES). No downloads yet; experimental.
+
+---
+
+### 16. Wan-Dancer-14B → new build_wan_dancer
+**Risk: LOW** | Released: Jul 13 2026 (adjacent to window)
+
+Open-weight (Apache 2.0) music-to-dance video model. Reference image + audio track → 720p/30fps
+dance video up to ~60 s. Genres: Chinese Classical, K-Pop, Street, Tap, Latin. INT4 quantized
+builds (`Winnougan/Wan-Dancer-14B-INT8-INT4-Convrot`) fit well within 16 GB. Official ComfyUI
+tutorial available at docs.comfy.org/tutorials/video/wan/wan-dancer. Entirely new capability
+class not currently in the stack.
+
+**Action:** Implement `build_wan_dancer` builder once node pack is validated. Start from the
+official ComfyUI tutorial workflow.
+
+---
+
+### 17. LongCat Video Avatar 1.5 → new build_longcat_avatar
+**Risk: LOW** | Released: Meituan, May 2026
+
+13.6B DiT supporting AT2V (audio+text→video), ATI2V (audio+text+image→video), and video
+continuation in one checkpoint. Whisper-Large audio encoder for lip-sync. FP8 checkpoint
+fits 12 GB (comfortable on 16 GB). 8-step distilled inference. Can generate 5+ minute videos
+with consistent lip-sync and identity preservation. Runs via Kijai's WanVideoWrapper in
+ComfyUI. GGUF builds available (`vantagewithai/LongCat-Video-Avatar-1.5-GGUF-ComfyUI`).
+New capability class (audio-driven talking-head avatar + long-form video).
+
+**Action:** Implement `build_longcat_avatar` builder using WanVideoWrapper. New dependency:
+Whisper-Large audio encoder.
+
+---
+
+### 18. FlashVSR V1.1 → additive fast-path complement to build_seedvr2_video_upscale
+**Risk: LOW** | Alibaba / CVPR 2026
+
+Real-time streaming diffusion video super-resolution, 2x/4x upscale. ~8–16 GB VRAM.
+ComfyUI: `1038lab/ComfyUI-FlashVSR` with three quality tiers (Full, Tiny, Tiny-Long).
+Complementary to SeedVR2 (not a replacement): FlashVSR is best for streaming/live preview
+while SeedVR2 remains the quality-first batch upscaler.
+
+**Action:** Add FlashVSR as an optional fast-path in `build_seedvr2_video_upscale` or a
+separate `build_flashvsr_upscale` builder. Install `1038lab/ComfyUI-FlashVSR`.
+
+---
+
+### 19. RTX VSR ComfyUI node → hardware-accelerated upscale path (Windows)
+**Risk: LOW** | Source: Comfy-Org/Nvidia_RTX_Nodes_ComfyUI
+
+Wraps NVIDIA VFX SDK for hardware tensor-core upscaling. ~30x faster than diffusion upscalers
+at a fraction of VRAM. RTX 5060 Ti explicitly supported. Four modes: VSR (compressed content),
+High Bitrate, Denoise, Deblur. No model file download required. Official Comfy-Org repository.
+**Windows only.**
+
+**Action:** Add `build_rtx_vsr_upscale` builder as a Windows-only hardware-accelerated
+alternative path alongside SeedVR2 and FlashVSR.
+
+---
+
+### 20. LTX-2.3 IC-LoRA Cameraman → new build_ltx_camera_control
+**Risk: LOW (LTX-2.3 already in stack)** | Released: Cseti, May 2026 (active, updated Jun–Jul 2026)
+
+In-context LoRA adapter that transfers camera motion (pan, tilt, dolly, zoom, orbit) from a
+reference video clip to LTX-2.3 generated video. Accepts text prompts ("new camera angle:
+slightly left, higher"). Since LTX-2.3 is already integrated in spellcaster, this is a
+near-zero-friction addition — no new model architecture required.
+
+**Action:** Implement `build_ltx_camera_control` builder layering IC-LoRA Cameraman v2 on
+the existing LTX-2.3 node graph.
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+| Item | Reason not ready | When to revisit |
+|---|---|---|
+| **FLUX 3** (BFL, Jul 23 2026) | No open weights; API-only. Dev weights "Q4 2026 at earliest." | On open-weight release announcement |
+| **InterLCM** (face restore, ICLR 2025 / NTIRE 2026 winner) | Research code only; no ComfyUI node. Beats CodeFormer on all benchmarks. | If a community ComfyUI wrapper appears |
+| **BFS-Best-Face-Swap-Video V3** (IC-LoRA for LTX video headswap) | VRAM requirements at 768 px likely exceed 16 GB. ComfyUI-BFSNodes early-stage. | When VRAM benchmarks for 16 GB cards appear |
+| **Bernini-R 1.3B** (ByteDance, Wan2.1 fine-tune) | Needs direct VRAM benchmarking on 16 GB; ComfyUI node early-stage. | When ComfyUI support confirmed + VRAM validated |
+| **LucidFlux** (beats SUPIR) | Full model ≈28 GB; offloading claim unconfirmed at 16 GB. | When community confirms 16 GB viability |
+| **SAM 3.1** (Object Multiplex) | Gated HF access. Only viable once access granted. | On HF access approval |
+| **ColorFLUX** (CVPR 2026 colorization) | No public weights. Await post-CVPR release. | On weight release |
+| **Hunyuan3D-3.0** | No open weights confirmed; announced only via marketing. | On confirmed open-weight release |
+| **SeedVR2 v2.5 modular** (4-node system) | Workflow migration needed; GGUF 7B on 8 GB is attractive. | On community validation of node stability |
+| **DiffusionGemma 26B** (Google, Jun 2026) | 25.8B params, no ComfyUI native nodes. | If a Comfy-native loader + int4 quant appears |
+| **Sasori Klein 9B TQ3P** | Novel quantization format; needs Sasori runner in ComfyUI. | On ComfyUI-Sasori node release |
+| **HunyuanVideo-Foley** (Tencent, Aug 2025) | Video → Foley audio. XL model tight at 16 GB with offload; audio dependency chain adds complexity. | On community validation of 16 GB path + when audio output is a stated user need |
+| **Motif-Video 2B** (Motif-Technologies, Apr 2026) | 2B T2V/I2V with GGUF; too small to rival WAN 2.2 5B quality in most tests. Useful mainly as an ultra-fast draft tool. | If VBench community benchmarks confirm quality parity at low settings |
+| **AlayaWorld** (Shanda AI, Jul 10 2026) | Long-horizon interactive world video. Full pipeline code released but no ComfyUI node; VRAM unknown (likely >16 GB). Research grade. | If ComfyUI integration appears |
+
+---
+
+## No-finds (verified)
+
+All of the following were explicitly searched and NOT found to have new releases in the Jul 23–30 window (or at all in 2026 where indicated):
+
+- **WAN 3.0 / next-gen WAN**: ⚠️ **Confirmed no open weights.** Multiple "Apache 2.0" WAN 3.0 links are fabricated SEO spam. No Wan-AI org upload on HuggingFace. WAN 2.7 (ModelScope + community GGUF Q4) is the real current ceiling.
+- **ReActor v2 / inswapper successor**: HyperSwap is the upgrade path; no new "inswapper 2" family.
+- **CodeFormer update or successor (ready)**: InterLCM supersedes it in quality but has no ComfyUI node.
+- **PuLID v1.0**: Stuck at v0.9.1; no 2026 release found.
+- **DDColor update**: Last updated Jun 12 2026; no new architecture.
+- **BiRefNet v2/v3**: Still at v1 (May 2024); repo active but no checkpoint push this week.
+- **FramePack major update**: Nothing in past 7 days; stable. FramePack-P1 on roadmap but no open weights.
+- **Seedance 2.5** (ByteDance, Jun 2026): Confirmed proprietary cloud only (Jimeng/Dreamina/CapCut/Volcano APIs). Requires H100 cluster. No local path.
+- **LTX 2.3**: ✅ ALREADY IN SPELLCASTER (confirmed from workflows.py `# CANONICAL LTX 2.3 BUILDER`).
+- **SeedVR2 3B FP8**: ✅ ALREADY IN SPELLCASTER (confirmed from `build_seedvr2_video_upscale`, dit_model default).
+- **Hunyuan3D 2.1**: ✅ ALREADY IN SPELLCASTER (confirmed from architectures.py).
+- **Hunyuan3D-Omni**: Sep 2025 release; not new this week. Not yet integrated.
+- **InstantID**: Maintenance-only mode since Apr 2025; deprioritized.
+- **Mochi update**: No new release.
+- **CogVideo update**: No new release.
+- **New SUPIR version**: No update.
+- **New LaMa / object-removal model**: No update.
+
+---
+
+*Generated by automated daily SOTA review agent. All implementation upgrades require local node-pack installs on the user's machine. The nightly export at `tools/export_comfyui_workflows.py` (local cron, 03:30) refreshes ComfyUI workflow snapshots automatically.*


### PR DESCRIPTION
## Summary

Automated daily SOTA audit for ISO week **2026-W31** (2026-07-23 → 2026-07-30).
Hardware budget: RTX 5060 Ti, 16 GB VRAM.
Files added: `_dev_docs/upgrade_research/2026-W31.md` (human report) + `_dev_docs/upgrade_research/2026-W31.json` (34 structured records).

| Tier | Count | Description |
|---|---|---|
| **Tier 1** — drop-in supersessions (ship soon) | 4 | HyperSwap 1b_256, HiDream-O1 FP8, Lucida v1.3 BiRefNet, SeedVR2-1.4B distilled |
| **Tier 2** — additive new builders | 16 | WAN 2.7 GGUF, Wan-Dancer-14B, LongCat Avatar 1.5, FlashVSR V1.1, RTX VSR node, LTX Cameraman LoRA, HunyuanVideo 1.5, FeyNoBg, Portrait Engine LoRA, Boogu Edit Turbo, Krea 2 Turbo, BFS Head LoRA, FLUX.2-small-decoder, Qwen ControlNet Inpaint, Klein SDR→HDR LoRA, ZIT ControlNet |
| **Tier 3** — monitor / not wire-ready | 14 | FLUX 3, InterLCM, BFS Video, Bernini-R 1.3B, LucidFlux, SAM 3.1, ColorFLUX, Hunyuan3D-3.0, SeedVR2 v2.5, DiffusionGemma 26B, Sasori TQ3P, HunyuanVideo-Foley, Motif-Video 2B, AlayaWorld |
| **Already in stack** | 3 | LTX 2.3 ✅, SeedVR2 3B FP8 ✅, Hunyuan3D 2.1 ✅ |
| **No-finds / confirmed closed** | 2 notable | WAN 3.0 ⚠️ (fabricated open-weight claims — all SEO spam), Seedance 2.5 (proprietary cloud only) |

### Tier 1 highlights

**HyperSwap 1b_256** (`build_faceswap*`) — Drop-in ONNX for ComfyUI-ReActor v0.6.2. 256 px native vs 128 px, no VRAM overhead. Change `swap_model` default; keep inswapper as fallback.

**HiDream-O1-Image-Dev FP8** — 8B pixel-native (no VAE), MIT license, ~10 GB VRAM. Beats FLUX.2 Dev (32B) on 5 Arena benchmarks. Needs new `build_hidream_txt2img` / `build_hidream_edit` builders + `hidream` arch registration.

**Lucida v1.3** — BiRefNet fine-tune (MIT, in-window Jul 23) for glass/transparency/VFX failures. Already in ComfyUI-RMBG v3.1.0. Add as optional mode in `build_rembg_birefnet`.

**SeedVR2-1.4B distilled** — One-step distillation (in-window Jul 29), ~4–6 GB VRAM vs 3B's ~8 GB. int4 bundle updated Jul 30. Update default `dit_model` in `build_seedvr2_video_upscale`.

### New capability classes in Tier 2

- **Wan-Dancer-14B** (Apache 2.0, Jul 13) — music-to-dance video, INT4 fits 16 GB, official ComfyUI tutorial available.
- **LongCat Video Avatar 1.5** (May 2026) — audio-driven talking-head + 5+ min long-form video, FP8 = 12 GB, WanVideoWrapper in ComfyUI.
- **LTX-2.3 IC-LoRA Cameraman** — camera motion transfer LoRA; near-zero friction since LTX-2.3 is already in stack.
- **FlashVSR V1.1 + RTX VSR node** — complementary fast-path upscalers alongside SeedVR2; RTX VSR requires no model download (Windows only).

---

> **Do not merge** — leave open for human review. All upgrades require local node-pack installs on the user's machine.
> The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh the ComfyUI workflow snapshots automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNK75m16KLfDFgNWR34aRt)_