### PR TITLE
chore(research): daily SOTA review 2026-08-03

### DIFF
--- a/_dev_docs/upgrade_research/2026-W32.json
+++ b/_dev_docs/upgrade_research/2026-W32.json
@@ -1,0 +1,222 @@
+[
+  {
+    "method": "build_txt2img",
+    "category": "model",
+    "name": "Mage-Flow 4B (microsoft / Comfy-Org/Mage-Flow)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/Mage-Flow",
+    "risk": "high",
+    "confidence": 0.92,
+    "notes": "Microsoft Research 4B NR-MMDiT + Mage-VAE architecture, MIT license. Released July 22 2026; ComfyUI native support in v0.29.0 (July 29 — within 7-day window). Beats FLUX.2 on GenEval (0.90 vs 0.87). INT8-ConvRot variant ~9-12 GB VRAM on RTX 5060 Ti. Entirely new architecture — not drop-in for Klein/FLUX2 node graphs; high integration effort. Paper: arxiv:2607.19064. 82K downloads. Also relevant: build_img2img, build_generate_anything."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "model",
+    "name": "Mage-Flow-Edit 4B (microsoft/Mage-Flow-Edit)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/microsoft/Mage-Flow-Edit",
+    "risk": "high",
+    "confidence": 0.90,
+    "notes": "Instruction-guided image editing variant of Mage-Flow (same NR-MMDiT backbone). MIT license. Released July 22, ComfyUI native v0.29.0 (July 29). Turbo 4-step: 1.02 s/edit at 1024px. Accepts up to 3 reference images + text. INT8 ~9-12 GB VRAM. 5× smaller than current Qwen-Image 20B backbone; closest direct alternative. New architecture — needs new pipeline wiring in Spellcaster."
+  },
+  {
+    "method": "new_builder",
+    "category": "model",
+    "name": "MiniMax H3 FL2VA + Ref2VA (Comfy-Org/MiniMax-H3)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/MiniMax-H3",
+    "risk": "high",
+    "confidence": 0.91,
+    "notes": "Open weights released August 3 2026 (today) under MiniMax H3 Community License. ComfyUI v0.29.2 (API partner node July 31) + v0.30.0 (open-weight native Aug 3). FL2VA: text-to-video + first/last-frame I2V; Ref2VA: reference-based video. Up to 2K, 15s per clip, native stereo audio. VRAM: 12 GB minimum for 480p (RTX 3060); 16 GB handles 720p with layerwise offload and FP8/INT8 convrot; 2K needs 24 GB+. Blackwell NVFP4 quant: lilcheaty/MiniMax-H3-NVFP4. New capability class — no current Spellcaster builder produces video+audio. Two potential new builders: build_minimax_h3_video (T2V) + build_minimax_h3_flf (first/last-frame)."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "controlnet",
+    "name": "Uni3C ControlNet for WAN (ComfyUI v0.29.0 native, July 29)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "ComfyUI v0.29.0 (July 29, within window) adds native WanUni3CControlnetApply node (PR CORE-365). Checkpoint: Wan21_Uni3C_controlnet_fp16.safetensors (~2 GB) at Kijai/WanVideo_comfy. Enables camera-motion transfer and 3D-referenced video on all WAN variants. Additive overlay on existing WAN pipeline — ~2 GB additional VRAM, fits 16 GB budget. Applies to build_wan_video, build_wan22_t2v, build_wan_flf, build_wan_animate_video, build_wan_video_blockswap."
+  },
+  {
+    "method": "new_builder",
+    "category": "model",
+    "name": "Wan-Dancer-14B (Wan-AI/Wan-Dancer-14B)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI/Wan-Dancer-14B",
+    "risk": "medium",
+    "confidence": 0.92,
+    "notes": "Released July 13 2026 (outside 7-day window; not in W22 baseline). Apache 2.0. Music + reference image → 720p/30fps dance video up to 1 minute. Hierarchical audio-driven framework. 4.4K downloads. Comfy-Org FP8 weights: wan2.2_dancer_14b_global_fp8_scaled.safetensors. GGUF Q3_K_M–Q6_K also available. RTX 5060 Ti 16 GB handles 720p with FP8 + T5 CPU offload (24 GB system RAM needed). Official ComfyUI workflow at docs.comfy.org/tutorials/video/wan/wan-dancer. arxiv:2607.09581. New builder: build_wan_dancer_video."
+  },
+  {
+    "method": "new_builder",
+    "category": "model",
+    "name": "ID-V2V: Identity-Preserving Video Restylization (Eyeline-Labs/ID-V2V)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Eyeline-Labs/ID-V2V",
+    "risk": "high",
+    "confidence": 0.90,
+    "notes": "Released July 29 2026 (within window). Apache 2.0. SIGGRAPH Asia 2026 paper (arXiv:2607.22830). Preserves facial identity/expressions/gaze/motion while completely restyling scene/lighting from a style keyframe. Built on Wan2.1-I2V-14B-720P + VACE control. Full weights ~96 GB. Kijai int8-convrot: Kijai/Wan_ID_V2V_comfy (July 29). ComfyUI support requires PR #15139 to merge. VRAM: int8-convrot potentially runnable at 16 GB with CPU offload — not yet benchmarked. New builder class: build_id_v2v."
+  },
+  {
+    "method": "new_builder",
+    "category": "node_pack",
+    "name": "Kijai/Wan_ID_V2V_comfy — int8-convrot weights for ID-V2V",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/Wan_ID_V2V_comfy",
+    "risk": "high",
+    "confidence": 0.88,
+    "notes": "Published July 29 2026 (within window). ComfyUI-optimized int8-convrot quantized weights for Eyeline-Labs ID-V2V. Companion to Eyeline-Labs/ID-V2V. Requires ComfyUI PR #15139. Paired item — see ID-V2V entry above."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 INT8-distilled-convrot (SimpleTuner/ltxvideo-2.3-distilled-convrot-int8)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/SimpleTuner/ltxvideo-2.3-distilled-convrot-int8",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Released July 29 2026 (within window). Community (not official Lightricks) INT8-convrot distilled version of LTX-2.3 (22B, March 2026 base). 3K downloads. Potentially makes LTX-2.3 runnable at 16 GB VRAM — previously blocked. LTX-2.3 also generates native audio alongside video. Benchmark fidelity vs current 2B LTX-Video baseline before switching. Tags: ltx-2.3, int8, convrot, sdnq, audio-video."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Anima Base/Turbo/Aesthetic v1 (circlestone-labs/Anima)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/circlestone-labs/Anima",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "2B anime/illustration T2I model (Cosmos-Predict2 FT), Qwen-3 0.6B text encoder + Qwen-Image VAE. Aesthetic/Turbo variants July 24; ComfyUI native v0.29.0 July 29 (within window). ~8 GB VRAM. 3.5M downloads, 1997 HF likes. Turbo is 4-step. NICHE: anime/illustration only — not photorealistic. Additive to build_txt2img or build_style_transfer for illustration use cases."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "model",
+    "name": "JoyAI-Image-Edit-Plus (jdopensource/JoyAI-Image-Edit-Plus-Diffusers)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/jdopensource/JoyAI-Image-Edit-Plus-Diffusers",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "JD.com 16.3B multi-image instruction-guided editing model. Apache 2.0. Uses Qwen3-VL-8B encoder — same family as current build_qwen_edit backbone. Comfy-Org native support July 20, in ComfyUI v0.29.0. BF16 ~24 GB VRAM; INT8 needed for 16 GB. Evaluate after Mage-Flow-Edit (lighter, MIT). Paper: arxiv:2605.04128."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "model",
+    "name": "BiRefNet Lucida fine-tune (egeorcun/lucida v1.3)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/egeorcun/lucida",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "BiRefNet_HR fine-tune for transparency/glass, camouflage, text+logos, VFX glow, illustration edges. v1.3 July 23 2026. MIT license. 220.7M params. Now in Comfy-Org/BiRefNet (updated July 14) and ComfyUI-RMBG v3.1.0 (July 21) as drop-in 'BiRefNet-Lucida' selector option. Drop-in extra option for build_rembg_birefnet — expose as model parameter alongside existing BiRefNet-general/BiRefNet-portrait variants."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "model",
+    "name": "FLUX 3 (Black Forest Labs — watch item)",
+    "source": "other",
+    "url": "https://bfl.ai/models/flux-3",
+    "risk": "high",
+    "confidence": 0.60,
+    "notes": "BFL announced FLUX 3 on July 23 2026. Unified multimodal architecture (image + video up to 20s + audio). FLUX 3 Image and open-weight FLUX 3 Dev NOT yet released as of Aug 3 2026 — API-gated video only. When FLUX 3 Dev ships, likely successor to Klein backbone for build_txt2img and build_klein_*. Zero confidence for VRAM estimate until weights are public. High-priority watch item."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "node_pack",
+    "name": "FaceFusion 3.8.0 — video pipeline update",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion/releases/tag/3.8.0",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Released July 31 2026 (within window). VIDEO PIPELINE changes only: FFmpeg-based video manager, AV1 codec, --workflow-strategy, alpha channel, HDR color fix. NO new face swap models. Face swap models (HyperSwap 1a/1b/1c_256.onnx) unchanged — these are already available in ComfyUI-ReActor. Reference only; no Spellcaster action needed."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "lora",
+    "name": "BFS-Best-Face-Swap LoRA series (Alissonerdx, v5 head / v1 face)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Alissonerdx/BFS-Best-Face-Swap",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "July 30 2026 README update (within window) — no new model files; documentation only. The underlying LoRA series (Head V1–V5, Face V1) is the dominant Klein Flux2 9B face/head-swap LoRA (581K downloads). Head V5 (5500+ steps, Qwen-Image 2511 optimized) is most capable. If build_klein_headswap is not yet using BFS, this is a low-risk additive enhancement. LoRA weight: 0.75–0.85 recommended. This week's touch is README-only."
+  },
+  {
+    "method": "build_faceid_img2img",
+    "category": "lora",
+    "name": "krea2-identity-edit v1.2 (conradlocke)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/conradlocke/krea2-identity-edit",
+    "risk": "high",
+    "confidence": 0.82,
+    "notes": "v1.2 released July 29 2026 (within window). 602 HF likes. Identity-preserving instruction-editing LoRA for Krea 2 Raw backbone (NOT Klein Flux2). Re-stages people with face likeness preserved across new poses/angles; two-input edits (scene ref + person ref). Requires Krea 2 Raw checkpoint and ComfyUI-Krea2Edit node pack (github.com/lbouaraba/comfyui-krea2edit). High risk for Spellcaster because it needs a separate backbone; not drop-in for current Klein stack. Monitor if Krea 2 integration is ever planned."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "Wan 2.7 — NOT open-source",
+    "source": "other",
+    "url": "",
+    "risk": "low",
+    "confidence": 0.98,
+    "notes": "VERIFIED NO-FIND. Wan 2.7 shipped April 22 2026 as API-only. Official Wan-AI org on HuggingFace publishes weights only up to Wan 2.2. Any 'Wan 2.7 Apache 2.0' claims on SEO sites are fabricated. Wan 2.2 remains the most recent open-weight Wan backbone. No action for Spellcaster."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "model",
+    "name": "HyperSwap 1a/1b/1c_256.onnx — already known W22",
+    "source": "github",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Already known — W22 (T1-D). Status: unimplemented as of this review. No new developments in 7-day window. ComfyUI-ReActor issues #183/#226 (black artifacts, broken output) remain open. Test hyperswap_1c before switching from inswapper_128 as default."
+  },
+  {
+    "method": "build_klein_headswap",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2 (iFayens) — already known W22",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Already known — W22 (T1-A). Status: unimplemented. sipie800 fork still discontinued. No new v0.6.x release in 7-day window. Migration still required. Also relevant: build_klein_face_detail, build_faceid_img2img, build_pulid_flux."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "BiRefNet native ComfyUI (Comfy-Org/BiRefNet) — already known W22",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/new-open-source-models-now-in-comfyui",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Already known — W22 (T1-B). Status: unimplemented. BiRefNet Lucida (row 11 in findings table, new this week) adds additional value on top of this item."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "MoGe-2 (Ruicheng/moge-2-vitl-normal) — already known W22",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Ruicheng/moge-2-vitl-normal",
+    "risk": "low",
+    "confidence": 0.91,
+    "notes": "Already known — W22 (T1-C). Status: unimplemented. No competing normal-map model released in 7-day window. Still the recommended upgrade for build_normal_map."
+  },
+  {
+    "method": "build_inpaint",
+    "category": "checkpoint",
+    "name": "FLUX.1 Kontext [dev] — already known W22",
+    "source": "huggingface",
+    "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Already known — W22 (T2-A). Status: unimplemented. No new Kontext release in window. FLUX 3 (Tier 3) may eventually supersede Kontext, but current recommendation stands. Also relevant: build_img2img, build_style_transfer."
+  },
+  {
+    "method": "build_wan_video",
+    "category": "checkpoint",
+    "name": "Kijai/WanVideo_comfy_nvfp4 — already known W22",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy_nvfp4",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Already known — W22 (T2-C). Status: unimplemented. Verify ComfyUI-WanVideoWrapper GH issue #1888 loader support status before deploying. Blackwell-native NVFP4 format."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W32.md
+++ b/_dev_docs/upgrade_research/2026-W32.md
@@ -1,0 +1,231 @@
+# Spellcaster daily SOTA review — 2026-08-03
+
+ISO week: `2026-W32`. Baseline: `2026-W22` (2026-05-29).
+
+Research window: 2026-07-27 → 2026-08-03 (primary).  
+Gap coverage: 2026-05-29 → 2026-07-27 where items are newly relevant.  
+Hardware budget: RTX 5060 Ti, 16 GB VRAM.  
+All 73 `build_*` methods audited across four families.
+
+> **Note on gap:** No SOTA review ran between W22 (2026-05-29) and today (W32). Items from the W22 punch lists are flagged `Already known — W22` in the Notes column. Items discovered in the 2026-05-29 → 2026-07-27 gap that are actionable for Spellcaster are surfaced under Tier 2/3.
+
+---
+
+## Findings table
+
+| # | Method(s) | Current backbone | Still SOTA? | Replacement / upgrade | Source URL | Risk | Notes |
+|---|-----------|-----------------|-------------|----------------------|------------|------|-------|
+| 1 | build_txt2img · build_img2img · build_generate_anything | FLUX2/Klein (4B/9B) | ⚠️ Upgrade avail | **Mage-Flow 4B** (Microsoft, MIT, NR-MMDiT; ComfyUI native v0.29.0, July 29) | https://huggingface.co/Comfy-Org/Mage-Flow | High | 7-day window. INT8 variant ~9-12 GB VRAM. Beats FLUX.2 on GenEval (0.90 vs 0.87). Entirely new architecture — not drop-in for Klein nodes. |
+| 2 | build_qwen_edit | Qwen-Image 20B | ⚠️ Strong alternative | **Mage-Flow-Edit 4B** (Microsoft, MIT; ComfyUI native v0.29.0, July 29) | https://huggingface.co/microsoft/Mage-Flow-Edit | High | 7-day window. Same NR-MMDiT backbone, instruction-guided editing. Turbo 4-step: 1.02 s/edit at 1024px. New architecture — needs new pipeline wiring. |
+| 3 | new_builder | — | N/A (additive) | **MiniMax H3 (Hailuo 3.0)**: video + native stereo audio, up to 2K, 15s (open weights Aug 3, day-0 ComfyUI) | https://huggingface.co/Comfy-Org/MiniMax-H3 | Medium | **In window (today).** Min 12 GB VRAM for 480p; 16 GB usable for 720p with layerwise offload. FL2VA (T2V + first/last-frame) + Ref2VA (reference-based). |
+| 4 | build_txt2img · build_style_transfer | SDXL/Flux LoRA | ✅ Additive | **Anima 2B** anime/illustration (Cosmos-Predict2 FT; ComfyUI v0.29.0 July 29) | https://huggingface.co/circlestone-labs/Anima | Medium | 7-day window (Aesthetic/Turbo variants July 24 → native v0.29.0 July 29). ~8 GB VRAM; 3.5M downloads. Niche: anime/illustration; not photorealistic. |
+| 5 | build_wan_flf · build_wan_video | Wan 2.2 | ✅ Additive (new capability) | **MiniMax H3 FL2VA** first-last-frame I2V + audio (Aug 3) | https://huggingface.co/Comfy-Org/MiniMax-H3 | Medium | 7-day window. Same checkpoint as row 3 but specifically the FL2VA first/last-frame conditioning path parallels build_wan_flf. |
+| 6 | build_qwen_edit | Qwen-Image 20B | ⚠️ Upgrade avail | **JoyAI-Image-Edit-Plus** (JD.com, 16.3B, Apache 2.0; Comfy-Org support July 20) | https://huggingface.co/jdopensource/JoyAI-Image-Edit-Plus-Diffusers | Medium | Near 7-day window (Comfy-Org updated July 20). Uses Qwen3-VL-8B encoder — closer architectural fit to current build_qwen_edit. BF16 ~24 GB; INT8 needed for 16 GB VRAM. |
+| 7 | new_builder | — | N/A (additive) | **Wan-Dancer-14B** (Wan-AI/Alibaba, Apache 2.0; July 13): music+image→dance video, 720p/30fps | https://huggingface.co/Wan-AI/Wan-Dancer-14B | Medium | Gap (July 13). 4.4K downloads. FP8 weights from Comfy-Org. 16 GB VRAM feasible with FP8+T5 offload at 720p. Official ComfyUI docs tutorial available. |
+| 8 | build_txt2img · build_klein_* | Flux2/Klein | ⚠️ Monitor | **FLUX 3** (BFL, July 23): multimodal image+video+audio; API-only, no open weights yet | https://bfl.ai/models/flux-3 | High | Gap (July 23). FLUX 3 Dev (open weights) planned later 2026. When available, likely successor to Klein backbone. |
+| 9 | build_rembg_birefnet | BiRefNet base | ✅ Additive | **BiRefNet Lucida** fine-tune (MIT, July 21 → ComfyUI-RMBG v3.1.0): transparent/camouflage/text targets | https://huggingface.co/egeorcun/lucida | Low | Near window (July 21). Drop-in extra option in existing ComfyUI-RMBG node selector; update node pack to v3.1.0. |
+| 10 | new_builder (video identity) | — | N/A (additive) | **ID-V2V** (Eyeline-Labs/Netflix, July 29, Apache 2.0): identity-preserving video restylization; Wan2.1-I2V-14B-720P base | https://huggingface.co/Eyeline-Labs/ID-V2V | High | 7-day window. SIGGRAPH Asia 2026 paper (arXiv:2607.22830). Kijai int8 convrot weights: Kijai/Wan_ID_V2V_comfy. Full: 96 GB; int8 convrot dramatically smaller. ComfyUI PR #15139. |
+| 11 | build_wan_video · build_wan22_t2v · build_wan_flf · build_wan_animate_video | Wan 2.1/2.2 | ✅ Additive | **Uni3C ControlNet for WAN** — camera motion transfer, native ComfyUI v0.29.0 (July 29) | https://huggingface.co/Kijai/WanVideo_comfy | Low | 7-day window. WanUni3CControlnetApply node. ~2 GB checkpoint. Adds camera control to all existing WAN builders. Applies across 4+ methods. |
+| 12 | build_ltx_video | LTX-Video 0.9.x (2B) | ⚠️ Upgrade avail | **LTX-2.3 INT8-convrot quant** (SimpleTuner, July 29): first INT8 path for 22B LTX-2.3 within 16 GB VRAM | https://huggingface.co/SimpleTuner/ltxvideo-2.3-distilled-convrot-int8 | Medium | 7-day window. Community (not official Lightricks) INT8 distilled. 3K downloads. Potentially unblocks LTX-2.3 on 16 GB VRAM. Test fidelity vs current 2B baseline before switching. |
+| 10 | build_inpaint · build_img2img · build_style_transfer | SDXL/Flux ControlNet | Already known — W22 | FLUX.1 Kontext [dev] (T2-A W22) | https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev | Low | Already known — W22. Status: unimplemented. |
+| 11 | build_klein_headswap · build_faceid_img2img · build_pulid_flux | sipie800 fork (discontinued) | Already known — W22 | PuLID-Flux2 v0.6.2 migration (T1-A W22) | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Low | Already known — W22. Status: unimplemented. sipie800 fork still discontinued. |
+| 12 | build_rembg_birefnet | BiRefNet custom node | Already known — W22 | BiRefNet native ComfyUI (T1-B W22) | https://huggingface.co/Comfy-Org/BiRefNet | Low | Already known — W22. Status: unimplemented. Also see row 9 (Lucida adds value on top). |
+| 13 | build_normal_map | custom backbone | Already known — W22 | MoGe-2 (T1-C W22) | https://huggingface.co/Ruicheng/moge-2-vitl-normal | Low | Already known — W22. Status: unimplemented. No new competing model in window. |
+| 14 | build_faceswap · build_faceswap_model | InSwapper 128 | Already known — W22 | HyperSwap 256 ONNX (T1-D W22) | https://github.com/Gourieff/ComfyUI-ReActor | Low | Already known — W22. Status: unimplemented. No new face-swap model found in 7-day window. |
+| 15 | build_wan22_t2v | Wan 2.2-TI2V-5B | ✅ Yes | — | — | Low | **Wan 2.7 is NOT open-source** (API-only). Wan 2.2 remains the most recent open-weight Wan backbone. |
+| 16 | build_wan_video · build_wan_video_blockswap | Kijai WanVideo FP8 | Already known — W22 | Kijai NVFP4 (T2-C W22) | https://huggingface.co/Kijai/WanVideo_comfy_nvfp4 | Medium | Already known — W22. Status: unimplemented. Verify GH WanVideoWrapper issue #1888 before deploying. |
+| 17 | build_supir | SUPIR (SDXL-based) | ✅ Yes | — | — | Low | No SUPIR update in window or gap. |
+| 18 | build_depth_map_v3 | Depth Anything v3 | ✅ Yes | — | — | Low | No new depth model in window. |
+| 19 | build_sam3_segment · build_sam3_mask · build_sam3_extract | SAM 3 | ✅ Yes | — | — | Low | No update in window. SAM 3.1 (March 2026) tracking-only; segmentation quality unchanged. |
+| 20 | build_hunyuan_3d_mesh · build_hunyuan_3d_textured | HunyuanDiT 3D | ✅ Yes (for now) | Hunyuan3D 3.1 is API-only — no public weights | — | Low | No open-weight 3D improvement in window. |
+| 21 | build_ltx_video | LTX-Video 0.9.x (2B) | ✅ Yes | — | — | Low | LTX-2 (22B, Jan 2026) exceeds 16 GB VRAM — hard skip. No smaller official update in window. |
+| 22 | build_hunyuan_video | HunyuanVideo | ✅ Yes | — | — | Low | No update in window. |
+| 23 | build_mochi_video | Mochi | ✅ Yes | — | — | Low | No update in window. |
+| 24 | build_cogvideo_video | CogVideo | ✅ Yes | — | — | Low | No update in window. |
+| 25 | build_framepack_video | FramePack | ✅ Yes | — | — | Low | No v2 or successor found in window. |
+| 26 | build_seedvr2_video_upscale · build_wavespeed_upscale | SeedVR2 | ✅ Yes | — | — | Low | No update in window. |
+| 27 | build_face_restore · build_photo_restore | CodeFormer/GFPGAN | ✅ Yes | — | — | Low | No new face restore model in window. NTIRE 2026 winners still not public. |
+| 28 | build_ddcolor | DDColor artistic | ✅ Yes | — | — | Low | No update in window. |
+| 29 | build_rembg_v3 | RMBG-2.0 | ✅ Yes | — | — | Low | No update in window. |
+| 30 | build_iclight | IC-Light | ✅ Yes | — | — | Low | No update in window. |
+| 31 | build_lama_remove | LaMa | ✅ Yes | — | — | Low | No update in window. |
+| 32 | build_colorize | DDColor / BigColor | ✅ Yes | — | — | Low | No update in window. |
+| 33 | build_upscale · build_upscale_blend | 4x-UltraSharp.pth | ✅ Yes | — | — | Low | No new ESRGAN SR model in window. |
+| 34 | build_video_upscale | frame SR | ✅ Yes | — | — | Low | No update in window. |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+### T1-A · BiRefNet Lucida — add transparent/camouflage option to build_rembg_birefnet
+
+**Affected:** `build_rembg_birefnet`
+
+`egeorcun/lucida` (MIT, v1.3 July 23, 2026) is a BiRefNet_HR fine-tune optimized for transparency, camouflage, text/logos, VFX glow, and illustration edges — the exact failure cases of the standard BiRefNet base. ComfyUI-RMBG v3.1.0 (July 21) already wires it as a drop-in selector option (`BiRefNet-Lucida`). No code changes needed to `workflows.py`; update the node pack and add `BiRefNet-Lucida` to the model dropdown in `build_rembg_birefnet` as an optional override.
+
+**Action:** `pip install --upgrade ComfyUI-RMBG` (or ComfyUI Manager update); download `egeorcun/lucida → birefnet_lucida.safetensors`; expose as `build_rembg_birefnet(model="lucida")` option.  
+**Source:** https://huggingface.co/egeorcun/lucida | https://github.com/1038lab/ComfyUI-RMBG  
+**Risk:** Low
+
+### T1-B · ComfyUI version bump to v0.29.0/0.29.2 — unlocks Mage-Flow, JoyAI, Anima, MiniMax H3
+
+**Affected:** `build_qwen_edit`, `build_txt2img`, any new builders for MiniMax H3 and Wan-Dancer
+
+ComfyUI v0.29.0 (July 29) adds native node support for Mage-Flow, Mage-Flow-Edit, JoyAI-Image-Edit, and Anima — without any custom node installs. v0.29.2 (July 31) adds MiniMax H3 video model support. This is a single ComfyUI update that unlocks all Tier 2 items in this report.
+
+**Action:** Update ComfyUI to ≥ v0.29.2.  
+**Risk:** Low (ComfyUI minor version bump; test existing workflows after update)
+
+---
+
+## Tier 2 — Additive new builders (needs new workflow wiring after local node/model install)
+
+### T2-A · Mage-Flow-Edit — potential upgrade for build_qwen_edit
+
+**Affected:** `build_qwen_edit`; secondarily `build_img2img`, `build_inpaint`
+
+Microsoft Research released Mage-Flow (4B NR-MMDiT + Mage-VAE architecture, MIT license) on July 22, 2026; the editing variant Mage-Flow-Edit landed with ComfyUI native support in v0.29.0 (July 29). At 4B parameters it is 5× smaller than the current Qwen-Image 20B backbone, with an INT8 quantization path fitting ~9–12 GB VRAM on the RTX 5060 Ti.
+
+Benchmarks: matches or exceeds FLUX.2 on GenEval (0.90 vs 0.87). Editing Turbo variant: 1.02 s/edit at 1024px. Accepts up to 3 reference images + text instruction.
+
+**Caveats:** This is an entirely new architecture (NR-MMDiT + Mage-VAE) — not drop-in for current Klein/FLUX2 nodes. Wiring a `build_mageflow_edit` workflow requires configuring the new UNETLoader, the Mage-VAE, and the conditioning scheme from scratch. Recommend a focused prototyping sprint before committing.
+
+**Action:** Update ComfyUI to ≥ v0.29.0; download `Comfy-Org/Mage-Flow` repackaged weights; build new `build_mageflow_edit` workflow alongside existing `build_qwen_edit` (do not replace yet).  
+**Source:** https://huggingface.co/Comfy-Org/Mage-Flow | https://huggingface.co/microsoft/Mage-Flow-Edit  
+**Risk:** High (new architecture, no existing Spellcaster node mapping)
+
+---
+
+### T2-B · MiniMax H3 — new video+audio builder
+
+**Affected:** New builder (no current equivalent in Spellcaster)
+
+MiniMax H3 (Hailuo 3.0) open weights published **today** (August 3, 2026) under MiniMax H3 Community License. One unified transformer that generates video with native stereo audio up to 2K, 15 seconds in a single pass. Two checkpoints in `Comfy-Org/MiniMax-H3`:
+- **FL2VA**: text-to-video + first/last-frame I2V (parallels `build_wan_flf`)
+- **Ref2VA**: reference-image-guided generation
+
+Minimum tested: RTX 3060 12 GB → 480p in ~9 min (20 steps). RTX 5060 Ti 16 GB → 720p feasible with layerwise offload + FP8 quantization.
+
+Community NVFP4 quant already available: `lilcheaty/MiniMax-H3-NVFP4` (for Blackwell RTX 50xx native FP4).
+
+**Action:** Update ComfyUI to ≥ v0.29.2 (adds MiniMax H3 nodes); download Comfy-Org/MiniMax-H3 checkpoints; wire two new builders: `build_minimax_h3_video` (T2V via FL2VA) and `build_minimax_h3_flf` (first/last-frame via FL2VA).  
+**Source:** https://huggingface.co/Comfy-Org/MiniMax-H3  
+**Risk:** Medium (16 GB borderline for 720p, very slow for 2K; audio output is genuinely new capability)
+
+---
+
+### T2-C · Wan-Dancer-14B — new music-to-dance video builder
+
+**Affected:** New builder (no current equivalent in Spellcaster)
+
+Wan-AI (Alibaba) released Wan-Dancer-14B on July 13, 2026 under Apache 2.0. Hierarchical audio-driven framework: input = reference image + music → output = 720p/30fps dance video up to 1 minute, temporally coherent. Supports Chinese Classical, K-Pop, Street, Tap, and Latin genres.
+
+Hardware: 14B parameter model. Comfy-Org FP8 weights available (`wan2.2_dancer_14b_global_fp8_scaled.safetensors`); GGUF quantizations at Q3_K_M–Q6_K also available. RTX 5060 Ti 16 GB handles 720p at FP8 with T5 CPU offload. System RAM: 24 GB minimum for T5 offload.
+
+Official ComfyUI workflow docs: https://docs.comfy.org/tutorials/video/wan/wan-dancer  
+HuggingFace: 4.4K downloads; arxiv:2607.09581.
+
+**Action:** Download Comfy-Org FP8 Wan-Dancer weights; install ComfyUI-WanVideoWrapper (Kijai) if not already present; wire new `build_wan_dancer_video` builder following official docs workflow.  
+**Source:** https://huggingface.co/Wan-AI/Wan-Dancer-14B  
+**Risk:** Medium (14B model, T5 offload required for 16 GB VRAM, 24 GB system RAM needed)
+
+---
+
+### T2-E · ID-V2V — new video identity-restylization builder
+
+**Affected:** New builder (no current equivalent in Spellcaster)
+
+Eyeline-Labs (backed by Netflix) released ID-V2V on July 29, 2026 under Apache 2.0. Given a source video and one or more stylized keyframes, it re-skins scene lighting, environment, and aesthetic while precisely preserving character facial identity, expressions, gaze, and body motion. Paper: SIGGRAPH Asia 2026 (arXiv:2607.22830).
+
+Built on Wan2.1-I2V-14B-720P. Full weights ~96 GB (multi-GPU environment). Kijai published int8-convrot quantized weights at `Kijai/Wan_ID_V2V_comfy` (July 29) — substantially reduced footprint, potentially runnable in 16 GB with CPU offload. Requires ComfyUI core PR #15139 (VACE + I2V reference support) to be merged first.
+
+**Action:** Monitor PR #15139 merge into ComfyUI core; then download `Kijai/Wan_ID_V2V_comfy` int8 weights; wire new `build_id_v2v` builder.  
+**Source:** https://huggingface.co/Eyeline-Labs/ID-V2V | https://huggingface.co/Kijai/Wan_ID_V2V_comfy  
+**Risk:** High (96 GB full model; int8 not yet benchmarked on 16 GB; depends on un-merged PR)
+
+---
+
+### T2-F · Uni3C ControlNet for WAN — add camera-control to existing WAN builders
+
+**Affected:** `build_wan_video`, `build_wan22_t2v`, `build_wan_flf`, `build_wan_animate_video`, `build_wan_video_blockswap`
+
+ComfyUI v0.29.0 (July 29) adds native `WanUni3CControlnetApply` node (PR CORE-365). Checkpoint `Wan21_Uni3C_controlnet_fp16.safetensors` (~2 GB) is hosted at `Kijai/WanVideo_comfy`. Enables camera-motion transfer and 3D-referenced video generation layered on top of existing WAN pipelines. Adds ~2 GB to the existing WAN model VRAM footprint — well within the 16 GB budget.
+
+**Action:** Update ComfyUI to ≥ v0.29.0; download `Wan21_Uni3C_controlnet_fp16.safetensors` into `models/wan_controlnets/`; inject `WanUni3CControlnetApply` node between the WAN model load and the sampler in affected builders.  
+**Source:** https://huggingface.co/Kijai/WanVideo_comfy  
+**Risk:** Low
+
+---
+
+### T2-D · JoyAI-Image-Edit-Plus — closer architectural alternative for build_qwen_edit
+
+**Affected:** `build_qwen_edit`
+
+JD.com open-source 16.3B instruction-guided editing model (Apache 2.0, June 23; Comfy-Org native support July 20). Uses Qwen3-VL-8B-Instruct as encoder — the same encoder family as the current `build_qwen_edit` backbone — making this architecturally closer to a drop-in upgrade than Mage-Flow-Edit.
+
+**Caveat:** 16.3B BF16 requires ~24 GB VRAM; an INT8 community quantization is needed for the RTX 5060 Ti 16 GB. ComfyUI support exists in v0.29.0. Treat as "evaluate after Mage-Flow-Edit" since Mage-Flow-Edit is lighter.
+
+**Source:** https://huggingface.co/jdopensource/JoyAI-Image-Edit-Plus-Diffusers  
+**Risk:** Medium (VRAM borderline without INT8; needs quantization testing)
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Target method | Blocker | Revisit trigger |
+|------|--------------|---------|-----------------|
+| FLUX 3 (BFL, July 23, 2026) | build_txt2img / build_klein_* succession | API-only, no open weights; FLUX 3 Dev "planned for later 2026" | Open-weight FLUX 3 Dev model card appears on HuggingFace |
+| Wan 3.0 (Alibaba, expected ~Aug 6, 2026) | build_wan_video / build_wan22_t2v | Not yet released (rumored Aug 6); MoE 14B active — VRAM TBD | Official Wan-AI release on HuggingFace / ModelScope |
+| Mage-Flow base (Microsoft, July 22) | build_txt2img | New architecture, high integration effort; evaluate edit path first | Successful Mage-Flow-Edit prototype in Spellcaster |
+| Anima Base v1 (animation/anime) | build_txt2img | Niche (anime/illustration only); not photorealistic | User demand signal for anime/illustration T2I |
+| JoyAI-Image-Edit-Plus INT8 quant | build_qwen_edit | Needs INT8 quantization for 16 GB VRAM | Community INT8 quant appears on HuggingFace |
+| Boogu-Image-0.1 (JD.com / tysto1727, July 24, 10B) | build_txt2img / build_img2img | Custom diffusers BooguImagePipeline — high integration effort; low community uptake (2.1K downloads) | Community validates quality vs Mage-Flow on photorealistic benchmarks |
+| LTX-2.3 INT8-convrot quant (SimpleTuner, July 29) | build_ltx_video | Community (not official Lightricks) distilled quant; fidelity vs current 2B baseline untested | Benchmark INT8-convrot vs current LTX-Video 2B on Spellcaster outputs |
+| krea2-identity-edit v1.2 (conradlocke, July 29, 602 likes) | build_faceid_img2img | Uses Krea 2 Raw backbone (not Klein Flux2) — parallel approach, not drop-in | If Spellcaster ever adds Krea 2 support |
+| ID-V2V (Eyeline-Labs/Netflix, July 29) | new_builder (video identity) | Requires ComfyUI PR #15139 to merge; full weights 96 GB; Kijai int8 not benchmarked on 16 GB | PR #15139 merged into ComfyUI main + Kijai int8 tested on 16 GB |
+| FaceFusion 3.8.0 (July 31) | build_faceswap (pipeline) | Video pipeline update only — no new face models | n/a (pipeline reference only) |
+| Qwen-Image-2.0 (Alibaba, Feb 2026) | build_qwen_edit | Weights not yet confirmed public (closed API so far); 7B successor to 20B | Official Qwen HF weight card with Apache-2.0 / similar |
+| Hunyuan3D 3.1 (Tencent) | build_hunyuan_3d_mesh / build_hunyuan_3d_textured | API-only; no public weights | Open-source HuggingFace release |
+| NTIRE 2026 face restoration winners | build_face_restore / build_photo_restore | Winning weights still not public | github.com/jkwang28/NTIRE2026_RealWorld_Face_Restoration publishes safetensors |
+| Cosmos 3 Nano (NVIDIA) | build_wan_video / build_hunyuan_video | 16B BF16 requires ~32 GB VRAM — hard skip for RTX 5060 Ti 16 GB | Available at FP4/INT8 quant with confirmed 16 GB compatibility |
+| MiniMax M3 (428B LLM) | N/A | Not an image/video gen model; LLM context only | N/A |
+| Kimi K3 (2.8T MoE LLM, July 27) | N/A | Not an image/video gen model | N/A |
+
+---
+
+## No-finds (verified)
+
+The following current Spellcaster backbones were actively searched — no superseding release or substantive update found in the 7-day window:
+
+| Method | Backbone | Verified via |
+|--------|---------|--------------|
+| build_faceswap (new model) | ReActor + InSwapper/HyperSwap | Web + GitHub; no new face-swap model in 7-day window |
+| build_face_restore | CodeFormer/GFPGAN | No update in window; PMRF mirror-upload (July 27) is not new capability |
+| build_supir | SUPIR (SDXL-based) | No update since May 2026 |
+| build_depth_map_v3 | Depth Anything v3 | No new checkpoint in window |
+| build_hunyuan_3d_mesh / textured | HunyuanDiT 3D | 3.1 API-only, no open weights |
+| build_rembg | rembg (u2net) | catrex-lite (July 28) is 4.6M params, unvalidated student upload — not production |
+| build_rembg_v3 | RMBG-2.0 | No update in window |
+| build_sam3_* | SAM 3 | No new checkpoint or ComfyUI node update in window |
+| build_ddcolor | DDColor | No update |
+| build_iclight | IC-Light | No update |
+| build_lama_remove | LaMa | No update |
+| build_colorize | DDColor / BigColor | No update |
+| build_hunyuan_video | HunyuanVideo | No update |
+| build_mochi_video | Mochi | No update |
+| build_cogvideo_video | CogVideo | No update |
+| build_framepack_video | FramePack | No v2 found |
+| build_ltx_video | LTX-Video 0.9.x 2B | LTX-2 (22B) exceeds 16 GB VRAM; no smaller official update |
+| build_seedvr2_video_upscale | SeedVR2 | No update in window |
+| build_wavespeed_upscale | WaveSpeed | No update |
+| build_upscale / build_upscale_blend | 4x-UltraSharp + ESRGAN | No new SR model |
+| build_video_upscale | frame SR | No update |
+| build_color_match / build_klein_color_match | color-match utility | No new backbone |
+| build_lut | LUT grading | No relevant releases |
+| build_normal_map | MoGe-2 (T1-C W22 — pending) | No competing model released |
+| build_wan22_t2v / build_wan_video | Wan 2.2 | Wan 2.7 is API-ONLY — NOT open weights. Wan 2.2 remains current. |
+| build_wan_video_blockswap | Wan 2.1/2.2 blockswap | No update |
+
+---
+
+*Generated by Spellcaster daily SOTA review agent. Nightly workflow snapshots are refreshed automatically by `tools/export_comfyui_workflows.py` at 03:30 local time — no manual snapshot action needed after local node-pack installs.*


### PR DESCRIPTION
## What does this change?

Adds `_dev_docs/upgrade_research/2026-W32.md` and `2026-W32.json` — the automated daily SOTA research report for 2026-08-03. Baseline: `2026-W22` (2026-05-29). This is the first review since the W22 gap; 73 `build_*` methods audited.

## Type of change

- [x] Docs only

## Checklist

- [x] **No personal data in the diff.** No real IPs, no `C:\Users\...` paths, no email addresses, no tokens.
- [x] **No NSFW content in the public repo.**
- [x] **`spellcaster_core/` stays in sync.** Docs-only change; no spellcaster_core edits.
- [x] **New ComfyUI custom nodes are declared.** Research report only — no implementation.
- [x] **New GIMP procedures are registered.** Research report only — no implementation.
- [x] **Tested locally.** Research document; no code to test.

## Test plan

Human review only. Do not merge until the Tier-1 and Tier-2 items have been vetted against a running ComfyUI + RTX 5060 Ti 16 GB setup.

---

## Findings summary

| Tier | Count | Items |
|------|-------|-------|
| Tier 1 — Drop-in (ship soon) | 2 | BiRefNet Lucida option (ComfyUI-RMBG v3.1.0); ComfyUI upgrade to v0.29.2 |
| Tier 2 — Additive new builders | 6 | Mage-Flow-Edit, MiniMax H3 (video+audio), ID-V2V (video identity), Wan-Dancer-14B, Uni3C ControlNet for WAN, JoyAI-Image-Edit-Plus |
| Tier 3 — Monitor | 9 | FLUX 3, Wan 3.0, Mage-Flow base, LTX-2.3 INT8 quant, krea2-identity-edit v1.2, Boogu-Image-0.1, Hunyuan3D 3.1, NTIRE 2026, Cosmos 3 Nano |
| Already known (W22, unimplemented) | 5 | PuLID-Flux2 migration, BiRefNet native, MoGe-2, HyperSwap 256, FLUX.1 Kontext dev |
| No-finds | 20 | See full table in report |

### Tier-1 highlights (do first)

**T1-A · BiRefNet Lucida** (`build_rembg_birefnet`): BiRefNet fine-tune for transparent/camouflage objects now available as a drop-in selector in ComfyUI-RMBG v3.1.0. Update node pack + download `egeorcun/lucida` weights. Low risk.

**T1-B · ComfyUI v0.29.0/0.29.2 version bump**: unlocks Mage-Flow, JoyAI-Image-Edit, Anima, and MiniMax H3 native nodes without any custom node installs. Low risk.

### Tier-2 highlights (schedule)

**T2-A · Mage-Flow-Edit 4B** (`build_qwen_edit`): Microsoft Research MIT-licensed 4B editing model; INT8 variant ~9-12 GB VRAM. ComfyUI native v0.29.0. 5× smaller than current Qwen-Image 20B but new architecture — needs new workflow wiring.

**T2-B · MiniMax H3** (new builder): Open weights today (Aug 3). Video + native stereo audio up to 2K/15s. FL2VA + Ref2VA checkpoints. 16 GB VRAM handles 720p with layerwise offload.

**T2-C · Wan-Dancer-14B** (new builder): Music + reference image → 720p/30fps dance video. Apache 2.0. FP8 Comfy-Org weights. 16 GB VRAM with FP8 + T5 CPU offload.

**T2-D · ID-V2V** (new builder, watch): Identity-preserving video restylization (Netflix/Eyeline-Labs, SIGGRAPH Asia 2026). Wan2.1-I2V-14B base; Kijai int8-convrot weights available. Pending ComfyUI PR #15139 merge.

**T2-E · Uni3C ControlNet for WAN** (`build_wan_video` and 4 others): Camera-motion transfer layered on all existing WAN builders. ~2 GB checkpoint, native ComfyUI v0.29.0 node. Low risk additive.

### Notable no-find: Wan 2.7

**Wan 2.7 is NOT open-source.** Official Wan-AI HuggingFace org publishes weights only up to Wan 2.2. API-only. Multiple SEO sites fabricate an Apache 2.0 release — disregard. Wan 2.2 remains the current open backbone.

---

> **Nightly export reminder:** `tools/export_comfyui_workflows.py` runs at 03:30 local time and refreshes ComfyUI workflow snapshots automatically — no manual snapshot action needed after local node-pack installs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGHtrmLN76DMCVL4QYfqYG)_