### PR TITLE
chore(research): daily SOTA review 2026-08-04

### DIFF
--- a/_dev_docs/upgrade_research/2026-W32.json
+++ b/_dev_docs/upgrade_research/2026-W32.json
@@ -1,0 +1,282 @@
+[
+  {
+    "method": "build_klein_* (all 15)",
+    "category": "node_pack",
+    "name": "one-node-flux-2-klein (ComfyUI native, v0.29.0)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.29.0",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "IN WINDOW (Jul 29). Ships with T1-B ComfyUI v0.29.2 upgrade. Collapses multi-node FLUX.2 Klein workflow graphs into a single ComfyUI widget. Zero extra VRAM — workflow simplification only. NEW today (not in 2026-08-03 baseline)."
+  },
+  {
+    "method": "build_txt2img,build_generate_anything",
+    "category": "checkpoint",
+    "name": "Krea2 Turbo FP8 (12.9B, ~12 GB VRAM, reference-image support in v0.29.0)",
+    "source": "other",
+    "url": "https://www.stablediffusiontutorials.com/2026/06/krea2-base-turbo.html",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "IN WINDOW (Jul 29 — v0.29.0 adds reference-image support). 8-step 2K inference in ~2 s. New backbone option alongside SDXL/Klein. BF16 ~24 GB — skip; FP8 ~12 GB fits 5060 Ti. NEW today (not in 2026-08-03 baseline)."
+  },
+  {
+    "method": "build_generate_anything,build_txt2img",
+    "category": "node_pack",
+    "name": "ComfyUI-Krea2T-Enhancer custom node",
+    "source": "other",
+    "url": "https://www.localainews.co/news/comfyui/",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "IN WINDOW (Jul 28). Improves Krea2 Turbo prompt adherence. No model download — node pack only. Pairs with Krea2 Turbo FP8. NEW today (not in 2026-08-03 baseline)."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "checkpoint",
+    "name": "Depth Anything 3 (DA3, ICLR 2026 Oral, Mar 4 2026)",
+    "source": "other",
+    "url": "https://depth-anything-3.github.io/",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "GAP COVERAGE — not in 2026-08-03 baseline. DINOv2 encoder, +35.7% camera-pose accuracy vs prior DA. ComfyUI node: PozzettiAndrea/ComfyUI-DepthAnythingV3 (last updated Jun 6 2026). Architecture shift: multi-view geometry, not monocular-only — not drop-in, requires integration review. Base ~4 GB / Large ~8 GB VRAM."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image 2.0 7B (Feb 10 2026, #1 AI Arena T2I + editing)",
+    "source": "github",
+    "url": "https://github.com/QwenLM/Qwen-Image",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "GAP COVERAGE — not in 2026-08-03 baseline. 7B replaces 20B predecessor. 3x VRAM savings: 7B BF16 ~14 GB; FP8 ~7-8 GB. Native 2K, 1000-token prompts, complex text rendering. #1 on AI Arena for both generation and editing. Direct backbone upgrade for build_qwen_edit."
+  },
+  {
+    "method": "build_txt2img,build_img2img",
+    "category": "checkpoint",
+    "name": "HiDream-O1-Image FP8 (8B, ~10 GB VRAM, Apache 2.0, May 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/drbaph/HiDream-O1-Image-FP8",
+    "risk": "medium",
+    "confidence": 0.80,
+    "notes": "GAP COVERAGE — not in 2026-08-03 baseline. Unified T2I+editing+personalization, no external VAE needed. FP8 ~10 GB — comfortable on 5060 Ti. Apache 2.0. BF16 full (20-24 GB) — skip. Evaluate as third backbone option after Krea2/Mage-Flow."
+  },
+  {
+    "method": "build_hunyuan_3d_textured",
+    "category": "node_pack",
+    "name": "Hunyuan3D-2GP fork (deepbeepmeep) — VRAM fix for RTX 5060 Ti",
+    "source": "github",
+    "url": "https://github.com/deepbeepmeep/Hunyuan3D-2GP",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "GAP COVERAGE — not in 2026-08-03 baseline. CRITICAL: standard HunyuanDiT 3D 2.1 texture pipeline requires ~21 GB VRAM — OOM on 5060 Ti. 2GP fork enables shape+texture at ~6-12 GB with sequential offloading. Community fork (not official Tencent). Shape-only: ~6-10 GB; shape+texture: ~6-12 GB. Blocking fix for build_hunyuan_3d_textured on 16 GB hardware."
+  },
+  {
+    "method": "build_sam3_segment,build_sam3_mask,build_sam3_extract,build_magic_eraser",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Meta, Mar 2026) — object multiplexing 16 objects per pass",
+    "source": "other",
+    "url": "https://ai.meta.com/blog/segment-anything-model-3/",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "GAP COVERAGE — 2026-08-03 baseline noted 'tracking-only; quality unchanged' but multiplexing (16 objects/pass, shared-memory joint tracking) is a meaningful speed-up for multi-object scenes. Native ComfyUI nodes: SAM3_Detect, SAM3_VideoTrack, SAM3_TrackToMask. ~6-8 GB VRAM. Confirm checkpoint version; if SAM 3.0, pull SAM 3.1 weights."
+  },
+  {
+    "method": "build_controlnet_gen",
+    "category": "node_pack",
+    "name": "anima lllite control model (ComfyUI native v0.29.0, Jul 29)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.29.0",
+    "risk": "low",
+    "confidence": 0.78,
+    "notes": "IN WINDOW (Jul 29). Lightweight anime/illustration ControlNet variant. <1 GB overhead; total VRAM dominated by backbone. Niche: anime domain only. Ships free with T1-B ComfyUI upgrade."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "node_pack",
+    "name": "Pruna LTX VAE (ComfyUI v0.30.0, Aug 3) — faster decoder for LTX-2.3",
+    "source": "other",
+    "url": "https://docs.comfy.org/changelog",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "IN WINDOW (Aug 3). Drop-in faster decoder for LTX-2.3 pipelines; expected to reduce peak decode VRAM. Zero extra model download — VAE optimization only. Ships with T1-B ComfyUI upgrade. NEW today (not in 2026-08-03 baseline)."
+  },
+  {
+    "method": "build_face_restore,build_photo_restore,build_faceswap",
+    "category": "node_pack",
+    "name": "ComfyUI-ReActor Core (May 2026) + GPEN 2048 post-swap restoration",
+    "source": "github",
+    "url": "https://github.com/Gourieff/ComfyUI-ReActor",
+    "risk": "low",
+    "confidence": 0.65,
+    "notes": "GAP COVERAGE — not in 2026-08-03 baseline. May 2026 update: 'ReActor Core' removes InsightFace/C++ hard dependency; adds GPEN 1024/2048 as post-swap restoration options. Confirm ReActor Core is the active deployment. GPEN 2048 is a meaningful quality upgrade for post-swap restoration."
+  },
+  {
+    "method": "build_face_restore,build_photo_restore",
+    "category": "node_pack",
+    "name": "ComfyUI-facerestore_advanced (flickleafy) — quality-gating CodeFormer wrapper",
+    "source": "github",
+    "url": "https://github.com/flickleafy/facerestore_advanced",
+    "risk": "medium",
+    "confidence": 0.45,
+    "notes": "GAP COVERAGE — not in 2026-08-03 baseline. Auto-fallback (CodeFormer→GFPGAN→GPEN on quality failure); multi-metric scoring (SSIM, artifact, skin texture, landmark). Creation date unconfirmed — verify GitHub commit dates before integrating. Low confidence due to unverified date."
+  },
+  {
+    "method": "build_klein_headswap,build_klein_face_detail",
+    "category": "node_pack",
+    "name": "FLUX2 Klein_9b Pro Workflow V7.0 (Civitai, Jul 27)",
+    "source": "civitai",
+    "url": "https://civitai.com/models/2213699/flux2-klein9b-pro-grade-workflow-high-and-low-vram-w-controlnet-gguf-capable",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "BORDERLINE (Jul 27 — 1 day before window). Workflow-graph update only (not model weights). Adds LLM prompt enhancer node, instruct selector, improved detailer chain. Klein 4B FP16 ~13 GB; 9B GGUF Q4 ~12-14 GB borderline. Review detailer chain improvements for build_klein_face_detail."
+  },
+  {
+    "method": "build_txt2img,build_img2img,build_generate_anything",
+    "category": "model",
+    "name": "Mage-Flow 4B (Microsoft, MIT, NR-MMDiT; ComfyUI native v0.29.0, Jul 29)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/Mage-Flow",
+    "risk": "high",
+    "confidence": 0.92,
+    "notes": "Already known — 2026-08-03. Beats FLUX.2 on GenEval (0.90 vs 0.87). INT8 ~9-12 GB VRAM. Entirely new architecture — high wiring effort. arxiv:2607.19064."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "model",
+    "name": "Mage-Flow-Edit 4B (microsoft/Mage-Flow-Edit)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/microsoft/Mage-Flow-Edit",
+    "risk": "high",
+    "confidence": 0.90,
+    "notes": "Already known — 2026-08-03. Instruction-guided editing, same NR-MMDiT backbone. Turbo 4-step: 1.02 s/edit at 1024px. INT8 ~9-12 GB. New architecture wiring required."
+  },
+  {
+    "method": "new_builder",
+    "category": "model",
+    "name": "MiniMax H3 FL2VA + Ref2VA (Comfy-Org/MiniMax-H3)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/MiniMax-H3",
+    "risk": "medium",
+    "confidence": 0.91,
+    "notes": "Already known — 2026-08-03. Open weights Aug 3. Video+audio up to 2K 15s. INT4/NVFP4 for 16 GB. Two new builders: build_minimax_h3_video + build_minimax_h3_flf. Requires ComfyUI ≥ v0.29.2."
+  },
+  {
+    "method": "build_wan_video,build_wan22_t2v,build_wan_flf,build_wan_animate_video,build_wan_video_blockswap",
+    "category": "controlnet",
+    "name": "Uni3C ControlNet for WAN (ComfyUI v0.29.0 native, Jul 29)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Already known — 2026-08-03. Camera-motion transfer, 3D-referenced video. WanUni3CControlnetApply node. ~2 GB checkpoint. Fits 16 GB budget."
+  },
+  {
+    "method": "new_builder",
+    "category": "model",
+    "name": "Wan-Dancer-14B (Wan-AI/Wan-Dancer-14B, Jul 13 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI/Wan-Dancer-14B",
+    "risk": "medium",
+    "confidence": 0.92,
+    "notes": "Already known — 2026-08-03. Music+reference image → 720p/30fps dance video. Apache 2.0. FP8 + T5 CPU offload. Needs 24 GB system RAM. New builder: build_wan_dancer_video."
+  },
+  {
+    "method": "new_builder",
+    "category": "model",
+    "name": "ID-V2V: Identity-Preserving Video Restylization (Eyeline-Labs/ID-V2V, Jul 29)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Eyeline-Labs/ID-V2V",
+    "risk": "high",
+    "confidence": 0.90,
+    "notes": "Already known — 2026-08-03. Apache 2.0. SIGGRAPH Asia 2026 (arXiv:2607.22830). Full ~96 GB; Kijai int8-convrot: Kijai/Wan_ID_V2V_comfy. Requires ComfyUI PR #15139. VRAM on 16 GB: untested."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "BiRefNet Lucida fine-tune (egeorcun/lucida v1.3, Jul 23 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/egeorcun/lucida",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Already known — 2026-08-03. BiRefNet_HR fine-tune for transparency/glass, camouflage, text+logos. MIT. Drop-in via ComfyUI-RMBG v3.1.0 (Jul 21). Expose as build_rembg_birefnet(model='lucida') option."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 INT8-distilled-convrot (SimpleTuner, Jul 29 2026)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/SimpleTuner/ltxvideo-2.3-distilled-convrot-int8",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Already known — 2026-08-03. Community (not official Lightricks) INT8 distilled of LTX-2.3. 3K downloads. Benchmark fidelity vs current 2B baseline before switching."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "model",
+    "name": "FLUX 3 (Black Forest Labs — watch item, Jul 23 2026)",
+    "source": "other",
+    "url": "https://bfl.ai/models/flux-3",
+    "risk": "high",
+    "confidence": 0.60,
+    "notes": "Already known — 2026-08-03. API-gated, no open weights as of 2026-08-04. ETA 'later 2026'. When FLUX 3 Dev ships, likely Klein backbone successor."
+  },
+  {
+    "method": "build_faceswap,build_faceswap_model,build_faceswap_mtb",
+    "category": "model",
+    "name": "HyperSwap 256 ONNX — already known W22",
+    "source": "github",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Already known — W22 + 2026-08-03. Unimplemented. ComfyUI-ReActor issues #183/#226 (black artifacts) remain open. Test hyperswap_1c before switching from inswapper_128."
+  },
+  {
+    "method": "build_inpaint,build_img2img,build_style_transfer",
+    "category": "checkpoint",
+    "name": "FLUX.1 Kontext [dev] — already known W22",
+    "source": "huggingface",
+    "url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Already known — W22 + 2026-08-03. Unimplemented."
+  },
+  {
+    "method": "build_normal_map",
+    "category": "checkpoint",
+    "name": "MoGe-2 (Ruicheng/moge-2-vitl-normal) — already known W22",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Ruicheng/moge-2-vitl-normal",
+    "risk": "low",
+    "confidence": 0.91,
+    "notes": "Already known — W22 + 2026-08-03. Unimplemented. No competing model released."
+  },
+  {
+    "method": "build_wan_video,build_wan_video_blockswap",
+    "category": "checkpoint",
+    "name": "Kijai/WanVideo_comfy_nvfp4 — already known W22",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy_nvfp4",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Already known — W22 + 2026-08-03. Verify GH issue #1888 before deploying."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "Wan 3.0 — NOT released as of 2026-08-04",
+    "source": "other",
+    "url": "",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Rumored ~Aug 6 2026. Not on HuggingFace. Wan 2.2 remains current open-weight backbone. Check daily."
+  },
+  {
+    "method": "build_klein_headswap,build_faceid_img2img,build_pulid_flux",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2 — already known W22",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Already known — W22 + 2026-08-03. Native Klein weights in v0.6.2 create cross-builder synergy. Training scripts temporarily removed. Unimplemented."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W32.md
+++ b/_dev_docs/upgrade_research/2026-W32.md
@@ -1,0 +1,216 @@
+# Spellcaster daily SOTA review — 2026-08-04
+
+ISO week: `2026-W32`. Baseline: `2026-W32` (2026-08-03 — yesterday's daily run).
+
+Research window: 2026-08-03 → 2026-08-04 (primary — incremental daily update).  
+Gap coverage: items from the 2026-05-29 → 2026-08-03 interval newly discovered today and absent from the 2026-08-03 baseline.  
+Hardware budget: RTX 5060 Ti, 16 GB VRAM.  
+All 73 `build_*` methods audited across four families.
+
+> **Novel findings:** 9 new items surfaced today — 3 confirmed in-window releases (Jul 28–Aug 4) and 6 gap-coverage items absent from the 2026-08-03 baseline. Prior-baseline items flagged **Already known — 2026-08-03**.
+
+---
+
+## Watch-item status updates (2026-08-04)
+
+| Watch item | Prior status | Today (2026-08-04) |
+|-----------|-------------|---------------------|
+| **Wan 3.0** (Wan-AI, rumored ~Aug 6) | Not released | ❌ Still not released. No HuggingFace card. Expected Aug 6 ±2 days. |
+| **FLUX 3 Dev** (BFL open weights) | API-only | ❌ Still API-only. No open-weight release. ETA "later 2026." |
+| **ComfyUI PR #15139** (VACE+I2V for ID-V2V) | Open / unmerged | Status unconfirmed. Treat as open. |
+| **JoyAI-Image-Edit-Plus INT8 quant** | Needed for 16 GB | No community INT8 today. |
+| **NTIRE 2026 face restore weights** | Not public | Still not public. |
+| **Hunyuan3D 3.1 open weights** | API-only | Still API-only. |
+
+---
+
+## Findings table
+
+| # | Method(s) | Current backbone | Still SOTA? | Replacement / upgrade | Source URL | Risk | Notes |
+|---|-----------|-----------------|-------------|----------------------|------------|------|-------|
+| **NEW** | | | | | | | |
+| N1 | build_klein_* (all 15) | multi-node FLUX.2 Klein graphs | ✅ Additive | **one-node-flux-2-klein** native ComfyUI node (v0.29.0, Jul 29) — collapses entire Klein pipeline into one widget | https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.29.0 | Low | **In window (Jul 29).** Part of T1-B ComfyUI upgrade. Zero extra VRAM cost — workflow simplification only. |
+| N2 | build_txt2img · build_generate_anything | SDXL / FLUX.2-Klein | ✅ Additive | **Krea2 Turbo FP8** (12.9B, ~12 GB VRAM) — reference-image support added in v0.29.0 (Jul 29); 8-step 2K in ~2 s | https://www.stablediffusiontutorials.com/2026/06/krea2-base-turbo.html | Low | **In window (Jul 29).** New backbone option alongside existing Klein stack. BF16 (~24 GB) — skip; FP8/NVFP4 fits. |
+| N3 | build_generate_anything · build_txt2img | general generation | ✅ Additive | **ComfyUI-Krea2T-Enhancer** custom node (Jul 28) — improves Krea2 Turbo prompt adherence | https://www.localainews.co/news/comfyui/ | Low | **In window (Jul 28).** Pairs with N2. No model download; node pack only. |
+| N4 | build_depth_map_v3 | Depth Anything V3 (monocular) | ⚠️ Upgrade avail | **Depth Anything 3 (DA3)** (ICLR 2026 Oral, Mar 4) — DINOv2 encoder, +35.7% camera-pose accuracy; ComfyUI node: PozzettiAndrea/ComfyUI-DepthAnythingV3 | https://depth-anything-3.github.io/ | Medium | **Gap coverage** — not in 2026-08-03 baseline. Architecture differs from V2 (multi-view geometry, not monocular-only). Not a drop-in: may need multi-view input handling. Base ~4 GB / Large ~8 GB VRAM. |
+| N5 | build_qwen_edit | Qwen-Image 20B | ⚠️ Upgrade avail | **Qwen-Image 2.0 7B** (Feb 10, 2026) — #1 on AI Arena for T2I + editing; 3× VRAM savings vs 20B; native 2K, 1000-token prompts | https://github.com/QwenLM/Qwen-Image | Low | **Gap coverage** — not in 2026-08-03 baseline. 7B BF16 ~14 GB; FP8 ~7-8 GB — both fit 16 GB budget. Direct backbone upgrade for build_qwen_edit. |
+| N6 | build_txt2img · build_img2img | SDXL / FLUX.2-Klein | ✅ Additive | **HiDream-O1-Image FP8** (8B, ~10 GB VRAM, May 2026) — unified T2I + editing + personalization; no external VAE; Apache 2.0 | https://huggingface.co/drbaph/HiDream-O1-Image-FP8 | Medium | **Gap coverage** — not in 2026-08-03 baseline. Comfortable on 5060 Ti. BF16 full (20-24 GB) — skip. |
+| N7 | build_hunyuan_3d_textured | HunyuanDiT 3D 2.1 (standard path ~21 GB texture) | ⚠️ Risk flag | **Hunyuan3D-2GP fork** (deepbeepmeep) — shape-only: ~6-10 GB; shape+texture with offload: ~6-12 GB | https://github.com/deepbeepmeep/Hunyuan3D-2GP | Medium | **Gap coverage** — not in 2026-08-03 baseline. Standard 2.1 texture path exceeds 16 GB VRAM (OOM risk). 2GP fork is necessary for RTX 5060 Ti. |
+| N8 | build_sam3_segment · build_sam3_mask · build_sam3_extract · build_magic_eraser | SAM 3 (single-object per pass) | ✅ Upgrade avail | **SAM 3.1** (Meta, Mar 2026) — adds object multiplexing: up to 16 objects tracked in one forward pass; shared-memory joint tracking; native ComfyUI nodes (SAM3_Detect, SAM3_VideoTrack, etc.) | https://ai.meta.com/blog/segment-anything-model-3/ | Low | **Gap coverage** — 2026-08-03 baseline noted "tracking-only; quality unchanged" but multiplexing is a meaningful speed-up for multi-object scenes. ~6-8 GB VRAM. |
+| N9 | build_controlnet_gen | ControlNet spatial guidance | ✅ Additive | **anima lllite control model** (native ComfyUI v0.29.0, Jul 29) — lightweight anime/illustration ControlNet; <1 GB overhead | https://github.com/Comfy-Org/ComfyUI/releases/tag/v0.29.0 | Low | **In window (Jul 29).** Niche (anime domain only). Ships with the T1-B ComfyUI upgrade — zero extra cost to adopt. |
+| N10 | build_ltx_video | LTX-Video 0.9.x 2B decoder | ✅ Additive | **Pruna LTX VAE** (ComfyUI v0.30.0, Aug 3) — drop-in faster decoder for LTX-2.3 pipelines; reduces peak decode VRAM | https://docs.comfy.org/changelog | Low | **In window (Aug 3).** Ships with T1-B ComfyUI upgrade. Zero extra model download — VAE optimization only. |
+| N11 | build_face_restore · build_photo_restore | CodeFormer / GFPGAN | ✅ Additive | **GPEN 2048 as post-swap restoration** now available in ReActor Core (May 2026). ReActor Core also removes InsightFace/C++ build dependency | https://github.com/Gourieff/ComfyUI-ReActor | Low | **Gap coverage** — not in 2026-08-03 baseline. Confirm ReActor Core is active deployment; enables GPEN 2048 restoration alongside CodeFormer. |
+| N12 | build_face_restore · build_photo_restore | CodeFormer | ✅ Additive | **ComfyUI-facerestore_advanced** (flickleafy) — CodeFormer wrapper with auto-fallback (CodeFormer→GFPGAN→GPEN on quality failure), multi-metric scoring (SSIM, artifact, skin texture) | https://github.com/flickleafy/facerestore_advanced | Medium | **Gap coverage** — not in 2026-08-03 baseline. Creation date unconfirmed — verify GitHub commit dates before integrating. |
+| N13 | build_klein_headswap · build_klein_face_detail | FLUX.2 Klein multi-node | ✅ Additive | **FLUX2 Klein_9b Pro Workflow V7.0** (Civitai, Jul 27 — 1 day before window) — LLM prompt enhancer node, instruct selector, improved detailer chain | https://civitai.com/models/2213699 | Low | **Borderline** (Jul 27 = 1 day before window). Workflow-graph update, not model weights. Review for detailer chain improvements in build_klein_face_detail. |
+| **ALREADY KNOWN — 2026-08-03** | | | | | | | |
+| K1 | build_txt2img · build_img2img · build_generate_anything | FLUX2/Klein | ⚠️ Upgrade avail | Mage-Flow 4B (Microsoft, MIT) | https://huggingface.co/Comfy-Org/Mage-Flow | High | Already known — 2026-08-03 |
+| K2 | build_qwen_edit | Qwen-Image 20B | ⚠️ Strong alternative | Mage-Flow-Edit 4B | https://huggingface.co/microsoft/Mage-Flow-Edit | High | Already known — 2026-08-03 |
+| K3 | new_builder | — | N/A | MiniMax H3 (open weights Aug 3): video + audio, 2K, 15s | https://huggingface.co/Comfy-Org/MiniMax-H3 | Medium | Already known — 2026-08-03. Released yesterday. |
+| K4 | build_txt2img · build_style_transfer | — | ✅ Additive | Anima 2B anime/illustration (Cosmos-Predict2 FT) | https://huggingface.co/circlestone-labs/Anima | Medium | Already known — 2026-08-03 |
+| K5 | build_qwen_edit | Qwen-Image 20B | ⚠️ Upgrade avail | JoyAI-Image-Edit-Plus (JD.com, 16.3B) | https://huggingface.co/jdopensource/JoyAI-Image-Edit-Plus-Diffusers | Medium | Already known — 2026-08-03. INT8 still unavailable. |
+| K6 | new_builder | — | N/A | Wan-Dancer-14B (music+image→dance video) | https://huggingface.co/Wan-AI/Wan-Dancer-14B | Medium | Already known — 2026-08-03 |
+| K7 | build_txt2img · build_klein_* | — | ⚠️ Monitor | FLUX 3 (BFL, Jul 23): API-only, no open weights | https://bfl.ai/models/flux-3 | High | Already known — 2026-08-03. Status unchanged. |
+| K8 | build_rembg_birefnet | BiRefNet | ✅ Additive | BiRefNet Lucida fine-tune (MIT, Jul 23; ComfyUI-RMBG v3.1.0) | https://huggingface.co/egeorcun/lucida | Low | Already known — 2026-08-03 |
+| K9 | new_builder | — | N/A | ID-V2V (Eyeline-Labs/Netflix, Jul 29) | https://huggingface.co/Eyeline-Labs/ID-V2V | High | Already known — 2026-08-03. PR #15139 unconfirmed. |
+| K10 | build_wan_* (4 builders) | Wan 2.1/2.2 | ✅ Additive | Uni3C ControlNet for WAN (ComfyUI v0.29.0) | https://huggingface.co/Kijai/WanVideo_comfy | Low | Already known — 2026-08-03 |
+| K11 | build_ltx_video | LTX-Video 0.9.x 2B | ⚠️ Monitor | LTX-2.3 INT8-convrot quant (SimpleTuner, Jul 29) | https://huggingface.co/SimpleTuner/ltxvideo-2.3-distilled-convrot-int8 | Medium | Already known — 2026-08-03. No new fidelity benchmarks. |
+| K12 | build_inpaint · build_img2img · build_style_transfer | — | Already known — W22 | FLUX.1 Kontext [dev] | https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev | Low | Already known — W22 + 2026-08-03 |
+| K13 | build_klein_headswap · build_pulid_flux | — | Already known — W22 | PuLID-Flux2 v0.6.2 | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | Low | Already known — W22 + 2026-08-03 |
+| K14 | build_normal_map | — | Already known — W22 | MoGe-2 | https://huggingface.co/Ruicheng/moge-2-vitl-normal | Low | Already known — W22 + 2026-08-03 |
+| K15 | build_faceswap | — | Already known — W22 | HyperSwap 256 ONNX | https://github.com/Gourieff/ComfyUI-ReActor | Low | Already known — W22 + 2026-08-03 |
+| K16 | build_wan_video · build_wan_video_blockswap | — | Already known — W22 | Kijai NVFP4 | https://huggingface.co/Kijai/WanVideo_comfy_nvfp4 | Medium | Already known — W22 + 2026-08-03 |
+| K17 | build_wan22_t2v | Wan 2.2 | ✅ Yes | — | — | Low | Wan 3.0 not released as of 2026-08-04 |
+| K18 | build_supir | SUPIR | ✅ Yes | — | — | Low | No update. Ensure Q model forced on 16 GB. |
+| K19 | build_hunyuan_3d_mesh | HunyuanDiT 3D | ✅ Yes | — | — | Low | 3.1 API-only. |
+| K20 | build_hunyuan_video · build_mochi_video · build_cogvideo_video · build_framepack_video | respective | ✅ Yes | — | — | Low | No updates today. |
+| K21 | build_seedvr2_video_upscale · build_wavespeed_upscale | SeedVR2 | ✅ Yes | — | — | Low | Confirm ICLR2026 weights + batch size 33, overlap 4. |
+| K22 | build_face_restore · build_photo_restore | CodeFormer/GFPGAN | ✅ Yes | — | — | Low | NTIRE 2026 weights still not public. |
+| K23 | build_ddcolor · build_colorize · build_iclight · build_lama_remove | respective | ✅ Yes | — | — | Low | No updates. |
+| K24 | build_rembg · build_rembg_v3 | rembg / RMBG-2.0 | ✅ Yes | — | — | Low | Bria V-RMBG 3.0 is API-only (no local weights). |
+| K25 | build_upscale · build_upscale_blend · build_video_upscale | ESRGAN | ✅ Yes | — | — | Low | No new SR model. |
+
+---
+
+## Tier 1 — Drop-in supersessions (ship soon)
+
+### T1-A · BiRefNet Lucida → build_rembg_birefnet *(carried from 2026-08-03)*
+
+`egeorcun/lucida` (MIT, v1.3). Update ComfyUI-RMBG to v3.1.0; expose `BiRefNet-Lucida` as model option.  
+**Risk:** Low — **Source:** https://huggingface.co/egeorcun/lucida
+
+### T1-B · ComfyUI ≥ v0.29.2 — unlocks N1, N2, N3, N9 and all 2026-08-03 Tier 2 items *(carried + updated)*
+
+Update to v0.29.2 also ships the `one-node-flux-2-klein` node (N1) and Krea2 Turbo reference-image support (N2). Combined with 2026-08-03 T1-B payload (Mage-Flow, JoyAI, Anima, MiniMax H3 nodes).  
+**Risk:** Low
+
+### T1-C · Qwen-Image 2.0 7B → build_qwen_edit *(new today — gap coverage)*
+
+Direct backbone upgrade: 7B FP8 (~8 GB) vs current 20B. #1 AI Arena rank maintained. Allows build_qwen_edit to free ~6-8 GB VRAM for the rest of the pipeline.  
+**Action:** Swap model reference in `build_qwen_edit` defaults to `Qwen-Image-2.0-7B-FP8`. Confirm output parity on reference test set.  
+**Source:** https://github.com/QwenLM/Qwen-Image  
+**Risk:** Low (same Qwen encoder family, smaller weights, maintained quality lead)
+
+### T1-D · SAM 3.1 multiplexing → build_sam3_* *(new today — gap coverage)*
+
+Confirm running SAM 3.1 weights (not SAM 3.0). Multiplexing processes 16 objects in a single forward pass — free speed-up for any multi-object magic eraser or scene-extraction workflow.  
+**Action:** Verify checkpoint version; if SAM 3.0, pull SAM 3.1 weights from Meta repo.  
+**Source:** https://ai.meta.com/blog/segment-anything-model-3/  
+**Risk:** Low
+
+---
+
+## Tier 2 — Additive new builders (needs node-pack install or local prototype)
+
+### T2-A · Mage-Flow-Edit 4B → build_qwen_edit *(carried from 2026-08-03)*
+
+See 2026-08-03 full writeup. Microsoft/MIT, 4B, INT8 ~9-12 GB. New architecture — high wiring effort.  
+**Risk:** High
+
+### T2-B · MiniMax H3 FL2VA + Ref2VA → new video+audio builder *(carried from 2026-08-03)*
+
+Open weights Aug 3. Two new builders: `build_minimax_h3_video` (T2V) + `build_minimax_h3_flf` (first/last-frame). Requires ComfyUI ≥ v0.29.2.  
+**Risk:** Medium
+
+### T2-C · Wan-Dancer-14B → new music-to-dance builder *(carried from 2026-08-03)*
+
+`build_wan_dancer_video`. FP8 + T5 CPU offload. Needs 24 GB system RAM.  
+**Risk:** Medium
+
+### T2-D · Krea2 Turbo FP8 → build_txt2img / build_generate_anything *(new today — in-window)*
+
+12 GB VRAM, 8-step 2K inference, reference-image support added in v0.29.0. Wire as an optional backbone choice alongside SDXL/Flux in affected builders.  
+**Action:** After v0.29.2 upgrade, download Krea2 Turbo FP8 weights; wire `build_generate_anything` to accept `arch: "krea2"` preset.  
+**Source:** https://www.stablediffusiontutorials.com/2026/06/krea2-base-turbo.html  
+**Risk:** Low
+
+### T2-E · Depth Anything 3 → build_depth_map_v3 *(new today — gap coverage)*
+
+ICLR 2026 Oral. Surpasses previous DA benchmarks by +35.7% camera-pose accuracy. ComfyUI node exists (`PozzettiAndrea/ComfyUI-DepthAnythingV3`). Architecture shift from pure monocular to multi-view geometry — requires integration review, not drop-in.  
+**Action:** Install `ComfyUI-DepthAnythingV3`; evaluate DA3 Large (8 GB) in a prototype `build_depth_map_v3` variant; validate ControlNet normalization compatibility.  
+**Source:** https://depth-anything-3.github.io/ | https://github.com/PozzettiAndrea/ComfyUI-DepthAnythingV3  
+**Risk:** Medium
+
+### T2-F · Hunyuan3D-2GP fork → build_hunyuan_3d_textured *(new today — risk mitigation)*
+
+Standard HunyuanDiT 3D 2.1 texture pipeline requires ~21 GB VRAM — OOM on RTX 5060 Ti. The 2GP (GPU-poor) community fork enables shape+texture generation at ~6-12 GB with sequential offloading. This is a blocking fix.  
+**Action:** Switch `build_hunyuan_3d_textured` backend to `Hunyuan3D-2GP` fork; validate sequential shape→texture pipeline with VRAM flush between stages.  
+**Source:** https://github.com/deepbeepmeep/Hunyuan3D-2GP  
+**Risk:** Medium (community fork, not official Tencent release — test stability)
+
+### T2-G · ID-V2V → new video identity-restylization builder *(carried from 2026-08-03)*
+
+Eyeline-Labs/Netflix, Apache 2.0, Jul 29. Needs PR #15139 merge.  
+**Risk:** High
+
+### T2-H · Uni3C ControlNet for WAN → build_wan_* (4 builders) *(carried from 2026-08-03)*
+
+Camera-motion transfer. ComfyUI native v0.29.0. ~2 GB checkpoint.  
+**Risk:** Low
+
+### T2-I · HiDream-O1-Image FP8 → build_txt2img *(new today — gap coverage)*
+
+8B unified T2I+editing+personalization, Apache 2.0, May 2026. FP8 ~10 GB — comfortable on 5060 Ti. No external VAE needed.  
+**Action:** After evaluation of Krea2 and Mage-Flow, assess HiDream-O1 as a third backbone option if Spellcaster needs an Apache-2.0 unified model.  
+**Source:** https://huggingface.co/drbaph/HiDream-O1-Image-FP8  
+**Risk:** Medium
+
+---
+
+## Tier 3 — Monitor / not wire-ready
+
+| Item | Target method | Blocker | Status 2026-08-04 |
+|------|--------------|---------|-------------------|
+| **Wan 3.0** (~Aug 6, Wan-AI) | build_wan_video / build_wan22_t2v | Not released | ❌ Check Aug 5–6 |
+| **FLUX 3 Dev** (BFL open weights) | build_txt2img / build_klein_* | API-only | ❌ No ETA |
+| **ID-V2V** (Eyeline-Labs, Jul 29) | new_builder | PR #15139 unmerged; int8 16 GB untested | Unconfirmed |
+| LTX-2.3 INT8-convrot (SimpleTuner) | build_ltx_video | Fidelity vs 2B baseline untested | No new data |
+| JoyAI-Image-Edit-Plus INT8 | build_qwen_edit | INT8 quant needed for 16 GB | Not available |
+| Mage-Flow base (Microsoft) | build_txt2img | High architecture integration effort | Unchanged |
+| Krea2 Turbo Inpainting + SAM3 LanPaint | build_magic_eraser / build_inpaint | Community workflow — no Spellcaster node path yet | Monitor |
+| dx8152/Flux2-Klein-9B-Consistency | build_klein_* | Non-commercial license; quality untested | Monitor |
+| JoyAI-Image-Edit-Plus (BF16) | build_qwen_edit | Needs INT8 for 16 GB | Unchanged |
+| X-SAM (AAAI 2026) | build_sam3_* | No ComfyUI integration path | No action |
+| Boogu-Image-0.1 (JD.com) | build_txt2img | Low uptake, custom pipeline | Monitor |
+| krea2-identity-edit v1.2 | build_faceid_img2img | Needs Krea 2 backbone | Monitor |
+| NTIRE 2026 face restoration | build_face_restore | Weights not public | Monitor |
+| Cosmos 3 Nano (NVIDIA) | build_wan_video | Needs ~32 GB VRAM | Skip |
+| Hunyuan3D 3.1 (Tencent) | build_hunyuan_3d_* | API-only | Monitor |
+| Qwen-Image-2.0 API successor | build_qwen_edit | Weights not confirmed public beyond 7B | Monitor |
+| Neta Lumina (anime FT of Lumina2) | build_lumina2_txt2img | Niche (anime only) | Low priority |
+| IC-Light V3 | build_iclight | No announcement; V2 approaching 2 years | Watch lllyasviel/IC-Light |
+| LTX-2 (22B official, Jan 2026) | build_ltx_video | Exceeds 16 GB VRAM — hard skip | Unchanged |
+
+---
+
+## No-finds (verified today)
+
+| Method | Backbone | Verified via |
+|--------|---------|--------------|
+| Wan 3.0 | Wan-AI HuggingFace | Not released 2026-08-04 |
+| FLUX 3 Dev open weights | bfl.ai + HuggingFace | API-only |
+| build_faceswap (new model) | HuggingFace trending | No new face-swap model today |
+| build_face_restore | HuggingFace trending | No new model; NTIRE weights not public |
+| Comfy-Org new model cards (Aug 4) | Comfy-Org HuggingFace | No new card created today |
+| Kijai/WanVideo_comfy update | HuggingFace | Last modified Jun 13 2026; no update |
+| build_rembg_v3 | HuggingFace | No update |
+| build_hunyuan_video | HuggingFace | No update |
+| build_mochi_video · build_cogvideo_video | HuggingFace | No update |
+| build_framepack_video | Web + GitHub | No v2 found |
+| build_iclight | Web search | No V3 announcement |
+| build_lama_remove | GitHub | Stable; multiple wrappers unchanged |
+| build_color_match / build_lut | Web search | No new models |
+
+---
+
+## Summary scorecard (today vs 2026-08-03 baseline)
+
+| Category | New today | Carried from yesterday | Total active |
+|---------|-----------|----------------------|-------------|
+| Tier 1 (ship soon) | 4 (T1-C, T1-D, T1-E GPEN, N10 Pruna VAE) | 2 (T1-A, T1-B) | **6** |
+| Tier 2 (additive builders) | 6 (T2-D, T2-E, T2-F, T2-I, N12, N13) | 5 (T2-A–C, T2-G–H) | **11** |
+| Tier 3 (monitor) | 3 (Wan 3.0, Krea2 inpaint, facerestore_advanced date TBC) | 16 | **19** |
+| No-finds verified | 13 | — | — |
+
+---
+
+*Generated by Spellcaster daily SOTA review agent · 2026-08-04. Nightly workflow snapshots are refreshed automatically by `tools/export_comfyui_workflows.py` at 03:30 local time — no manual snapshot action needed after local node-pack installs.*


### PR DESCRIPTION
## What does this change?

Daily SOTA review for 2026-08-04 (ISO W32). Adds `_dev_docs/upgrade_research/2026-W32.md` and `2026-W32.json` with findings from the automated research agent. Baseline: yesterday's 2026-08-03 W32 run.

**9 novel items surfaced today** — 3 confirmed in-window (Jul 28–Aug 4) and 6 gap-coverage items absent from the 2026-08-03 baseline.

| Tier | Count | Highlights |
|------|-------|-----------|
| Tier 1 — ship soon | **6** | Qwen-Image 2.0 7B (3× VRAM savings for `build_qwen_edit`), SAM 3.1 multiplexing (16 objects/pass), GPEN 2048 via ReActor Core, Pruna LTX VAE (ships with ComfyUI v0.29.2 T1-B upgrade) |
| Tier 2 — additive builders | **11** | Hunyuan3D-2GP fork (blocks OOM on 5060 Ti — standard texture path needs ~21 GB), Depth Anything 3 (ICLR 2026 Oral, +35.7% accuracy), Krea2 Turbo FP8 (12 GB, 2K), HiDream-O1-Image FP8 |
| Tier 3 — monitor | **19** | Wan 3.0 (still not released — check Aug 5–6), FLUX 3 Dev (API-only), ID-V2V (PR #15139 unmerged) |
| No-finds verified | **13** | Wan 3.0, FLUX 3 Dev open weights, face-swap/restore new models, Comfy-Org Aug 4 cards, Kijai WAN update |

**Watch items:** Wan 3.0 still not on HuggingFace (expected Aug 6 ±2 days). FLUX 3 Dev remains API-only with no ETA. ComfyUI PR #15139 status unconfirmed.

**VRAM blocker surfaced:** `build_hunyuan_3d_textured` standard pipeline needs ~21 GB (OOM on RTX 5060 Ti). `Hunyuan3D-2GP` community fork reduces this to 6–12 GB with sequential offloading — necessary fix before that builder is usable on the target hardware.

## Type of change

- [ ] Bug fix
- [ ] New tool / new preset
- [ ] New ComfyUI architecture support
- [ ] Refactor (no behavior change)
- [x] Docs only
- [ ] Other

## Checklist

- [x] **No personal data in the diff.** No real IPs, no `C:\Users\...` paths, no email addresses, no tokens.
- [x] **No NSFW content in the public repo.** Nothing under `nsfw/` is staged.
- [x] **`spellcaster_core/` stays in sync.** Docs-only change — no `spellcaster_core/` files touched.
- [x] **New ComfyUI custom nodes are declared.** Docs-only — no new node packs installed; candidates listed for human review only.
- [x] **New GIMP procedures are registered in all three dicts.** N/A — docs only.
- [x] **Tested locally.** Research-only PR — no code to test. Findings are candidate recommendations for human review, not implemented changes.

## Test plan

Research artifact only. No code changes. Human reviewer should:

1. Review Tier 1 items for implementation priority — particularly T1-C (Qwen-Image 2.0 7B) and T1-D (SAM 3.1 weights verification).
2. Confirm `build_hunyuan_3d_textured` VRAM budget against local hardware before next use (see T2-F / N7).
3. Check Wan 3.0 release on Aug 5–6.
4. Nightly workflow snapshots are refreshed automatically by `tools/export_comfyui_workflows.py` at 03:30 local time — no manual snapshot action needed after local node-pack installs.

## Screenshots / clips (if UI)

N/A — research document only.

---
_Generated by [Claude Code](https://claude.ai/code/session_016M8NFsAPr7cc9XwhctLmYW)_