### PR TITLE
Ecosystem digest 2026-08-18 — Tier-1 fixes + upgrade_research.py

### DIFF
--- a/DEEP_DIVE.md
+++ b/DEEP_DIVE.md
@@ -61,7 +61,7 @@ graph TB
         WF[workflows.py<br/>70+ build_* fns]
         NF[node_factory.py<br/>typed ComfyUI DSL]
         COMP[composites.py<br/>inject_controlnet<br/>load_model_stack<br/>inject_lora_chain]
-        ARCH[architectures.py<br/>22 arch registry<br/>supported_methods]
+        ARCH[architectures.py<br/>27 arch registry<br/>supported_methods]
         DISP[dispatch.py<br/>preflight → optimize → submit]
     end
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 <div align="center">
 
-<strong>📣 Status — May 2026</strong>
+<strong>📣 Status — August 2026</strong>
 
 <table>
 <tr><td><strong>🆕 News</strong></td><td>Self-healing installer + honest diagnostic validator landed. Local-LLM (LM Studio) prompt-enhancement promoted to canon, optional bearer-token auth across the HTTP surfaces, automated 6-surface mirror sync. DaVinci Resolve plugin is still in test — bug reports welcome.</td></tr>

--- a/_dev_docs/ecosystem_digest_2026-08-18.md
+++ b/_dev_docs/ecosystem_digest_2026-08-18.md
@@ -1,0 +1,181 @@
+# Ecosystem Research Digest — 2026-08-18
+
+Cloud-side sweep of the upgrade-opportunity surface for the Laboratoire
+Sonore / Spellcaster stack. See `_dev_docs/ecosystem_digest_*.md` for
+prior runs. Format follows the every-48h routine's tier split (Tier 1
+= apply here; Tier 2 = new-model integration needing human VRAM/quality
+judgment; Tier 3 = needs local fleet access, emitted as structured
+`local_action_queue`).
+
+## Meta — self-repairs this run made
+
+Previous runs of this routine noted `python tools/upgrade_research.py`
+as missing and silently degraded to web-only research. That's fixed
+this run:
+
+- **Drafted `tools/upgrade_research.py`.** Zero-dep stdlib script that
+  imports `architectures.py` in isolation, parses `builders_manifest.json`
+  and the `UNET_ARCH_RULES` / `CKPT_ARCH_RULES` tables out of
+  `model_detect.py`, and emits a JSON snapshot of "what Spellcaster
+  already integrates" so future digests can start from a stable state
+  instead of re-crawling. Verified end-to-end: 27 archs / 73 builders /
+  2 detect-rule tables in the payload.
+
+## Tier 1 — fixes applied in this PR
+
+Each item below is a real edit in this commit, not a note for a human
+to apply later. Ran `python3 tools/upgrade_research.py` after every fix
+to confirm no regression.
+
+### 1. Register the missing `supir` architecture stub
+
+**File**: `comfyui-spellcaster/spellcaster_core/architectures.py`
+
+`model_detect.CKPT_ARCH_RULES` line 103 maps any filename containing
+`supir` to the arch key `"supir"`, but `architectures.ARCHITECTURES`
+had no entry for it. `get_arch("supir")` therefore silently returned
+the SDXL config — meaning any caller iterating the registry for
+capability reporting would misclassify SUPIR as a first-class
+summonable SDXL model. Diagnostic's `_build_txt2img_test` would try
+to txt2img-test it as SDXL and fail confusingly at sampler time
+(SUPIR checkpoints don't have the CLIP/VAE for standalone summon —
+they need pairing with an SDXL backbone via `build_supir(sdxl_model,
+supir_model)` in `workflows.py:3108`).
+
+Added a `registered=False` stub with empty `supported_methods=()`,
+matching the pattern used for `sd3` / `pixart` / other DiT-only stubs.
+`get_arch("supir")` now returns a real ArchConfig with `.registered ==
+False` so callers can detect the stub state. The existing autoset
+lookups on the **SDXL** registration (`autoset_denoise["supir"] = 0.30`,
+`autoset_cn["supir"] = ...`) remain the source of truth for the SUPIR
+*method* running on an SDXL backbone — those are unchanged.
+
+Registry count: 26 → 27.
+
+### 2. Refresh README status date
+
+**File**: `README.md`
+
+`Status — May 2026` → `Status — August 2026`. Today is 2026-08-18;
+the badge was three months stale.
+
+### 3. Refresh DEEP_DIVE arch-count claim
+
+**File**: `DEEP_DIVE.md` (line 64 of the system-architecture mermaid)
+
+`22 arch registry` → `27 arch registry`. Actual `_reg()` calls in
+`architectures.py` = 26 before this PR, 27 after adding the SUPIR stub.
+Confirmed via `grep -cE "^_reg\(" architectures.py`.
+
+## Tier 2 — new-model / new-arch integration candidates
+
+Each entry names a real, currently-shippable upstream release, the
+Spellcaster surface it maps onto, the VRAM/risk tradeoff, and what
+"integrate" would concretely look like. **Not auto-applied** — VRAM
+and quality-vs-existing decisions belong to the operator.
+
+| model / arch | released | replaces / augments | vram_gb | risk | tier | integration notes |
+|---|---|---|---|---|---|---|
+| **LTX-2.5** | 2026-08-12 | our `ltx` arch (currently LTX-2.3 era per ComfyUI blog history) | ~24 | low | 2.1 | ComfyUI has day-0 support in core; `build_ltx_video` shape should carry over, but native multi-shot workflow is new — probably worth a sibling builder `build_ltx25_multi_shot` rather than patching `build_ltx_video` in place. Verify `LTXVBaseSampler` still the canonical node before promoting. |
+| **LTX-2.3** | 2026-03-05 | our `ltx` arch (if fleet is still pre-2.3) | ~20 | low | 2.1 | 22B, native 4K@50fps, first open model with synchronized audio+video generation. Even without going straight to 2.5, moving to 2.3 unlocks the audio track — currently no audio+video builder in `workflows.py`. |
+| **HunyuanImage-3.0-Instruct** | 2026-01-26 | new image arch (MoE) + I2I with prompt-reasoning | 80B params, ~48–64 needed | high | 2.2 | Adds reasoning-based prompt enhancement + I2I creative editing. Would slot in as a new arch `hunyuan_image_3` alongside the existing `hunyuan_dit` stub (which stays as-is, image-1.x). VRAM is a real gate — most Sparks won't run it. Consider only if Theo has 48+ GB free. |
+| **Hunyuan3D-Shape-v2-1 Small** | 2026-02 | refines our existing `hunyuan_3d` arch | ~8 | low | 2.3 | Baseline model shipped alongside HY3D-Bench dataset; small variant fits low-VRAM. Straight upgrade path to the existing `build_hunyuan_3d_mesh` / `build_hunyuan_3d_textured` builders — check the Kijai wrapper pack has caught up before swapping. |
+| **Flux2-Klein-9B-Consistency** (community fine-tune, `dx8152/…`) | live | augments existing `flux2klein` for portrait consistency | same as Klein 9B | low | 2.3 | Direct drop-in checkpoint for the 9B Klein slot when the workflow is portrait-consistency-sensitive (character portraits, headswap chains). No builder change needed — this is a preset addition. |
+| **FLUX 3** (announcement only) | 2026-07-23 | watch-only; would replace or supersede `flux1dev` + `flux2klein` if BFL ships open weights | unknown | n/a | watch | BFL announced multimodal (image/video/audio/action) but no repo, no license, no param count as of the sweep. Re-check on next run. |
+
+**Explicitly NOT-actionable this cycle** (avoid re-proposing):
+
+- **Wan 2.5 / 2.6** — Alibaba shipped Wan 2.5 (Sep 2025, audio+video +1080p@24fps) and Wan 2.6 (Dec 2025, Reference-to-Video), but **weights are not public**. API-only. Fleet stays on Wan 2.2 for local. Do not add a Wan 2.5/2.6 arch stub.
+- **HunyuanImage-3.0 base** (Sep 2025, 80B MoE) — superseded here by the Instruct variant above (same weights + reasoning head + I2I). Only list one.
+- **Z-Image Turbo v2** — no announcement from Tongyi-MAI as of 2026-08. Turbo v1 is our current `zit`. Don't add speculative entries.
+- **"SUPIR successor"** — nothing shipping. Arxiv 2507.20590 ("Harnessing Diffusion-Yielded Score Priors for Image Restoration") is research, not weights. Keep SUPIR as-is.
+
+## Tier 3 — local_action_queue (structured, machine-consumable)
+
+Actions that need a host on the operator's LAN (Spark GPUs, Theo,
+Hermes downloader). Emitted as YAML so a local process can consume
+them mechanically instead of parsing prose. Consumer contract: read
+this block, execute in order, mark done.
+
+```yaml
+local_action_queue:
+  - action: download_model_update
+    target_repo: Lightricks/LTX-Video   # verify exact HF path against ComfyUI-LTXVideo README before pulling
+    target_host: unknown                # whichever Spark hosts the video-gen ComfyUI (Spark that serves the `ltx` arch); operator picks
+    reason: >
+      LTX-2.5 landed 2026-08-12 with ComfyUI day-0 support and native
+      multi-shot generation; 2.3 (2026-03-05) is also a jump if the
+      fleet is still on the pre-audio branch. Local weights currently
+      unknown from cloud sandbox — operator/Hermes to check disk.
+    command_hint: >
+      # from the ComfyUI models/ dir on the video-host:
+      huggingface-cli download Lightricks/LTX-Video --local-dir models/checkpoints/LTX --include "*ltx*2.5*.safetensors"
+      # then restart ComfyUI and run the LTX-2.5 template workflow to confirm the new nodes register.
+    risk: low
+
+  - action: download_model_update
+    target_repo: tencent/Hunyuan3D-Shape-v2-1
+    target_host: unknown                # whichever host runs the hunyuan_3d builder (build_hunyuan_3d_mesh)
+    reason: >
+      HY3D-Bench release (2026-02) shipped a small baseline model that
+      improves shape quality on the low-VRAM Hunyuan3D 2.x pipeline
+      already wired via `_reg("hunyuan_3d", ...)`. Straight upgrade
+      path; no builder change required — verify Kijai wrapper pack
+      version accepts v2.1 shape weights first.
+    command_hint: >
+      huggingface-cli download tencent/Hunyuan3D-Shape-v2-1 --local-dir models/checkpoints/Hunyuan3D
+    risk: low
+
+  - action: evaluate_and_maybe_download
+    target_repo: tencent/HunyuanImage-3.0-Instruct
+    target_host: theo                   # only Theo could plausibly hold a 80B MoE (13B active); confirm free VRAM
+    reason: >
+      New multimodal image arch with reasoning + I2I creative editing;
+      MoE 80B total / 13B active. Would land as a new `hunyuan_image_3`
+      arch entry, NOT replacing the existing `hunyuan_dit` stub. Skip
+      unless Theo has 48+ GB VRAM free — the whole model plus the T5
+      encoder overshoots most single-GPU Sparks.
+    command_hint: >
+      # inspect first without pulling weights:
+      hf_hub_download tencent/HunyuanImage-3.0-Instruct --filename README.md --local-dir /tmp/hy3-inspect
+    risk: high
+
+  - action: preset_addition_only
+    target_repo: dx8152/Flux2-Klein-9B-Consistency
+    target_host: unknown                # whichever host serves Klein 9B
+    reason: >
+      Community fine-tune of Flux 2 Klein 9B specialised for portrait
+      consistency across shots. Slots in as a preset-level checkpoint
+      swap for the 9B Klein slot on portrait-heavy workflows (headswap
+      chains, character sheets). No `build_klein_*` code change needed.
+    command_hint: >
+      huggingface-cli download dx8152/Flux2-Klein-9B-Consistency --local-dir models/unet/Flux-2-Klein/Consistency
+    risk: low
+```
+
+## Corrections to prior operator-memory notes
+
+None this run — prior digest history is empty (`_dev_docs/` contained
+only the WHIMWEAVER_REPLAY_BRIDGE_PROPOSAL.md before this commit).
+
+## Delivery status
+
+- Gmail MCP requires re-auth (this session non-interactive → cannot
+  run the OAuth flow). Notification via Gmail is **skipped**; PR is
+  sole delivery channel per the routine's fallback rule.
+- Google-Drive MCP is available but the routine's contract puts
+  the digest in-repo (`_dev_docs/…`) so external mirroring would be
+  redundant — skipped.
+- CI on this PR: not evaluated yet (this is the initial push). If
+  `leak-check.yml` or any other check goes red purely on pre-existing
+  main issues unrelated to the diff, will diff-verify against base
+  and comment rather than treating it as this run's failure.
+
+## Budget accounting
+
+- WebSearch calls used this sweep: 6 (LTX-2.5, LTX-2.3 lineage, FLUX 3,
+  Z-Image v2, HunyuanImage 3.0, ReActor). Well inside the ~25 combined
+  cap.
+- WebFetch calls used: 0 — every WebSearch summary carried enough
+  metadata (release dates, VRAM, licence) that no follow-up fetch
+  was needed.

--- a/_dev_docs/ecosystem_digest_2026-08-18.md
+++ b/_dev_docs/ecosystem_digest_2026-08-18.md
@@ -158,6 +158,26 @@ local_action_queue:
 None this run — prior digest history is empty (`_dev_docs/` contained
 only the WHIMWEAVER_REPLAY_BRIDGE_PROPOSAL.md before this commit).
 
+## Pre-existing CI drift on `main` (not this PR's, but flagged)
+
+Running `python tests/mirror_drift.py` locally against `main` (before
+adding the SUPIR stub to either mirror) already reports drift on three
+files between the two in-repo surfaces:
+
+- `workflows.py`  (C=89ff6f52  1=32cc3498)
+- `preflight.py`  (C=2e9b4315  1=10c468ff)
+- `asset_gallery.py`  (C=f93e58e5  1=1e13ab48)
+
+Not fixed here — auto-picking a winning direction is risky without
+knowing which surface has the intended-newer content. Filed as a
+Tier 1 candidate for the next run: a small helper that either
+(a) reports which side is newer per-file by git log timestamp and
+proposes a mechanical merge, or (b) documents which surface is
+canonical in `MIRROR_TARGETS.md` so `tests/mirror_drift.py --fix`
+has a defined direction to snap to. If `mirror-drift.yml` fails on
+this PR's CI run, this is the cause — the SUPIR-stub mirror IS
+included in this PR (both surfaces get the same 27-line addition).
+
 ## Delivery status
 
 - Gmail MCP requires re-auth (this session non-interactive → cannot

--- a/comfyui-spellcaster/spellcaster_core/architectures.py
+++ b/comfyui-spellcaster/spellcaster_core/architectures.py
@@ -1082,6 +1082,33 @@ _reg("hunyuan_3d",
      registered=True)
 
 
+# ── SUPIR (restoration companion for SDXL) ──────────────────────────
+# SUPIR is a restoration/upscale model that runs on top of an SDXL
+# backbone via `build_supir` (workflows.py:3108). It is NOT a
+# standalone summonable architecture — the checkpoint alone has no
+# CLIP/VAE to sample from. `model_detect.CKPT_ARCH_RULES` still emits
+# the arch key "supir" for filenames containing "supir" so downstream
+# consumers can route them to the SUPIR pipeline instead of trying to
+# load them as an SDXL checkpoint. Registering the key as a stub
+# (registered=False, empty supported_methods) means:
+#   * `get_arch("supir")` returns a real ArchConfig instead of silently
+#     falling back to SDXL — callers can detect the stub via
+#     `.registered` and skip txt2img/etc.
+#   * The autoset_denoise/autoset_cn/autoset_loras entries on the SDXL
+#     registration (keys "supir": ...) remain the source of truth for
+#     the SUPIR *method* running on an SDXL backbone.
+_reg("supir",
+     loader="checkpoint", sampler="ksampler",
+     clip_mode="bundled", vae_mode="bundled",
+     supports_negative=True,
+     default_resolution=(1024, 1024),
+     default_cfg=6.5, default_steps=30, default_denoise=0.30,
+     default_sampler="dpmpp_2m_sde", default_scheduler="karras",
+     supported_methods=(),   # not summonable alone; use build_supir(sdxl_model, supir_model)
+     scene_group="sdxl",
+     registered=False)
+
+
 # Lumina-Image 2.0 — Alpha-VLLM 2024-12 MMDiT (~2.6B, Apache-2). Native
 # ComfyUI support via `CLIPTextEncodeLumina2`. Standard KSampler path
 # with Flux-style flow matching. Recommended: euler + normal, cfg=4.0,

--- a/plugins/gimp/comfyui-connector/spellcaster_core/architectures.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/architectures.py
@@ -1082,6 +1082,33 @@ _reg("hunyuan_3d",
      registered=True)
 
 
+# ── SUPIR (restoration companion for SDXL) ──────────────────────────
+# SUPIR is a restoration/upscale model that runs on top of an SDXL
+# backbone via `build_supir` (workflows.py:3108). It is NOT a
+# standalone summonable architecture — the checkpoint alone has no
+# CLIP/VAE to sample from. `model_detect.CKPT_ARCH_RULES` still emits
+# the arch key "supir" for filenames containing "supir" so downstream
+# consumers can route them to the SUPIR pipeline instead of trying to
+# load them as an SDXL checkpoint. Registering the key as a stub
+# (registered=False, empty supported_methods) means:
+#   * `get_arch("supir")` returns a real ArchConfig instead of silently
+#     falling back to SDXL — callers can detect the stub via
+#     `.registered` and skip txt2img/etc.
+#   * The autoset_denoise/autoset_cn/autoset_loras entries on the SDXL
+#     registration (keys "supir": ...) remain the source of truth for
+#     the SUPIR *method* running on an SDXL backbone.
+_reg("supir",
+     loader="checkpoint", sampler="ksampler",
+     clip_mode="bundled", vae_mode="bundled",
+     supports_negative=True,
+     default_resolution=(1024, 1024),
+     default_cfg=6.5, default_steps=30, default_denoise=0.30,
+     default_sampler="dpmpp_2m_sde", default_scheduler="karras",
+     supported_methods=(),   # not summonable alone; use build_supir(sdxl_model, supir_model)
+     scene_group="sdxl",
+     registered=False)
+
+
 # Lumina-Image 2.0 — Alpha-VLLM 2024-12 MMDiT (~2.6B, Apache-2). Native
 # ComfyUI support via `CLIPTextEncodeLumina2`. Standard KSampler path
 # with Flux-style flow matching. Recommended: euler + normal, cfg=4.0,

--- a/tools/upgrade_research.py
+++ b/tools/upgrade_research.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""upgrade_research.py — inventory current integration state.
+
+The 48-hour ecosystem-research routine (see PR #… / _dev_docs/ecosystem_digest_*.md)
+starts its sweep by asking: "what does Spellcaster already integrate, so I know
+what NOT to re-propose?". Prior runs of the routine re-crawled the repo every
+time — this is that crawl, extracted so the cloud agent can `python
+tools/upgrade_research.py` and get a stable, machine-readable snapshot in
+one call instead of grepping around.
+
+Output shape (stdout, JSON):
+
+    {
+      "generated_at": "<iso8601 utc>",
+      "arch_registry": {
+        "count": 27,
+        "registered": ["sd15", "sdxl", ...],
+        "stubs":      ["sd3", "supir", ...],   # registered=False
+      },
+      "builders": {
+        "count": 73,
+        "ids":   ["build_txt2img", ...],
+      },
+      "detect_keywords": {
+        "unet_ckpt_arch_rules": [ ["klein", "flux2klein"], ... ],
+      },
+      "notes": [ "one-line strings about non-obvious integration state" ],
+    }
+
+The digest routine consumes this to skip already-covered ground.
+
+Deliberately zero deps beyond stdlib so it runs on any CI runner /
+sandbox without needing pip install.
+"""
+from __future__ import annotations
+
+import ast
+import datetime as _dt
+import importlib.util
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+CORE = ROOT / "comfyui-spellcaster" / "spellcaster_core"
+
+
+def _load_architectures():
+    """Import architectures.py in isolation and return (registered, stubs)."""
+    path = CORE / "architectures.py"
+    spec = importlib.util.spec_from_file_location("_arch_probe", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    registered, stubs = [], []
+    for key, cfg in sorted(module.ARCHITECTURES.items()):
+        (registered if cfg.registered else stubs).append(key)
+    return registered, stubs
+
+
+def _extract_builder_ids():
+    """Read builders_manifest.json and return the sorted id list."""
+    path = CORE / "builders_manifest.json"
+    if not path.exists():
+        return []
+    data = json.loads(path.read_text(encoding="utf-8"))
+    # Schema (see comfyui-spellcaster/spellcaster_core/build_builders_manifest.py):
+    #   {"schema_version": ..., "generator": ..., "source": ...,
+    #    "method_count": N, "methods": [ {"id": ..., "builder": ..., ...}, ... ]}
+    methods = data.get("methods", []) if isinstance(data, dict) else data
+    ids = [m["id"] for m in methods if isinstance(m, dict) and "id" in m]
+    return sorted(set(ids))
+
+
+_KW_RE = re.compile(
+    r'^(UNET_ARCH_RULES|CKPT_ARCH_RULES)\s*=\s*(\[.*?\])',
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def _extract_detect_rules():
+    """Parse the substring→arch rule tables out of model_detect.py."""
+    src = (CORE / "model_detect.py").read_text(encoding="utf-8")
+    out = {}
+    for match in _KW_RE.finditer(src):
+        name, body = match.group(1), match.group(2)
+        try:
+            out[name.lower()] = [list(t) for t in ast.literal_eval(body) if isinstance(t, tuple)]
+        except (SyntaxError, ValueError):
+            continue
+    return out
+
+
+def _notes(registered, stubs, builder_ids):
+    notes = []
+    if "supir" in stubs:
+        notes.append("supir: restoration companion for SDXL, not summonable alone (build_supir(sdxl_model, supir_model)).")
+    dit_stubs = [k for k in ("sd3", "sd3_turbo", "hunyuan_dit", "pixart", "auraflow", "kolors") if k in stubs]
+    if dit_stubs:
+        notes.append(f"DiT-only stubs (no builder yet): {', '.join(dit_stubs)}. Do not re-propose without pairing with a workflow builder.")
+    video_covered = {"wan", "ltx", "seedvr", "cogvideo", "framepack", "hunyuan_video", "mochi"}
+    live_video = sorted(video_covered.intersection(registered))
+    if live_video:
+        notes.append(f"Video archs already live: {', '.join(live_video)}.")
+    if "hunyuan_3d" in registered:
+        notes.append("hunyuan_3d: only 3D modality currently wired (mesh_gen + mesh_textured).")
+    notes.append(f"{len(builder_ids)} builder ids in builders_manifest.json (source of truth for method dispatch).")
+    return notes
+
+
+def main() -> int:
+    registered, stubs = _load_architectures()
+    builder_ids = _extract_builder_ids()
+    payload = {
+        "generated_at": _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+        "arch_registry": {
+            "count": len(registered) + len(stubs),
+            "registered": registered,
+            "stubs": stubs,
+        },
+        "builders": {
+            "count": len(builder_ids),
+            "ids": builder_ids,
+        },
+        "detect_keywords": _extract_detect_rules(),
+        "notes": _notes(registered, stubs, builder_ids),
+    }
+    json.dump(payload, sys.stdout, indent=2, sort_keys=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What does this change?

The every-48h cloud research routine ran today (2026-08-18). Per the
new tier split, this PR **applies Tier-1 fixes in-repo** instead of
just describing them in a digest for a human to apply later. Full
findings (Tier 2 model-integration candidates, Tier 3 fleet-side
`local_action_queue`) are in `_dev_docs/ecosystem_digest_2026-08-18.md`.

Tier-1 fixes applied here:

1. **`comfyui-spellcaster/spellcaster_core/architectures.py`** — register
   the missing `supir` architecture stub. `model_detect.CKPT_ARCH_RULES`
   maps SUPIR-named checkpoints to arch key `"supir"`, but the registry
   had no entry, so `get_arch("supir")` silently fell back to SDXL and
   diagnostic would try to txt2img-test SUPIR files against the SDXL
   sampler path. Added `registered=False` stub with empty
   `supported_methods=()` (SUPIR is a restoration companion, not
   summonable alone — the pipeline is
   `build_supir(sdxl_model, supir_model)`). Registry count 26 → 27.
2. **`plugins/gimp/comfyui-connector/spellcaster_core/architectures.py`** —
   same 27-line addition, mirroring surface C into surface 1 per
   `mirror-drift.yml`.
3. **`README.md`** — Status badge `May 2026` → `August 2026`
   (three months stale).
4. **`DEEP_DIVE.md`** — arch-count in the system-architecture mermaid
   `22 arch registry` → `27 arch registry`, matching the actual
   `_reg()` count.
5. **`tools/upgrade_research.py`** — new file. The routine has been
   calling this for prior runs but the file never existed. Zero-dep
   stdlib script that imports `architectures.py` in isolation, parses
   `builders_manifest.json` and the detect-rule tables out of
   `model_detect.py`, and prints a JSON snapshot of "what's already
   integrated" so future digests start from a stable state instead of
   re-crawling the repo. Verified end-to-end (27 archs / 73 builders).
6. **`_dev_docs/ecosystem_digest_2026-08-18.md`** — this run's digest.

## Type of change

- [x] Bug fix (SUPIR stub registration; get_arch no longer silently falls back to SDXL)
- [ ] New tool / new preset
- [ ] New ComfyUI architecture support
- [ ] Refactor (no behavior change)
- [x] Docs only (README/DEEP_DIVE date + count freshness)
- [x] Other (new `tools/upgrade_research.py` inventory helper + ecosystem digest)

## Checklist

- [x] **No personal data in the diff.** No IPs, no `C:\Users\...` paths, no emails, no tokens.
- [x] **No NSFW content in the public repo.** Nothing under `nsfw/` is staged.
- [x] **`spellcaster_core/` stays in sync.** SUPIR-stub 27-line addition applied identically to both in-repo mirrors (`plugins/gimp/comfyui-connector/spellcaster_core/architectures.py` + `comfyui-spellcaster/spellcaster_core/architectures.py`). Note: `tests/mirror_drift.py` reports pre-existing drift on `workflows.py`, `preflight.py`, and `asset_gallery.py` on `main` unrelated to this PR — see the "Pre-existing CI drift" section in the digest; not fixed here (auto-picking a winning direction is risky). If `mirror-drift.yml` fails on this PR's CI, that's why.
- [x] **New ComfyUI custom nodes are declared.** N/A — no new custom-node pack in this PR.
- [x] **New GIMP procedures are registered in all three dicts.** N/A — no new GIMP procedures.
- [x] **Tested locally against a running ComfyUI server.** Not applicable — this was a cloud-sandbox research run without LAN access to the ComfyUI fleet. What WAS validated: `python3 tools/upgrade_research.py` runs clean and returns the expected 27-arch / 73-builder inventory; `python3 -c "import ...architectures ..."` confirms `get_arch("supir").registered == False` and the pre-existing SDXL `autoset_denoise["supir"]` / `autoset_cn["supir"]` lookups still resolve to their old values (no behavior change for the SUPIR-method-on-SDXL path).

## Test plan

- Reviewer runs `python3 tools/upgrade_research.py` and confirms JSON payload:
  - `arch_registry.count == 27`, `arch_registry.stubs` includes `"supir"`.
  - `builders.count == 73`.
  - `notes` mentions the SUPIR stub + DiT-only stubs list + video archs already live.
- Reviewer imports architectures and confirms:
  - `get_arch("supir").registered is False`
  - `get_arch("supir").supported_methods == ()`
  - `get_arch("sdxl").autoset_denoise["supir"] == 0.30` (unchanged)
- Reviewer skims `_dev_docs/ecosystem_digest_2026-08-18.md` Tier-2 table and Tier-3 `local_action_queue` — decides which LTX / Hunyuan / Klein-Consistency actions to run on the fleet.
- If mirror-drift CI fails: check that the failing files are `workflows.py` / `preflight.py` / `asset_gallery.py` (pre-existing on main), not `architectures.py` (this PR's diff).

## Screenshots / clips (if UI)

N/A — no UI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GP5DuinhKwx1UN44n9LkJ)_