### PR TITLE
chore(research): daily SOTA review 2026-08-15

### DIFF
--- a/_dev_docs/upgrade_research/2026-W33.json
+++ b/_dev_docs/upgrade_research/2026-W33.json
@@ -1,0 +1,92 @@
+[
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-Edit-2511",
+    "source": "huggingface",
+    "url": "https://huggingface.co/QwenLM/Qwen-Image-Edit-2511",
+    "risk": "low",
+    "confidence": 0.92,
+    "notes": "Drop-in replacement for Qwen-Image 2509 already wired in build_qwen_edit. Same UNET architecture; 2511 adds multi-angle view generation and better face identity preservation. Released Dec 26 2025, now has native ComfyUI workflow docs (docs.comfy.org). Only checkpoint path needs updating."
+  },
+  {
+    "method": "build_rembg_birefnet",
+    "category": "checkpoint",
+    "name": "BiRefNet-Lucida",
+    "source": "github",
+    "url": "https://github.com/1038lab/ComfyUI-RMBG",
+    "risk": "low",
+    "confidence": 0.88,
+    "notes": "Additive BiRefNet fine-tune specialised for transparent objects, camouflage, text/logos, and glow/VFX. Added in ComfyUI-RMBG v3.1.0 (Jul 21 2026). Same BiRefNetRMBG node class; expose as new model option in the model parameter. Not a replacement for BiRefNet-general on standard shots."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "Wan2.2-Animate-2-14B",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-2-14B",
+    "risk": "medium",
+    "confidence": 0.9,
+    "notes": "End-to-end Diffusion Transformer character animation; eliminates intermediate motion extractors used by current WAN animate stack. Released Aug 6-7 2026 with same-day native ComfyUI support (WanAnimate2ToVideo + WanAnimate2Cache nodes). ~11 GB VRAM at Q4_K_M — feasible on 16 GB with quantisation. Distilled variant (Wan2.2-Animate-2-14B-Distilled) and W4A4 quant (ApacheOne/Wan2.2-Animate-2-14B-OrbitQuant-W4A4, Aug 11) also available. Requires new builder method."
+  },
+  {
+    "method": "build_wan_animate_video",
+    "category": "checkpoint",
+    "name": "Wan2.2-Animate-2-14B-Distilled-Diffusers",
+    "source": "huggingface",
+    "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-2-14B-Distilled-Diffusers",
+    "risk": "medium",
+    "confidence": 0.9,
+    "notes": "Distilled variant of Wan2.2-Animate-2-14B. Faster inference, real-time streaming targets. See parent record above for full context."
+  },
+  {
+    "method": "build_minimax_h3_video",
+    "category": "checkpoint",
+    "name": "MiniMax-H3",
+    "source": "huggingface",
+    "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3",
+    "risk": "medium",
+    "confidence": 0.85,
+    "notes": "Entirely new builder needed. Open-weights omni-modal model (text/image/video/audio → video + native 32 kHz stereo audio). Up to 2K, 15 seconds per clip. Launched Aug 3 2026 with same-day ComfyUI native support (4 nodes, 6 workflow templates). VRAM ~11.7 GB; on 16 GB card practical output capped around 960x544 with generation times >10 min per clip. Audio output is a new capability not currently in Spellcaster. Needs local node-pack install and model download before wiring."
+  },
+  {
+    "method": "build_video_rembg",
+    "category": "checkpoint",
+    "name": "Bria VRMBG 3.0",
+    "source": "huggingface",
+    "url": "https://huggingface.co/briaai/VRMBG-3.0",
+    "risk": "medium",
+    "confidence": 0.75,
+    "notes": "Video background removal (temporal-aware). Eliminates flickering from frame-by-frame approaches by propagating alpha across frames. Launched Jun 10 2026. 9x faster than competitors in benchmarks. New capability not yet in Spellcaster. ComfyUI node support status unclear — check 1038lab/ComfyUI-RMBG for VRMBG 3.0 integration. If available locally, wire a build_video_rembg method."
+  },
+  {
+    "method": "build_txt2img",
+    "category": "checkpoint",
+    "name": "Ideogram 4.0",
+    "source": "github",
+    "url": "https://blog.comfy.org/p/ideogram-4-day-0-support-in-comfyui",
+    "risk": "high",
+    "confidence": 0.7,
+    "notes": "DEFERRED: 9.3B T2I model with Qwen3-VL-8B-Instruct text encoder, specialised for structured text in images. NF4 checkpoint targets 24 GB GPU; FP8 untested on 16 GB. Released Jun 3 2026 with native ComfyUI day-0 support. Non-commercial license. Re-evaluate when confirmed 16 GB compatible build appears."
+  },
+  {
+    "method": "build_qwen_edit",
+    "category": "checkpoint",
+    "name": "Qwen-Image-Layered",
+    "source": "github",
+    "url": "https://github.com/QwenLM/Qwen-Image",
+    "risk": "high",
+    "confidence": 0.65,
+    "notes": "DEFERRED: Decomposes images into multiple RGBA layers for independent editing. Peak VRAM 45 GB on RTX Pro 6000; even FP8 variant likely exceeds 16 GB budget. Released Dec 19 2025. Re-evaluate when a confirmed 16 GB-compatible quantisation exists."
+  },
+  {
+    "method": "build_wan22_t2v",
+    "category": "checkpoint",
+    "name": "SeeDance 2.5",
+    "source": "huggingface",
+    "url": "https://technode.com/2026/07/31/bytedance-launches-seedance-2-5-video-generation-model/",
+    "risk": "high",
+    "confidence": 0.8,
+    "notes": "SKIPPED: Cloud API only — all inference runs on ByteDance servers. No local weights released. 30-second native video; ComfyUI support added Aug 7 2026 via partner nodes, but generation itself is remote. Not usable on RTX 5060 Ti without internet dependency."
+  }
+]

--- a/_dev_docs/upgrade_research/2026-W33.md
+++ b/_dev_docs/upgrade_research/2026-W33.md
@@ -1,0 +1,167 @@
+# Spellcaster daily SOTA review — 2026-08-15
+
+ISO week: `2026-W33`. Baseline: _no prior baseline — first run_.
+
+Review window: **2026-08-08 → 2026-08-15**.
+Hardware budget: **RTX 5060 Ti, 16 GB VRAM** (models requiring more are deferred to Tier 3 or skipped).
+
+---
+
+## Findings table
+
+| Method | Current backbone | Still SOTA? | Replacement (if not) | Source URL | Risk | Notes |
+|---|---|---|---|---|---|---|
+| build_wan_animate_video | WAN 2.2 animate (kijai wrapper) | **No** | Wan-AI/Wan2.2-Animate-2-14B | https://huggingface.co/Wan-AI/Wan2.2-Animate-2-14B | medium | End-to-end DiT; eliminates intermediate motion extractors; 14B params; ~11 GB VRAM at Q4_K_M; native ComfyUI nodes WanAnimate2ToVideo + WanAnimate2Cache shipped Aug 7. W4A4 quant released Aug 11. |
+| build_qwen_edit | Qwen-Image 2509 UNET | **No** | Qwen-Image-Edit-2511 | https://huggingface.co/QwenLM/Qwen-Image-Edit-2511 | low | Same UNET architecture; 2511 (Dec 26 2025) adds multi-angle view generation + better face identity preservation vs 2509; now has native ComfyUI workflow docs. |
+| build_rembg_birefnet | BiRefNet-general | Partial | BiRefNet-Lucida (additive variant) | https://github.com/1038lab/ComfyUI-RMBG | low | Lucida is a BiRefNet fine-tune for transparent objects, camouflage, text/logos, glow/VFX; added to ComfyUI-RMBG v3.1.0 (Jul 21 2026); additive option, not a replacement. |
+| build_hunyuan_video | HunyuanVideo | Yes | — | — | — | No drop-in replacement in past 7 days. |
+| build_ltx_video | LTX Video | Yes | — | — | — | No replacement found in past 7 days. |
+| build_mochi_video | Mochi video | Yes | — | — | — | No replacement found in past 7 days. |
+| build_cogvideo_video | CogVideoX | Yes | — | — | — | No replacement found in past 7 days. |
+| build_framepack_video | FramePack | Yes | — | — | — | No replacement found in past 7 days. |
+| build_wan_video | WAN video | Yes | — | — | — | No replacement found in past 7 days. |
+| build_wan22_t2v | WAN 2.2 T2V | Yes | — | — | — | No replacement found in past 7 days. |
+| build_wan_flf | WAN first-last-frame | Yes | — | — | — | No replacement found in past 7 days. |
+| build_wan_video_blockswap | WAN video blockswap | Yes | — | — | — | No replacement found. |
+| build_wan_video_blockswap_t2v | WAN video blockswap T2V | Yes | — | — | — | No replacement found. |
+| build_seedvr2_video_upscale | SeedVR2 | Yes | — | — | — | Community SeedVR2 v2.5 install guides appeared; needs verification vs current wired version. |
+| build_wavespeed_upscale | WaveSpeed / SeedVR2 | Yes | — | — | — | No replacement in past 7 days. |
+| build_video_upscale | 4x-UltraSharp | Yes | — | — | — | No replacement in past 7 days. |
+| build_upscale | traditional upscalers | Yes | — | — | — | No replacement in past 7 days. |
+| build_upscale_blend | traditional upscalers (blend) | Yes | — | — | — | No replacement in past 7 days. |
+| build_video_reactor | ReActor + FaceID | Yes | — | — | — | ReActor updated; GPEN 1024/2048 support added. No architectural replacement. |
+| build_faceswap | inswapper_128.onnx | Yes | — | — | — | No new face swap models found in past 7 days. |
+| build_faceswap_model | inswapper_128.onnx | Yes | — | — | — | Same as above. |
+| build_faceswap_mtb | MTB face swap | Yes | — | — | — | No replacement found. |
+| build_pulid_flux | PuLID Flux | Yes | — | — | — | PuLID in maintenance-only mode since Apr 2025; no Aug 2026 updates. |
+| build_faceid_img2img | FaceID / IP-Adapter | Yes | — | — | — | No new FaceID updates in past 7 days. |
+| build_face_restore | GFPGANv1.4 | Yes | — | — | — | No new face restoration models in past 7 days. |
+| build_photo_restore | GFPGAN + upscaler | Yes | — | — | — | No replacement found. |
+| build_photobooth | Flux / Klein | Yes | — | — | — | No replacement found. |
+| build_klein_headswap | Flux 2 Klein | Yes | — | — | — | No replacement found. |
+| build_klein_face_detail | Flux 2 Klein | Yes | — | — | — | No replacement found. |
+| build_detail_hallucinate | upscaler + diffusion | Yes | — | — | — | No replacement found. |
+| build_save_face_model | InsightFace | Yes | — | — | — | No replacement found. |
+| build_txt2img | SDXL / Flux 1 / Klein | Yes | — | — | — | FLUX.2 family (Klein) already wired. No new SDXL successor in 7-day window. Ideogram 4.0 open-weights is not SDXL but needs 24 GB VRAM → deferred. |
+| build_img2img | SDXL / Flux 1 / Klein | Yes | — | — | — | Same as txt2img. |
+| build_inpaint | SDXL / Flux 1 | Yes | — | — | — | No new inpainting arch in past 7 days. |
+| build_inpaint_fooocus | Fooocus inpaint | Yes | — | — | — | No replacement found. |
+| build_outpaint | SDXL / Flux 1 | Yes | — | — | — | No replacement found. |
+| build_controlnet_gen | ControlNet (various) | Yes | — | — | — | No major new ControlNet in past 7 days. |
+| build_generate_anything | BiRefNet + SDXL | Yes | — | — | — | No replacement found. |
+| build_style_transfer | SDXL | Yes | — | — | — | No replacement found. |
+| build_lumina2_txt2img | Lumina 2 | Yes | — | — | — | No replacement found. |
+| build_iclight | ICLight | Yes | — | — | — | No replacement found. |
+| build_layer_blend | blend node | Yes | — | — | — | No replacement found. |
+| build_magic_eraser | SAM3 + LaMa | Yes | — | — | — | No replacement found. |
+| build_lama_remove | LaMa | Yes | — | — | — | No replacement found. |
+| build_supir | SUPIR + SDXL | Yes | — | — | — | No SUPIR replacement found in past 7 days. |
+| build_color_match | color-matching node | Yes | — | — | — | No replacement found. |
+| build_klein_color_match | Klein + color-match | Yes | — | — | — | No replacement found. |
+| build_colorize | ddcolor + diffusion | Yes | — | — | — | No replacement found. |
+| build_ddcolor | ddcolor | Yes | — | — | — | No new colorization models found. |
+| build_lut | LUT node | Yes | — | — | — | No replacement found. |
+| build_rembg | rembg | Yes | — | — | — | No rembg replacement found. |
+| build_rembg_v3 | RMBG-2.0 | Yes | — | — | — | Bria VRMBG 3.0 is video-only and new capability; not a replacement for static-image RMBG. |
+| build_sam3_segment | SAM3 | Yes | — | — | — | No SAM3 updates in past 7 days. |
+| build_sam3_mask | SAM3 | Yes | — | — | — | Same. |
+| build_sam3_extract | SAM3 | Yes | — | — | — | Same. |
+| build_normal_map | normal map node | Yes | — | — | — | No replacement found. |
+| build_depth_map_v3 | da3_large.safetensors | Yes | — | — | — | Already on DA3; Depth Anything 3 was published Jan 2026 (ICLR 2026 oral) — Spellcaster is current. |
+| build_hunyuan_3d_mesh | HunyuanVideo 3D | Yes | — | — | — | No replacement found. |
+| build_hunyuan_3d_textured | HunyuanVideo 3D | Yes | — | — | — | No replacement found. |
+| build_seedv2r | SeedV2R diffusion | Yes | — | — | — | No replacement found. |
+| build_klein_* (other methods) | Flux 2 Klein 4B/9B | Yes | — | — | — | No new Klein-tier UNET released in past 7 days. |
+
+---
+
+## Tier 1 — drop-in supersessions (ship soon)
+
+### 1. Qwen-Image-Edit-2511 → `build_qwen_edit`
+
+Qwen-Image-Edit-2511 (released Dec 26 2025, now native in ComfyUI) supersedes the 2509 weights already wired in `build_qwen_edit`. The UNET architecture is unchanged; 2511 improves multi-image editing consistency, adds multi-angle view generation from a single reference image, and refines face identity preservation. Swapping the model file is the only code change needed.
+
+- **HF**: https://huggingface.co/QwenLM/Qwen-Image-Edit-2511
+- **ComfyUI docs**: https://docs.comfy.org/tutorials/image/qwen/qwen-image-edit-2511
+- **Risk**: low — same node class, same workflow graph, only checkpoint path changes
+- **Action**: update the default `unet_name` / `clip_name` / `vae_name` parameters in `build_qwen_edit` to point at the 2511 checkpoint
+
+### 2. BiRefNet-Lucida (additive) → `build_rembg_birefnet`
+
+ComfyUI-RMBG v3.1.0 (Jul 21 2026) added `BiRefNet-Lucida`, a fine-tune specialised for transparent objects, camouflage, glow/VFX, and illustrated content — all cases where the general-purpose BiRefNet struggles. It runs through the same `BiRefNetRMBG` node class.
+
+- **Node pack**: https://github.com/1038lab/ComfyUI-RMBG
+- **Risk**: low — additive model option, no workflow graph changes
+- **Action**: expose `BiRefNet-Lucida` as a selectable option in `build_rembg_birefnet`'s `model` parameter
+
+---
+
+## Tier 2 — additive new builders (needs node-pack install)
+
+### 1. Wan Animate 2 → replaces / supersedes `build_wan_animate_video`
+
+Alibaba Tongyi Lab released **Wan2.2-Animate-2-14B** (Aug 6-7 2026) with native ComfyUI support same day. This is an end-to-end character animation framework: a reference character image + a driving pose video produce animated output entirely inside a redesigned Diffusion Transformer, eliminating the separate motion-extractor step of prior WAN animate workflows.
+
+- **HF (base)**: https://huggingface.co/Wan-AI/Wan2.2-Animate-2-14B
+- **HF (distilled)**: https://huggingface.co/Wan-AI/Wan2.2-Animate-2-14B-Distilled-Diffusers
+- **HF (W4A4 quant, Aug 11)**: https://huggingface.co/ApacheOne/Wan2.2-Animate-2-14B-OrbitQuant-W4A4
+- **New ComfyUI nodes**: `WanAnimate2ToVideo`, `WanAnimate2Cache`
+- **VRAM**: ~11 GB at Q4_K_M; feasible on 16 GB with quantisation or sequential offload
+- **Risk**: medium — new node class + new model download; driving video format must match distilled pipeline
+- **Action**: wire a new `build_wan_animate2_video` method (or supersede current); needs the Wan-AI ComfyUI node pack update
+
+### 2. MiniMax H3 → new builder `build_minimax_h3_video`
+
+**MiniMax H3** launched Aug 3 2026 as an open-weights omni-modal model: accepts text, images, video, or audio → outputs up to 15-second 2K video **with native 32 kHz stereo audio** in one pass. ComfyUI native support merged same day (PR #15224), shipping 4 new nodes and 6 official workflow templates.
+
+- **HF (official weights)**: https://huggingface.co/MiniMaxAI/MiniMax-H3 (to verify)
+- **ComfyUI blog post**: https://blog.comfy.org/p/minimax-h3-day-0-support-in-comfyui
+- **New nodes**: `MiniMaxH3TextToVideo`, `MiniMaxH3ImageToVideo`, `MiniMaxH3ReferenceToVideo`, etc.
+- **VRAM**: ~11.7 GB; on a 16 GB card output resolution is limited to ~960×544 at practical inference times (>10 min per clip at higher res)
+- **Risk**: medium — entirely new builder; 16 GB card feasible but slow at full quality; audio output also new capability for Spellcaster
+- **Action**: add `build_minimax_h3_video` once node pack is installed locally
+
+### 3. Bria VRMBG 3.0 → new builder `build_video_rembg` (potential)
+
+Bria released **V-RMBG 3.0** (Jun 10 2026): a temporal-aware video background removal model that propagates alpha across frames, eliminating the flickering from frame-by-frame approaches. This capability does not exist in Spellcaster today.
+
+- **HF**: https://huggingface.co/briaai/VRMBG-3.0
+- **API**: https://fal.ai/models/bria/video/background-removal/realtime
+- **Risk**: medium — new capability; must confirm local-inference path (weights are on HF but ComfyUI node pack availability unclear)
+- **Action**: investigate ComfyUI-RMBG for VRMBG 3.0 node support; if available, wire `build_video_rembg`
+
+---
+
+## Tier 3 — monitor / not wire-ready
+
+| Model | Reason deferred | URL |
+|---|---|---|
+| **Ideogram 4.0** (Jun 3 2026) | NF4 checkpoint needs 24 GB GPU; FP8 untested on 16 GB | https://blog.comfy.org/p/ideogram-4-day-0-support-in-comfyui |
+| **Qwen-Image-Layered** (Dec 19 2025) | Peak VRAM 45 GB on RTX Pro 6000; even FP8 likely exceeds 16 GB | https://github.com/QwenLM/Qwen-Image |
+| **SeeDance 2.5** (Jul 2026, ComfyUI Aug 7) | Cloud API only — inference runs on ByteDance servers; no local weights released | https://technode.com/2026/07/31/bytedance-launches-seedance-2-5-video-generation-model/ |
+| **MiniMax Music 3** (Aug 13 2026, ComfyUI v0.33.1) | Audio-only generation; not in Spellcaster's image/video scope | https://blog.comfy.org/p/minimax-music-3-state-of-the-art |
+| **SeedVR2 v2.5** | Community install guides appeared; version bump vs current wired weights unclear; needs local verification | https://seedvr2.net/blog/tutorials/seedvr2-v25-installation-guide-2026 |
+
+---
+
+## No-finds (verified)
+
+The following categories were explicitly searched and returned no significant new models, node packs, or LoRAs within the past 7 days:
+
+- **ControlNet**: No new ControlNet models or adapters for Flux/SDXL found in Aug 8-15 window.
+- **Face swap (inswapper / ReActor)**: ReActor received minor GPEN 1024/2048 quality updates; no architectural replacement found.
+- **PuLID / FaceID**: PuLID has been in maintenance-only mode since April 2025; no August 2026 updates. FaceID unchanged.
+- **Face restoration (GFPGAN / CodeFormer)**: No new face restoration models released in past 7 days.
+- **SAM3**: No updates to Segment Anything Model 3 found.
+- **Depth estimation**: Spellcaster already uses `da3_large.safetensors` (Depth Anything 3, ICLR 2026); no v4 found.
+- **SDXL successor**: No new open-weight SDXL-successor model in past 7 days. Flux 1/2 Klein remain current for that tier.
+- **LaMa / object removal**: No new LaMa-class model found.
+- **ICLight**: No new ICLight version found.
+- **SUPIR**: No new SUPIR version found.
+- **HunyuanVideo 3D**: No new 3D-gen model found.
+
+---
+
+## Tooling note
+
+The `tools/export_comfyui_workflows.py` nightly export (scheduled 03:30 local) will automatically refresh all ComfyUI workflow snapshots — no manual action needed for that side of the pipeline.


### PR DESCRIPTION
## Summary

Automated daily SOTA survey for 2026-W33 (review window 2026-08-08 → 2026-08-15).
Adds `_dev_docs/upgrade_research/2026-W33.md` and `2026-W33.json`. No prior baseline — first run of this routine.

### Findings at a glance

| Tier | Count | Items |
|---|---|---|
| **Tier 1** — drop-in supersessions (ship soon) | 2 | Qwen-Image-Edit-2511 → `build_qwen_edit`; BiRefNet-Lucida → `build_rembg_birefnet` |
| **Tier 2** — additive new builders | 3 | Wan Animate 2 (supersedes `build_wan_animate_video`); MiniMax H3 (new `build_minimax_h3_video`); Bria VRMBG 3.0 (new `build_video_rembg`) |
| **Tier 3** — monitor / not wire-ready | 5 | Ideogram 4.0 (needs 24 GB VRAM); Qwen-Image-Layered (45 GB peak VRAM); SeeDance 2.5 (API-only); MiniMax Music 3 (audio-only); SeedVR2 v2.5 (version unclear) |
| **No-finds** | 11 | ControlNet, PuLID, FaceID, face restoration, SAM3, depth estimation, SDXL successor, LaMa, ICLight, SUPIR, HunyuanVideo 3D |

### Key Tier-1 actions for the local machine
1. **`build_qwen_edit`** — swap checkpoint to `Qwen-Image-Edit-2511` (same node graph, same UNET arch; better face identity and multi-angle generation).
2. **`build_rembg_birefnet`** — expose `BiRefNet-Lucida` as a selectable `model` option (same ComfyUI-RMBG node, added in v3.1.0).

### Key Tier-2 actions for the local machine (needs node-pack install first)
1. **Wan Animate 2** (`Wan-AI/Wan2.2-Animate-2-14B`) — end-to-end DiT character animation released Aug 7 2026; fits 16 GB at Q4_K_M; `WanAnimate2ToVideo` + `WanAnimate2Cache` nodes ship natively. Wire as `build_wan_animate2_video`.
2. **MiniMax H3** — open-weights omni-modal video+audio model, ~11.7 GB VRAM, native ComfyUI support (4 nodes). Wire as `build_minimax_h3_video`.
3. **Bria VRMBG 3.0** (`briaai/VRMBG-3.0`) — temporal-aware **video** background removal; new capability not yet in Spellcaster. Confirm ComfyUI node availability before wiring.

> **Do not merge** — this PR is for human review only. Implementation upgrades require local node-pack installs on the ComfyUI machine.

---

> The local 03:30 nightly export at `tools/export_comfyui_workflows.py` will refresh ComfyUI workflow snapshots automatically — no manual action needed for that side of the pipeline.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ywfg2aaTy3SKoFMKruRq2)_