### PR TITLE
chore(research): daily SOTA review 2026-08-14

### DIFF
--- a/_dev_docs/upgrade_research/2026-W33.json
+++ b/_dev_docs/upgrade_research/2026-W33.json
@@ -1,0 +1,132 @@
+[
+  {
+    "method": "build_ltx_video",
+    "category": "checkpoint",
+    "name": "LTX-2.5",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Lightricks/LTX-2.5",
+    "risk": "medium",
+    "confidence": 0.97,
+    "notes": "Released 2026-08-11 by Lightricks. Open weights. Day-one ComfyUI 0.32.0 native nodes (LTXV Spatio-Temporal Guidance, LTXV Modality Guidance, LTXV Dual CFG Guider, LTXV Duration Predictor). 22B transformer with distilled checkpoint; 16 GB VRAM feasible at reduced resolution with FP8. Adds multi-shot generation, audio-video coupling, diffusion video decoder replacing VAE reconstruction. Direct major version supersession of LTX-Video / LTX-2.3. Tier 1."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "Wan-Animate-2",
+    "source": "github",
+    "url": "https://github.com/Wan-Video/Wan-Animate-2",
+    "risk": "medium",
+    "confidence": 0.92,
+    "notes": "Released 2026-08-07 by Alibaba Tongyi Lab. Apache 2.0. 14B end-to-end character animation DiT; eliminates intermediate pose extractor. Native ComfyUI nodes: WanAnimate2ToVideo, WanAnimate2Cache. 480p feasible on 16 GB with INT8/FP8 quantization. Matches closed-source commercial SOTA (Dreamina, KLING MotionControl) in blind user studies. Wan-Animate-2-Lite streaming variant for real-time avatar use. Tier 1."
+  },
+  {
+    "method": "build_faceswap|build_faceswap_mtb",
+    "category": "node_pack",
+    "name": "FaceFusion 3.8.2",
+    "source": "github",
+    "url": "https://github.com/facefusion/facefusion/releases/tag/3.8.2",
+    "risk": "low",
+    "confidence": 0.95,
+    "notes": "Released 2026-08-10. Stability/compatibility patch: FFmpeg 9 fix (removed -vsync option), CUDA 12/13 VRAM leak fix, frame enhancer output scale fix. Not a new swap model checkpoint. Framework-level update; no new weights. If spellcaster uses FaceFusion backend, ensure dependency pinned to >=3.8.2 for CUDA 12/13 compat. Tier 3."
+  },
+  {
+    "method": "build_txt2img|build_img2img",
+    "category": "checkpoint",
+    "name": "Ideogram 4.0",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/ideogram-4-day-0-support-in-comfyui",
+    "risk": "low",
+    "confidence": 0.85,
+    "notes": "Released 2026-06-03 (outside 7-day window; first audit surfacing). 9.3B single-stream Diffusion Transformer. Open weights under Ideogram Non-Commercial Model Agreement (not Apache 2.0). Day-0 native ComfyUI support. Best-in-class text rendering and layout control, JSON-first structured prompting. 16 GB tight but feasible with offloading. No existing spellcaster builder. Would need new build_ideogram_txt2img. Tier 2."
+  },
+  {
+    "method": "build_wan_video|build_wan22_t2v|build_wan_flf",
+    "category": "checkpoint",
+    "name": "Wan 3.0",
+    "source": "github",
+    "url": "https://www.orcarouter.ai/blog/wan-3-0-release-date",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Public beta launched 2026-08-06 on Alibaba Cloud Model Studio. Generates 30-second clips with audio in single pass. Omni-reference (documents, slides, video). Apache 2.0 open weights CLAIMED by some sources but NOT confirmed; no weights on Wan-AI HuggingFace or Wan-Video GitHub as of 2026-08-14. API-only. Skip until weights ship. Tier 3."
+  },
+  {
+    "method": "build_txt2img|build_img2img|build_inpaint",
+    "category": "checkpoint",
+    "name": "Flux 3 (BFL)",
+    "source": "github",
+    "url": "https://www.marktechpost.com/2026/07/26/black-forest-labs-releases-flux-3-a-multimodal-flow-model-for-image-video-audio-and-robot-action-prediction/",
+    "risk": "low",
+    "confidence": 0.90,
+    "notes": "Announced 2026-07-26 by Black Forest Labs. Multimodal foundation model (image + video + audio + action prediction). Flux 3 Video available via API from 2026-08-05. Flux 3 Image API access announced. Open-weight Flux 3 Dev planned 'later 2026' — no date, no repo, no ComfyUI node. Monitor black-forest-labs HuggingFace org. Tier 3."
+  },
+  {
+    "method": "build_klein_headswap|build_klein_face_detail",
+    "category": "checkpoint",
+    "name": "Qwen-Image-3.0-Pro",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Qwen/Qwen-Image",
+    "risk": "low",
+    "confidence": 0.70,
+    "notes": "GA 2026-08-05 (model released Jul 21). Better skin/hair/pore rendering, 4.5K-token instruction limit. Already backbone for Qwen Edit headswap workflows in ComfyUI. Natural upgrade for build_klein_headswap and build_qwen_edit if they target Qwen Edit 2509/2511. Confirm current checkpoint version against Qwen-Image-3.0-Pro. 16 GB feasible. Tier 3 (near-window, need to verify version mismatch)."
+  },
+  {
+    "method": "build_sam3_segment|build_sam3_mask|build_sam3_extract|build_klein_sam3_inpaint",
+    "category": "checkpoint",
+    "name": "SAM 3.1 (Meta)",
+    "source": "github",
+    "url": "https://comfyui-wiki.com/en/models/sam/sam3.1",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Released 2026-03 by Meta. Now production-stable and natively supported in ComfyUI (sam3.1_multiplex model, no auth required unlike SAM3). Improved video tracking vs SAM3. Older item now production-stable. Verify build_sam3_* weight paths reference SAM 3.1 not SAM3/SAM2. Tier 3."
+  },
+  {
+    "method": "build_rembg_v3",
+    "category": "node_pack",
+    "name": "BEN2 in ComfyUI-RMBG v3.1.0",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-RMBG",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "ComfyUI-RMBG updated 2026-07-21 to v3.1.0 with BEN2 support (outside 7-day window). BEN2 offers enhanced batch processing (3 images/batch), better complex-scene accuracy vs BEN1. Could be a routing option in build_rembg_v3 alongside RMBG-2.0. Tier 3."
+  },
+  {
+    "method": "build_wan_video_blockswap|build_wan_animate_video",
+    "category": "controlnet",
+    "name": "Uni3C ControlNet for Wan (native ComfyUI)",
+    "source": "github",
+    "url": "https://github.com/Comfy-Org/ComfyUI/pull/14946",
+    "risk": "low",
+    "confidence": 0.80,
+    "notes": "Merged 2026-07-29 (outside window). Camera-control ControlNet for all Wan variants (2.1/2.2, T2V, I2V, VACE, Animate, etc.). New node: WanUni3CControlnetApply. Weights at Kijai/WanVideo_comfy: Wan21_Uni3C_controlnet_fp16.safetensors. Consider adding use_uni3c_controlnet option to build_wan_video_blockswap. Tier 3."
+  },
+  {
+    "method": "build_video_reactor",
+    "category": "checkpoint",
+    "name": "ID-V2V (Eyeline Labs / Netflix Research)",
+    "source": "github",
+    "url": "https://github.com/Eyeline-Labs/ID-V2V",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "ComfyUI PR merged 2026-07-29 (near-window). Identity-preserving video restylization via VACE + Wan I2V backbone; diffusion-native, no face-detection pipeline. Style from keyframe(s), identity from source video. int8 convrot weights at Kijai/Wan_ID_V2V_comfy. ~16 GB feasible at 480p. Different mechanism to face-swap (no ONNX detector). SIGGRAPH Asia 2026 paper. Tier 2 additive."
+  },
+  {
+    "method": "build_photobooth",
+    "category": "node_pack",
+    "name": "ComfyUI 0.32.0 Seedance 2.5 Virtual Portrait",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/unlock-seedance20-real-human-video-generation",
+    "risk": "low",
+    "confidence": 0.75,
+    "notes": "Available in ComfyUI 0.32.0 (released 2026-08-11). ByteDance Seedance 2.5 virtual portrait node: up to 20 reference images + 6 video clips as identity anchors, lip-sync and expression preservation for video. Cloud API, no local VRAM. Extends photobooth concept into video. Tier 3 (API-only, no local deployment)."
+  },
+  {
+    "method": "build_face_restore|build_photo_restore",
+    "category": "checkpoint",
+    "name": "RefSTAR (AAAI 2026)",
+    "source": "github",
+    "url": "https://github.com/yinzhicun/RefSTAR",
+    "risk": "medium",
+    "confidence": 0.40,
+    "notes": "AAAI 2026 paper; weights on GitHub. Reference-guided blind face restoration (RefSel + Arc2Face + CLIP + InsightFace). Outperforms CodeFormer on identity-preserving blind restoration. No ComfyUI node yet. Track for future packaging. Tier 3 (watch)."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W33.md
+++ b/_dev_docs/upgrade_research/2026-W33.md
@@ -1,0 +1,88 @@
+# Spellcaster daily SOTA review — 2026-08-14
+
+ISO week: `2026-W33`. Baseline: none (first audit).
+
+## Research scope
+
+Hardware budget: RTX 5060 Ti, 16 GB VRAM. Window: 2026-08-07 to 2026-08-14 (items outside the window flagged as near-miss or previously known).
+
+Sources: WebSearch, HuggingFace MCP, GitHub, blog.comfy.org, civitai.com. Four parallel research agents (image-gen, video-gen, face/portrait, restore/style/3D) plus direct searches.
+
+---
+
+## Findings table
+
+| Method(s) | Current backbone | Still SOTA? | Replacement / Addition | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| `build_ltx_video` | LTX-Video / LTX-2.3 | **No** | LTX-2.5 (Lightricks, Aug 11 2026) | https://huggingface.co/Lightricks/LTX-2.5 | medium | Day-one ComfyUI 0.32.0 nodes; open weights; 16 GB feasible (distilled FP8); new multi-shot, audio-video, diffusion decoder. Direct major version upgrade. |
+| `build_wan_animate_video` | Wan 2.2 Animate 14B | **No** | Wan-Animate-2 (Alibaba, Aug 7 2026) | https://github.com/Wan-Video/Wan-Animate-2 | medium | Apache 2.0; end-to-end pose-free character animation DiT; native ComfyUI nodes (`WanAnimate2ToVideo`, `WanAnimate2Cache`); 480p feasible on 16 GB with INT8/FP8 quant; matches commercial SOTA. |
+| `build_faceswap` / `build_faceswap_mtb` | inswapper_128, FaceFusion 3.7.x | Partial | FaceFusion 3.8.2 patch (Aug 10 2026) | https://github.com/facefusion/facefusion/releases/tag/3.8.2 | low | Bug-fix/compat release (FFmpeg 9, CUDA 12/13 VRAM leak fix); not a new swap model. Updates the framework dependency, not the checkpoint. |
+| `build_txt2img` / `build_img2img` (& related SDXL/Flux builders) | SDXL, Flux 2 Klein | Monitor | Ideogram 4.0 (Jun 3 2026) | https://blog.comfy.org/p/ideogram-4-day-0-support-in-comfyui | low | 9.3B single-stream DiT; open weights (non-commercial only); native ComfyUI day-0 support; best-in-class text rendering & layout. No spellcaster builder yet. 16 GB tight but feasible. Outside window — newly surfaced. |
+| `build_wan_video` / `build_wan22_t2v` family | WAN 2.2 | Monitor | Wan 3.0 public beta (Aug 6 2026) | https://www.orcarouter.ai/blog/wan-3-0-release-date | low | 30-second clips, omni-reference; **API-only, no open weights** as of Aug 14. Tier 3 until weights ship. |
+| `build_txt2img` / image builders | Flux 2 | Monitor | Flux 3 (BFL, Jul 26 2026) | https://www.marktechpost.com/2026/07/26/black-forest-labs-releases-flux-3-a-multimodal-flow-model | low | Multimodal (image + video + audio + action). **API-only**, no open weights, no ComfyUI node. Dev open weights planned "later 2026". Tier 3. |
+| `build_klein_headswap` / `build_klein_face_detail` | Klein 9B + Qwen Edit 2509 | Near-miss | Qwen-Image-3.0-Pro GA (Aug 5 2026) | https://huggingface.co/Qwen/Qwen-Image | low | Near-window (Aug 5). Better skin/hair detail, 4.5K-token instruction limit. Already backbone for headswap workflows; upgrade path natural. 16 GB feasible. Confidence 0.70. |
+| `build_sam3_*` | SAM3 | Partial | SAM 3.1 (Meta, Mar 2026) — now native in ComfyUI | https://comfyui-wiki.com/en/models/sam/sam3.1 | low | March release, now stable in ComfyUI. Improved video tracking vs SAM3. Spellcaster SAM3 nodes may need SAM 3.1 weight paths updated. Previously known older item now production-stable. |
+| `build_rembg_v3` | RMBG-2.0 | Partial | BEN2 (in ComfyUI-RMBG v3.1.0, Jul 21 2026) | https://github.com/1038lab/ComfyUI-RMBG | low | ComfyUI-RMBG updated Jul 21 with BEN2 support. Outside window. Better batch processing. Potential addition to `build_rembg_v3` routing. |
+| `build_wan_animate_video` | Wan 2.2 Animate | Monitor | Uni3C ControlNet for Wan (native in ComfyUI, Jul 29 2026) | https://github.com/Comfy-Org/ComfyUI/pull/14946 | low | Camera-control ControlNet for all Wan variants; `WanUni3CControlnetApply` node; outside strict window but newly native. Relevant to blockswap builders too. |
+| `build_video_reactor` | ReActor + face-detect pipeline | Monitor | ID-V2V (Eyeline/Netflix, Jul 29 2026 ComfyUI PR) | https://github.com/Eyeline-Labs/ID-V2V | medium | Identity-preserving video restylization via VACE + Wan I2V; diffusion-native, no face-detect step; 16 GB feasible (int8 convrot). Near-window (Jul 29). Different mechanism to face-swap. |
+| `build_photobooth` | Iterative frame ref | Monitor | ComfyUI 0.32.0 Seedance 2.5 virtual portrait (Aug 7–11 2026) | https://blog.comfy.org/p/unlock-seedance20-real-human-video-generation | low | API-based identity locking for video; up to 20 reference images + 6 clips. Extends photobooth into video. Cloud API, no VRAM cost. Confidence 0.75. |
+| `build_supir` / `build_photo_restore` | SUPIR (SDXL) / CodeFormer | Monitor | RefSTAR blind face restore (AAAI 2026) | https://github.com/yinzhicun/RefSTAR | medium | Reference-guided blind restore, beats CodeFormer. No ComfyUI node yet. Weights on GitHub. Worth watching. |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+**LTX-2.5** replaces `build_ltx_video` directly: same workflow pattern, new open weights at `Lightricks/LTX-2.5`, day-one ComfyUI 0.32.0 nodes, runs on 16 GB (distilled FP8, sub-720p). The current `build_ltx_video` builder targets the LTX-Video / LTX-2.3 checkpoint; the node class types changed in 0.32.0 (`LTXV Spatio-Temporal Guidance`, `LTXV Modality Guidance`, `LTXV Dual CFG Guider`, `LTXV Duration Predictor`). Requires updating checkpoint paths and node class types. **VRAM floor: 16 GB**.
+
+**Wan-Animate-2** replaces `build_wan_animate_video`: new open-weight 14B DiT (Apache 2.0) from Alibaba Tongyi Lab, eliminates intermediate pose extractor, native ComfyUI nodes (`WanAnimate2ToVideo`, `WanAnimate2Cache`). Matches or beats commercial SOTA on blind user studies. Feasible on 16 GB at 480p with INT8/FP8 quantization. Requires node-pack install (ComfyUI-WanVideoWrapper updates needed).
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+- **Ideogram 4.0** (Jun 3, 2026): New image architecture (9.3B single-stream DiT), best text rendering in open-weight class, native ComfyUI day-0 support. No existing `build_ideogram_*` method. Non-commercial license on weights. Would need a new `build_ideogram_txt2img` builder. Node pack: ComfyUI native (Ideogram 4.0 day-0). Outside 7-day window but first surfacing in audit.
+
+- **ID-V2V** (ComfyUI PR merged Jul 29): Diffusion-based identity-preserving video restylization (Wan VACE backbone). Alternative/complement to `build_video_reactor` for cases where face-detection-free approach is preferred. Weights at `Kijai/Wan_ID_V2V_comfy`. Would need new `build_id_v2v` builder or option flag on `build_video_reactor`.
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+- **Wan 3.0** (Aug 6 public beta): No open weights. API-only on Alibaba Cloud. Would eventually supersede `build_wan_video` family. Watch `Wan-Video` org on GitHub/HF for weight release.
+
+- **Flux 3** (BFL, Jul 26): No open weights, no ComfyUI node. "Dev" open weights planned Q4 2026. Would require new builders for image + video. Watch `black-forest-labs` on HF.
+
+- **FaceFusion 3.8.2** (Aug 10): Framework patch only. No new checkpoint weights or architecture. Monitor for 3.9.x which may introduce new swap model.
+
+- **Qwen-Image-3.0-Pro** (GA Aug 5): Upgrade backbone for Klein/Qwen headswap workflows. Currently used via Qwen Edit 2509/2511 paths. Near-window. Confirm whether spellcaster's `build_qwen_edit` / `build_klein_headswap` target the right checkpoint version.
+
+- **RefSTAR** (AAAI 2026): Reference-guided blind face restoration, beats CodeFormer. Weights on GitHub but no ComfyUI node yet. Track `yinzhicun/RefSTAR`.
+
+- **Uni3C ControlNet for Wan** (Jul 29): Now native in ComfyUI. Camera control for all Wan variants. Relevant to blockswap builders. Consider adding a `use_uni3c_controlnet` option to `build_wan_video_blockswap`.
+
+- **SAM 3.1** (Meta, Mar 2026): Now production-stable and native in ComfyUI. Improved video tracking. Verify `build_sam3_*` are referencing SAM 3.1 weights (not SAM 3 / SAM 2 paths).
+
+---
+
+## No-finds (verified)
+
+The following were searched and returned no novel in-window (Aug 7–14) releases relevant to spellcaster:
+
+- **ReActor ComfyUI node**: Last commit May 2026. No August update.
+- **ComfyUI-PuLID-Flux2**: Last update May 2026. No change.
+- **InstantID / InstantCharacter**: No August 2026 updates.
+- **GFPGAN**: No 2026 major version.
+- **HyperSwap model weights**: No new variant (1D/2×). Current set: 1A/1B/1C.
+- **FaceFusion checkpoint models** (separate from framework): Last release March 2026 (models-3.6.0).
+- **HunyuanImage-3.0**: Released Sep 2025 / Jan 2026. 160 GB VRAM minimum — **exceeds hardware budget entirely**. Skip.
+- **MiniMax H3 / Hailuo 3.0**: 42.5 GB minimum even at INT4 — **exceeds 16 GB budget 2.6×**. Skip.
+- **CogVideoX**: No August 2026 update found.
+- **Mochi video**: No August 2026 update found.
+- **FramePack**: No August 2026 update found.
+- **DDCOLOR (colorization)**: No new version found.
+- **BiRefNet background removal**: No August release; active but no in-window update.
+- **RMBG-3.0**: No such release found as of Aug 14. Current is RMBG-2.0.
+
+---
+
+*Generated 2026-08-14 by automated daily SOTA review agent.*


### PR DESCRIPTION
## Summary

Daily automated SOTA audit for ISO week `2026-W33` (2026-08-07 → 2026-08-14). First audit — no prior baseline. Sources: 4 parallel research agents + HuggingFace MCP + WebSearch. Hardware constraint: RTX 5060 Ti, 16 GB VRAM.

### Findings summary

| Tier | Count | Items |
|---|---|---|
| **Tier 1 — drop-in supersessions** | 2 | LTX-2.5 (`build_ltx_video`), Wan-Animate-2 (`build_wan_animate_video`) |
| **Tier 2 — additive new builders** | 2 | Ideogram 4.0 (new builder needed), ID-V2V (video restylization) |
| **Tier 3 — monitor / not wire-ready** | 9 | Wan 3.0, Flux 3, FaceFusion 3.8.2, Qwen-Image-3.0-Pro, SAM 3.1, BEN2/ComfyUI-RMBG, Uni3C ControlNet, Seedance 2.5 portrait, RefSTAR |
| **No-finds (verified)** | 14 | ReActor, PuLID-Flux2, InstantID, GFPGAN, HyperSwap, HunyuanImage-3.0 (too large), MiniMax H3 (too large), CogVideoX, Mochi, FramePack, DDCOLOR, BiRefNet, RMBG-3.0 (doesn't exist), CodeFormer++ (no weights) |

### Tier-1 detail

**LTX-2.5** (Lightricks, 2026-08-11 — _in window_)
Released with open weights at `Lightricks/LTX-2.5` on HuggingFace. Day-one native support in ComfyUI 0.32.0 with four new node types (`LTXV Spatio-Temporal Guidance`, `LTXV Modality Guidance`, `LTXV Dual CFG Guider`, `LTXV Duration Predictor`). Adds multi-shot generation, audio-video coupling, and a diffusion video decoder replacing VAE reconstruction. 16 GB VRAM feasible with distilled FP8 checkpoint at sub-720p. Directly supersedes the LTX-Video / LTX-2.3 checkpoint used by `build_ltx_video`. **Node class types changed — builder update required.**

**Wan-Animate-2** (Alibaba Tongyi Lab, 2026-08-07 — _in window_)
Apache 2.0 open weights; 14B end-to-end character animation DiT eliminating intermediate pose extraction. Native ComfyUI nodes: `WanAnimate2ToVideo`, `WanAnimate2Cache`. Matches commercial SOTA (Dreamina, KLING MotionControl) in blind user studies. 480p feasible on 16 GB with INT8/FP8 quantization. Wan-Animate-2-Lite variant for real-time streaming. Directly supersedes the Wan 2.2 Animate 14B checkpoint in `build_wan_animate_video`. **Requires ComfyUI-WanVideoWrapper update.**

### Implementation note

Both Tier-1 items require local node-pack installs (ComfyUI update to 0.32.0 for LTX-2.5; updated WanVideoWrapper for Wan-Animate-2) — these can only happen on the user's machine. The `tools/export_comfyui_workflows.py` nightly export at **03:30 local time** will automatically refresh ComfyUI workflow snapshots once the node packs are installed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHCBGYjGeyZ6bGCiyxZjyt)_