### PR TITLE
chore(research): daily SOTA review 2026-08-05

### DIFF
--- a/_dev_docs/upgrade_research/2026-W32.json
+++ b/_dev_docs/upgrade_research/2026-W32.json
@@ -1,0 +1,222 @@
+[
+  {
+    "method": "build_hunyuan_video",
+    "category": "checkpoint",
+    "name": "HunyuanVideo-1.5 720p FP8 (unsloth)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/unsloth/HunyuanVideo-1.5-720p-FP8",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "IN-WINDOW 2026-08-04. FP8 of HunyuanVideo-1.5 (8.3B, Nov 2025). Supersedes original 13B; ~9 GB VRAM vs ~17 GB. Native ComfyUI support confirmed. Also available in 480p variant. Tier 1 drop-in."
+  },
+  {
+    "method": "build_hunyuan_video",
+    "category": "checkpoint",
+    "name": "HunyuanVideo-1.5 480p FP8 (unsloth)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/unsloth/HunyuanVideo-1.5-480p-FP8",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "IN-WINDOW 2026-08-04. Companion to 720p FP8 variant; lower resolution, lower VRAM. Tier 1 drop-in."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "checkpoint",
+    "name": "HyperSwap 1c 256-px ONNX (FaceFusion 3.3.0)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/facefusion/models-3.3.0",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "Outside window (Q4 2025). Three-tier: 1a=speed, 1b=balanced, 1c=quality. ~403 MB each. Supported in ComfyUI-ReActor (Issue #143). Better identity fidelity and blending than inswapper_128. ~4 GB VRAM. Tier 1 drop-in; requires local hyperswap model class enabled in ReActor."
+  },
+  {
+    "method": "build_sam3_segment",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Meta)",
+    "source": "github",
+    "url": "https://ai.meta.com/blog/segment-anything-model-3/",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Outside window (2026-03-27). ~7x faster inference, half VRAM vs SAM 3.0. Native ComfyUI support merged (Comfy-Org PR #13408, kijai). Applies to build_sam3_segment, build_sam3_mask, build_sam3_extract. ~5 GB VRAM. Tier 1 checkpoint swap."
+  },
+  {
+    "method": "new_builder",
+    "category": "checkpoint",
+    "name": "MiniMax H3",
+    "source": "huggingface",
+    "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "IN-WINDOW 2026-08-03. 33.1B omni-transformer: T2V + I2V + stereo audio, up to 2K. INT4 ~15 GB fits RTX 5060 Ti 16 GB with blockswap. Day-0 ComfyUI v0.30.0 support (Comfy-Org PR #15224). Comfy-Org repack: https://huggingface.co/Comfy-Org/MiniMax-H3. New build_minimax_video needed. Tier 2 new builder."
+  },
+  {
+    "method": "new_builder",
+    "category": "checkpoint",
+    "name": "Krea 2 Base + Turbo",
+    "source": "huggingface",
+    "url": "https://huggingface.co/docs/diffusers/api/pipelines/krea2",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Outside window (2026-06-22). 12B MMDiT + Qwen3-VL-4B. FP8 ~13 GB; GGUF Q5_K_M ~8.87 GB. ComfyUI native since v0.26.0. Top-10 Artificial Analysis leaderboard. Permissive license. Identity-edit LoRA available. Tier 2 new builder (build_krea2_txt2img); strong SDXL/Flux replacement."
+  },
+  {
+    "method": "new_builder",
+    "category": "checkpoint",
+    "name": "Bernini-R (ByteDance, Wan 2.2 V2V editor)",
+    "source": "github",
+    "url": "https://github.com/bytedance/Bernini",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Outside window (2026-06-01). V2V editing, relighting, restyling, subject insertion via Wan 2.2 in-context reference. ComfyUI merged Comfy-Org PR #14216 (Jun 9). Weights: https://huggingface.co/ByteDance/Bernini-R. Node pack: https://github.com/AIMixer/ComfyUI-Bernini. 1.3B variant 16 GB viable; 14B needs GGUF. New build_bernini_video. Tier 2."
+  },
+  {
+    "method": "build_faceid_img2img",
+    "category": "node_pack",
+    "name": "ComfyUI-PuLID-Flux2 v0.6.2 (iFayens)",
+    "source": "github",
+    "url": "https://github.com/iFayens/ComfyUI-PuLID-Flux2",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Outside window (2026-03-21). First PuLID for FLUX.2. Models: https://huggingface.co/Fayens/Pulid-Flux2. ~8 GB VRAM. Known gap: male ID fidelity. Moves build_faceid_img2img from SD-era IPAdapter to FLUX.2 native. Tier 2."
+  },
+  {
+    "method": "build_klein_face_detail",
+    "category": "node_pack",
+    "name": "ComfyUI-Flux-FaceIR (cosmicrealm)",
+    "source": "github",
+    "url": "https://github.com/cosmicrealm/ComfyUI-Flux-FaceIR",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Outside window (2026-04-07). FLUX.2-Klein-4B LoRA + ComfyUI nodes for blind face restoration and reference-guided restoration. Companion: https://github.com/cosmicrealm/flux-restoration. ~6 GB VRAM. Adds blind-restoration path CodeFormer lacks. Tier 2."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "node_pack",
+    "name": "ComfyUI-Trellis2 MultiView update (visualbruno)",
+    "source": "github",
+    "url": "https://github.com/visualbruno/ComfyUI-Trellis2",
+    "risk": "medium",
+    "confidence": 0.88,
+    "notes": "ComfyUI wrapper IN-WINDOW updated 2026-07-31 (MultiView support, alpha fixes). TRELLIS.2 model itself: Microsoft, MIT license, 4B O-Voxel, full PBR GLB. ~16 GB VRAM minimum (viable at reduced resolution). Model: https://huggingface.co/microsoft/TRELLIS.2. MIT license advantage over Hunyuan community. New build_trellis2_3d. Tier 2."
+  },
+  {
+    "method": "build_seedv2r",
+    "category": "checkpoint",
+    "name": "FlashVSR (OpenImagingLab, CVPR 2026)",
+    "source": "github",
+    "url": "https://github.com/OpenImagingLab/FlashVSR",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "Outside window (2025-11). One-step diffusion streaming VSR; 17 FPS at 768x1408; 12x faster than prior diffusion VSR. ~8 GB VRAM. ComfyUI: https://github.com/1038lab/ComfyUI-FlashVSR. Stable variant: https://github.com/naxci1/ComfyUI-FlashVSR_Stable. Complementary to SeedVR2 (speed vs quality). Tier 2."
+  },
+  {
+    "method": "new_builder",
+    "category": "checkpoint",
+    "name": "Z-Image Turbo (Alibaba Tongyi Lab)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Comfy-Org/z_image_turbo",
+    "risk": "low",
+    "confidence": 0.87,
+    "notes": "Outside window (2025-11). 6B, 8-step distilled; FP8 ~8 GB VRAM. 1024x1024 in ~2.3s on RTX 4090. Comfy-Org packaged. Z-Image-Edit adds instruction-following editing. New build_zimage_txt2img. Tier 2."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "node_pack",
+    "name": "ComfyUI-RMBG v3.1.0 Lucida BiRefNet fine-tune (1038lab)",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-RMBG",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Released 2026-07-21 (8 days before window). Adds Lucida fine-tune for transparent objects, camouflage, text/logos, glow/VFX. Also new SAM2Segment node. ~3 GB VRAM. Drop-in update within 1038lab ecosystem. Tier 2."
+  },
+  {
+    "method": "build_face_restore",
+    "category": "checkpoint",
+    "name": "IConFace (cosmicrealm, FLUX.2-Klein-4B)",
+    "source": "github",
+    "url": "https://github.com/cosmicrealm/IConFace",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Outside window (2026-05). No ComfyUI node yet. Reference-aware face restoration on Klein-4B: dual-route cross-attention, AdaFace identity anchor, blind + reference modes. arXiv:2605.02814. ~8 GB VRAM. Monitor for ComfyUI wrapper from same author (cosmicrealm/ComfyUI-Flux-FaceIR). Tier 3."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-2.0-RL (Alibaba Qwen team)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/papers/2606.27608",
+    "risk": "low",
+    "confidence": 0.82,
+    "notes": "Outside window (2026-06-25). 7B RLHF/OPD fine-tune; Elo +78 T2I vs base. GGUF Q4_K_M ~14 GB. Apache 2.0. Checkpoint ID unconfirmed — verify at huggingface.co/Qwen. Tier 3 until weights confirmed."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Ideogram 4 FP8",
+    "source": "huggingface",
+    "url": "https://huggingface.co/ideogram-ai/ideogram-4-fp8",
+    "risk": "medium",
+    "confidence": 0.90,
+    "notes": "Outside window (2026-06-03). 9.3B flow-matching DiT; best-in-class multilingual text rendering. FP8 ~16 GB — tight fit. Gated HF access, non-OSI license. Civitai INT8 repack exists. Tier 3 — license review required."
+  },
+  {
+    "method": "new_builder",
+    "category": "checkpoint",
+    "name": "FLUX 3 (Black Forest Labs)",
+    "source": "bfl.ai",
+    "url": "https://bfl.ai/blog/flux-3",
+    "risk": "high",
+    "confidence": 0.90,
+    "notes": "Announced 2026-07-23/28 (crosses window). Multimodal single backbone (image/video/audio/robot). No open weights as of 2026-08-05. Open-weight Dev expected later in 2026. When weights drop, likely to supersede all Klein/FLUX.2 builders. Monitor. Tier 3."
+  },
+  {
+    "method": "build_hunyuan_3d_mesh",
+    "category": "checkpoint",
+    "name": "Hunyuan3D-Omni (Tencent)",
+    "source": "github",
+    "url": "https://github.com/Tencent-Hunyuan/Hunyuan3D-Omni",
+    "risk": "medium",
+    "confidence": 0.82,
+    "notes": "Outside window (2025-08). Multi-condition 3D control (point cloud, voxel, skeleton, bbox). 3.3B params; ~10 GB VRAM. No standalone ComfyUI nodes found. Tier 3 — monitor for node wrapper."
+  },
+  {
+    "method": "build_faceswap",
+    "category": "software_release",
+    "name": "FaceFusion 3.8.0",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion/releases/tag/3.8.0",
+    "risk": "medium",
+    "confidence": 0.95,
+    "notes": "IN-WINDOW 2026-07-31. Infrastructure-only: FFmpeg video manager, AV1 encode/decode, alpha channel, --workflow-strategy flag. No new face-swap model weights. Different toolchain from ReActor. No action needed. Tier 3 / informational."
+  },
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.3 distilled convrot INT8 (SimpleTuner community quant)",
+    "source": "huggingface",
+    "url": "https://huggingface.co/SimpleTuner/ltxvideo-2.3-distilled-convrot-int8",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "IN-WINDOW 2026-07-29. Community INT8 quantization of LTX-2.3. Spellcaster already uses LTX-2.3 backbone — this is packaging only, no new model. Lower peak activation memory. Not a new model. Tier 3 / informational."
+  },
+  {
+    "method": "build_depth_map_v3",
+    "category": "framework",
+    "name": "YOLO26 monocular depth (Ultralytics v8.4.104)",
+    "source": "github",
+    "url": "https://www.ultralytics.com/blog/ultralytics-yolo26-now-supports-monocular-depth-estimation",
+    "risk": "low",
+    "confidence": 0.72,
+    "notes": "IN-WINDOW 2026-07-29. Combined detection+depth pipeline; does not improve pure depth quality vs DA3-large. Relevant only for combined detect+depth use-cases. No action needed. Informational."
+  },
+  {
+    "method": "new_builder",
+    "category": "checkpoint",
+    "name": "Pixal3D (TencentARC, SIGGRAPH 2026)",
+    "source": "github",
+    "url": "https://github.com/TencentARC/Pixal3D",
+    "risk": "medium",
+    "confidence": 0.83,
+    "notes": "Outside window (2026-05). Pixel-aligned image-to-3D using TRELLIS.2 backbone. arXiv 2605.10922. ComfyUI wrappers: Saganaki22/Pixal3D-ComfyUI, dreamrec/ComfyUI-Pixal3D. ~16 GB borderline on RTX 5060 Ti. New build_pixal3d. Tier 3."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W32.md
+++ b/_dev_docs/upgrade_research/2026-W32.md
@@ -1,0 +1,215 @@
+# Spellcaster daily SOTA review — 2026-08-05
+
+ISO week: `2026-W32`. Baseline: none (first report — no prior punch lists exist).
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement (if not) | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| `build_hunyuan_video` | HunyuanVideo 13B (Dec 2024) | ❌ | HunyuanVideo-1.5 FP8 (8.3B, ~9 GB) | https://huggingface.co/unsloth/HunyuanVideo-1.5-720p-FP8 | low | **IN-WINDOW** Aug 4. Direct drop-in. → T1 |
+| `build_faceswap` / `build_faceswap_model` | inswapper_128.onnx (ReActor) | ❌ | HyperSwap 1a/1b/1c (~4 GB, 256-px ONNX) | https://huggingface.co/facefusion/models-3.3.0 | medium | Outside window (Q4 2025). ComfyUI-ReActor Issue #143. → T1 |
+| `build_sam3_*` (segment/mask/extract) | SAM 3.0 | ❌ | SAM 3.1 (7× faster, half VRAM, ~5 GB) | https://ai.meta.com/blog/segment-anything-model-3/ | low | Outside window (Mar 27 2026). Native ComfyUI merged. → T1 |
+| `build_txt2img` / `build_img2img` | SDXL / Flux | ⚠️ additive | Krea 2 (12B MMDiT, FP8 ~13 GB) | https://huggingface.co/docs/diffusers/api/pipelines/krea2 | low | Outside window (Jun 22). New builder recommended. → T2 |
+| `build_faceid_img2img` | FaceID IPAdapter (SD-era) | ⚠️ additive | ComfyUI-PuLID-Flux2 v0.6.2 (~8 GB) | https://github.com/iFayens/ComfyUI-PuLID-Flux2 | low | Outside window (Mar 21). Male ID gap known. → T2 |
+| `build_klein_face_detail` | Klein + CodeFormer | ⚠️ additive | ComfyUI-Flux-FaceIR (Klein-4B LoRA, ~6 GB) | https://github.com/cosmicrealm/ComfyUI-Flux-FaceIR | low | Outside window (Apr 7). Adds blind-restore path. → T2 |
+| `build_rembg_birefnet` | BiRefNet-general | ⚠️ additive | RMBG v3.1.0 Lucida fine-tune (~3 GB) | https://github.com/1038lab/ComfyUI-RMBG | low | Jul 21 (8 days before window). Transparent/VFX edge cases. → T2 |
+| `build_seedv2r` | SeedVR | ⚠️ additive | FlashVSR CVPR 2026 (17 FPS, ~8 GB) | https://github.com/OpenImagingLab/FlashVSR | low | Outside window (Nov 2025). Speed-mode complement; SeedVR2 still best quality. → T2 |
+| `build_hunyuan_3d_*` | HunyuanVideo3D 2.1 | ⚠️ additive | TRELLIS.2 + ComfyUI-Trellis2 (MIT, ~16 GB) | https://github.com/microsoft/TRELLIS.2 | medium | ComfyUI wrapper **IN-WINDOW** Jul 31. MIT license advantage. → T2 |
+| new | — | ➕ new | MiniMax H3 T2V/I2V (33.1B INT4 ~15 GB) | https://huggingface.co/MiniMaxAI/MiniMax-H3 | medium | **IN-WINDOW** Aug 3. Day-0 ComfyUI v0.30.0. → T2 |
+| new | — | ➕ new | Bernini-R V2V editor (Wan 2.2 backbone) | https://github.com/bytedance/Bernini | medium | Outside window (Jun 1). Apache 2.0, ComfyUI merged Jun 9. → T2 |
+| new | — | ➕ new | Z-Image Turbo (6B, FP8 ~8 GB) | https://huggingface.co/Comfy-Org/z_image_turbo | low | Outside window (Nov 2025). Comfy-Org packaged. → T2 |
+| new | — | ➕ new | ComfyUI-RMBG SAM2Segment node | https://github.com/1038lab/ComfyUI-RMBG | low | Jul 21. Same update as Lucida above. → T2 |
+| `build_ltx_video` | LTX-Video 2.3 | ✅ | — | — | — | Community INT8 quant (Jul 29) is packaging only. |
+| `build_wan_video` / `build_wan22_t2v` | WAN 2.1 / 2.2 | ✅ | — | — | — | No WAN 2.3+ open weights. Current ceiling. |
+| `build_supir` | SUPIR (SDXL) | ✅ | — | — | — | No successor found. Repo maintenance-only. |
+| `build_depth_map_v3` | DA3-large | ✅ | — | — | — | YOLO26 depth (Jul 29) is combined detect+depth; DA3 superior for pure depth. |
+| `build_rembg_v3` | RMBG-2.0 | ✅ | — | — | — | BRIA V-RMBG 3.0 is video API only; no image model. |
+| `build_normal_map` | Marigold | ✅ | — | — | — | RoSE (ICLR 2026) exists but no ComfyUI node. |
+| `build_colorize` / `build_ddcolor` | Klein / DDColor | ✅ | — | — | — | No new colorization models found. |
+| `build_face_restore` / `build_photo_restore` | CodeFormer | ⚠️ T3 | IConFace (Klein-4B, no node yet) | https://github.com/cosmicrealm/IConFace | low | Outside window (May 2026). No ComfyUI node yet. → T3 |
+| `build_qwen_edit` | Qwen2.5-VL | ⚠️ T3 | Qwen-Image-2.0-RL (7B, ~14 GB GGUF) | https://huggingface.co/papers/2606.27608 | low | Outside window (Jun 25). Checkpoint ID unconfirmed — verify before shipping. → T3 |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+### T1-1 · HunyuanVideo-1.5 FP8 → `build_hunyuan_video`
+
+**Released:** 2026-08-04 (**IN-WINDOW**)
+
+FP8 variants published by unsloth. Underlying HunyuanVideo-1.5 (Tencent, 2025-11-20, 8.3B params) supersedes the original 13B model Spellcaster currently uses. FP8 cuts transformer VRAM from ~17 GB to ~9 GB — comfortable on RTX 5060 Ti 16 GB. Native ComfyUI support confirmed.
+
+- 720p weights: https://huggingface.co/unsloth/HunyuanVideo-1.5-720p-FP8
+- 480p weights: https://huggingface.co/unsloth/HunyuanVideo-1.5-480p-FP8
+- Official repo: https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5
+
+**Action:** Update `build_hunyuan_video` checkpoint reference. No workflow graph changes needed.
+
+---
+
+### T1-2 · HyperSwap 1a/1b/1c → `build_faceswap` / `build_faceswap_model`
+
+**Released:** Q4 2025 (FaceFusion 3.3.0 model assets; outside window but unimplemented)
+
+Three-tier ONNX swapper: 1a=speed, 1b=balanced, 1c=quality (~403 MB each, 256 px). Reported better identity fidelity and blending than `inswapper_128.onnx`. Already supported in ComfyUI-ReActor (Issue #143). Drop ONNX files into `ComfyUI/models/hyperswap/`.
+
+- Model bundle: https://huggingface.co/facefusion/models-3.3.0
+
+**Action:** Add `hyperswap_1b_256.onnx` / `1c_256.onnx` as selectable swap models in `build_faceswap`. Requires local node-pack update to enable the new model class in ReActor.
+
+---
+
+### T1-3 · SAM 3.1 → `build_sam3_segment` / `build_sam3_mask` / `build_sam3_extract`
+
+**Released:** 2026-03-27 (outside window, but current SAM 3.0 is superseded)
+
+~7× faster inference, half the VRAM vs SAM 3.0. Native ComfyUI support merged upstream (Comfy-Org PR #13408, by kijai); also supported in ComfyUI-Easy-Sam3 and ComfyUI-TBG-SAM3. ComfyUI docs already document SAM 3.1 workflows under Utility > Video Segment.
+
+- Meta blog: https://ai.meta.com/blog/segment-anything-model-3/
+- Estimated VRAM: ~5 GB
+
+**Action:** Update SAM checkpoint reference in all three sam3 builders. API-compatible with SAM 3.0.
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+### T2-1 · MiniMax H3 → new `build_minimax_video`
+
+**Released:** 2026-08-03 (**IN-WINDOW**)
+
+33.1B omni-transformer: T2V + I2V + native stereo audio, up to 2K output. INT4 quantization (~15 GB) fits RTX 5060 Ti 16 GB with blockswap. Day-0 native ComfyUI support via Comfy-Org PR #15224 (ComfyUI v0.30.0+).
+
+- Repackaged weights: https://huggingface.co/Comfy-Org/MiniMax-H3
+- Original weights: https://huggingface.co/MiniMaxAI/MiniMax-H3
+
+**Action:** New `build_minimax_video` builder covering T2V and I2V modes.
+
+---
+
+### T2-2 · Krea 2 → new `build_krea2_txt2img` (or upgrade `build_txt2img`)
+
+**Released:** 2026-06-22
+
+12B single-stream MMDiT + Qwen3-VL-4B text encoder. FP8 ~13 GB; GGUF Q5_K_M ~8.87 GB. ComfyUI native since v0.26.0. Top-10 Artificial Analysis leaderboard. Permissive license. Identity-edit LoRA available (github.com/lbouaraba/comfyui-krea2edit).
+
+- Diffusers: https://huggingface.co/docs/diffusers/api/pipelines/krea2
+
+**Action:** New builder; strong SDXL/Flux replacement candidate for `build_txt2img` / `build_img2img` workflows.
+
+---
+
+### T2-3 · Bernini-R (ByteDance) → new `build_bernini_video`
+
+**Released:** 2026-06-01
+
+V2V editing, relighting, restyling, subject insertion via Wan 2.2 in-context reference conditioning. ComfyUI support merged (Comfy-Org PR #14216, Jun 9). Adds a video-editing category not currently in Spellcaster. 1.3B variant viable at 16 GB; 14B needs GGUF quantization for consumer use.
+
+- Weights: https://huggingface.co/ByteDance/Bernini-R
+- Node pack: https://github.com/AIMixer/ComfyUI-Bernini
+
+---
+
+### T2-4 · ComfyUI-PuLID-Flux2 v0.6.2 → upgrade `build_faceid_img2img`
+
+**Released:** 2026-03-21
+
+First PuLID implementation for FLUX.2 (Klein + Dev). Improved face recognition, fewer artifacts, native Klein weights. Uses InsightFace + EVA-CLIP. ~8 GB VRAM. Known gap: male ID fidelity inconsistent.
+
+- Weights: https://huggingface.co/Fayens/Pulid-Flux2
+- Node: https://github.com/iFayens/ComfyUI-PuLID-Flux2
+
+**Action:** Moves `build_faceid_img2img` from SD-era IPAdapter FaceID to FLUX.2 native identity.
+
+---
+
+### T2-5 · ComfyUI-Flux-FaceIR → additive path for `build_klein_face_detail`
+
+**Released:** 2026-04-07
+
+FLUX.2-Klein-4B LoRA + ComfyUI nodes for blind face restoration and reference-guided face restoration. Two modes: aligned face-patch input, or full-image with auto detect/align/paste-back. ~6 GB VRAM.
+
+- Node: https://github.com/cosmicrealm/ComfyUI-Flux-FaceIR
+- Companion: https://github.com/cosmicrealm/flux-restoration
+
+**Action:** Adds blind-restoration path that CodeFormer lacks; extend `build_klein_face_detail`.
+
+---
+
+### T2-6 · TRELLIS.2 + ComfyUI-Trellis2 → alternative `build_trellis2_3d`
+
+**ComfyUI wrapper updated:** 2026-07-31 (**IN-WINDOW**, added MultiView support + alpha fixes)
+
+4B O-Voxel sparse-voxel model (Microsoft). MIT license. Produces full PBR textured GLB assets. 16 GB VRAM minimum; viable at reduced resolution on RTX 5060 Ti. MIT license is a commercial advantage over Hunyuan community license.
+
+- Node: https://github.com/visualbruno/ComfyUI-Trellis2
+- Weights: https://huggingface.co/microsoft/TRELLIS.2
+
+**Action:** New builder (`build_trellis2_3d`) as MIT-licensed alternative to `build_hunyuan_3d_*`. Does not replace Hunyuan3D — additive.
+
+---
+
+### T2-7 · FlashVSR → speed-mode complement to `build_seedv2r`
+
+**Released:** 2025-11 (CVPR 2026)
+
+First one-step diffusion streaming video super-resolution. 17 FPS at 768×1408 on A100; 12× faster than prior single-step diffusion VSR. ~8 GB VRAM. Consensus: FlashVSR for speed, SeedVR2 for quality.
+
+- Repo: https://github.com/OpenImagingLab/FlashVSR
+- ComfyUI: https://github.com/1038lab/ComfyUI-FlashVSR (stable: https://github.com/naxci1/ComfyUI-FlashVSR_Stable)
+
+---
+
+### T2-8 · Z-Image Turbo → new `build_zimage_txt2img`
+
+**Released:** 2025-11
+
+6B, 8-step distilled model. FP8 ~8 GB VRAM; BF16 ~16 GB. Generates 1024×1024 in ~2.3s on RTX 4090. Comfy-Org pre-packaged. Z-Image-Edit adds instruction-following editing.
+
+- Weights: https://huggingface.co/Comfy-Org/z_image_turbo
+
+---
+
+### T2-9 · ComfyUI-RMBG v3.1.0 Lucida → additive for `build_rembg_birefnet`
+
+**Released:** 2026-07-21 (8 days before window)
+
+Adds Lucida, a BiRefNet fine-tune targeting transparent objects, camouflage, text/logos, glow/VFX — cases where generic BiRefNet struggles. Same 1038lab ecosystem as the current RMBG nodes. ~3 GB VRAM.
+
+- Node: https://github.com/1038lab/ComfyUI-RMBG
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+| Item | Blocker | URL |
+|---|---|---|
+| **FLUX 3** (BFL, announced Jul 23-28) | No open weights yet. When released, likely to supersede all Klein/FLUX.2 builders. | https://bfl.ai/blog/flux-3 |
+| **Qwen-Image-2.0-RL** (Alibaba, Jun 25) | Exact checkpoint ID unconfirmed on HuggingFace. Verify at huggingface.co/Qwen before integrating. Strong `build_qwen_edit` candidate (~14 GB GGUF Q4). | https://huggingface.co/papers/2606.27608 |
+| **IConFace** (cosmicrealm, May 2026) | No ComfyUI node yet. Compelling CodeFormer replacement for `build_face_restore` once wrapped. arXiv:2605.02814. | https://github.com/cosmicrealm/IConFace |
+| **Ideogram 4 FP8** (ideogram-ai, Jun 3) | Gated HF access, non-OSI license, tight 16 GB fit. Best-in-class text rendering; warrants `build_ideogram4_txt2img` if license cleared. | https://huggingface.co/ideogram-ai/ideogram-4-fp8 |
+| **Hunyuan3D-Omni** (Tencent, Aug 2025) | No standalone ComfyUI nodes yet. 10 GB VRAM, multi-condition 3D control. | https://github.com/Tencent-Hunyuan/Hunyuan3D-Omni |
+| **JoyAI-Image-Edit** (JD, May 2026) | ~18 GB INT8 — over 16 GB VRAM budget. Re-evaluate if lower-precision quant appears. | https://huggingface.co/jdopensource/JoyAI-Image-Edit |
+| **Pixal3D** (TencentARC SIGGRAPH 2026) | Borderline 16 GB (TRELLIS.2 backbone). Early ComfyUI wrappers exist. | https://github.com/TencentARC/Pixal3D |
+| **FaceFusion 3.8.0** (Jul 31, IN-WINDOW) | Infrastructure-only (FFmpeg, AV1, alpha). No new face model weights. Different toolchain from ReActor. | https://github.com/facefusion/facefusion/releases/tag/3.8.0 |
+| **LTX-2.3 INT8 quant** (Jul 29) | Community packaging only; no new model. | https://huggingface.co/SimpleTuner/ltxvideo-2.3-distilled-convrot-int8 |
+| **YOLO26 depth** (Jul 29) | Combined detection+depth; does not improve pure depth vs DA3-large. | https://www.ultralytics.com/blog/ultralytics-yolo26-now-supports-monocular-depth-estimation |
+
+---
+
+## No-finds (verified)
+
+The following were explicitly searched; no qualifying release found in or near the survey window:
+
+- SUPIR-2 or any diffusion upscaler successor to SUPIR
+- RMBG-3.0 image model (BRIA released video-only API; no image weights)
+- Marigold v1.2 or packaged normal-map successor (RoSE has no ComfyUI node)
+- New DDColor or standalone automatic colorization model
+- New open CodeFormer release
+- New ReActor version
+- WAN 2.3+ open weights (WAN 2.2 is current ceiling)
+- New Mochi or CogVideoX updates
+- New IPAdapter release (SD or Flux)
+- HunyuanVideo3D 2.2


### PR DESCRIPTION
## What does this change?

Adds the first weekly upgrade-research report (`_dev_docs/upgrade_research/2026-W32.md` + `2026-W32.json`). Automated daily SOTA survey covering image-gen, video, face/portrait, and restore/3D builder families against the 7-day window 2026-07-29 – 2026-08-05. No code changes — research artifact only.

## Type of change

- [ ] Bug fix
- [ ] New tool / new preset
- [ ] New ComfyUI architecture support
- [ ] Refactor (no behavior change)
- [x] Docs only
- [ ] Other

## Summary table

| Tier | Count | Highlights |
|---|---|---|
| **Tier 1** — drop-in supersessions | 3 | HunyuanVideo-1.5 FP8 (**in-window Aug 4**), HyperSwap 1c, SAM 3.1 |
| **Tier 2** — additive new builders | 9 | MiniMax H3 (**in-window Aug 3**), Krea 2, Bernini-R V2V, PuLID-Flux2, Flux-FaceIR, TRELLIS.2 (**in-window Jul 31 node update**), FlashVSR, Z-Image Turbo, RMBG Lucida |
| **Tier 3** — monitor / not wire-ready | 10 | FLUX 3 (no weights yet), Qwen-Image-2.0-RL, IConFace, Ideogram 4, Hunyuan3D-Omni, Pixal3D, … |
| **No-finds** | 11 | SUPIR-2, RMBG-3.0 image, Marigold successor, CodeFormer update, WAN 2.3+, … |

### In-window items (2026-07-29 – 2026-08-05)

- **MiniMax H3** (Aug 3) — 33.1B T2V+I2V omni-model, INT4 ~15 GB, day-0 ComfyUI v0.30.0. New `build_minimax_video` needed.
- **HunyuanVideo-1.5 FP8** (Aug 4) — supersedes 13B with 8.3B FP8 at ~9 GB VRAM. Drop-in for `build_hunyuan_video`.
- **ComfyUI-Trellis2 update** (Jul 31) — MultiView support added to MIT-licensed 3D mesh node.
- **FaceFusion 3.8.0** (Jul 31) — infrastructure only (FFmpeg/AV1); no new face model weights.
- **LTX-2.3 INT8 quant** (Jul 29) — community packaging of existing LTX-2.3; not a new model.
- **YOLO26 depth** (Jul 29) — combined detect+depth; does not improve `build_depth_map_v3`.

## Checklist

- [x] **No personal data in the diff.** No real IPs, no `C:\Users\...` paths, no email addresses, no tokens.
- [x] **No NSFW content in the public repo.** Nothing under `nsfw/` is staged.
- [x] **`spellcaster_core/` stays in sync.** No `spellcaster_core/` files were modified.
- [x] **New ComfyUI custom nodes are declared.** N/A — research doc only; no node installs in this PR.
- [x] **New GIMP procedures are registered in all three dicts.** N/A — research doc only.
- [ ] **Tested locally** — N/A for docs.

## Test plan

Research artifact only — no runnable code. Verify by reading `_dev_docs/upgrade_research/2026-W32.md`.

> **Reminder:** The nightly local export at `tools/export_comfyui_workflows.py` (runs at 03:30) will automatically refresh the ComfyUI workflow snapshots. Actual node-pack installs and model-weight swaps for Tier 1/2 items must be done on the local machine — this PR records what to install, not the installation itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U99gH3xDCCCSbdHpRGGgoY)_