### PR TITLE
ecosystem-digest 2026-08-28: SUPIR arch stub + upgrade_research.py + mirror auto-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 <div align="center">
 
-<strong>📣 Status — May 2026</strong>
+<strong>📣 Status — August 2026</strong>
 
 <table>
 <tr><td><strong>🆕 News</strong></td><td>Self-healing installer + honest diagnostic validator landed. Local-LLM (LM Studio) prompt-enhancement promoted to canon, optional bearer-token auth across the HTTP surfaces, automated 6-surface mirror sync. DaVinci Resolve plugin is still in test — bug reports welcome.</td></tr>

--- a/_dev_docs/ecosystem_digest_2026-08-28.md
+++ b/_dev_docs/ecosystem_digest_2026-08-28.md
@@ -1,0 +1,152 @@
+# Ecosystem Research Digest — 2026-08-28
+
+Cloud-side scheduled routine, every-48h. Repo baseline: `laboratoiresonore/spellcaster`, branch `claude/adoring-allen-45kzbe`, HEAD `ccef78a`. Sandbox: Anthropic remote (no LAN reach; no `C:\` or `D:\` FS; `laboratoiresonore/spellcaster` only, public).
+
+Run notes:
+
+- **Missing-tool gap closed this run.** `tools/upgrade_research.py` — a helper this routine's own prompt depends on — did not exist and prior runs had been silently degrading to open-ended web search each time. Drafted a minimal working version this run (see Tier 1 fix below). Future digest runs can now `python tools/upgrade_research.py --json` and get a stable, deterministic list of research targets keyed to the actual `_reg(...)` registry.
+- Web budget spent: 0 WebSearch, 4 WebFetch-equivalent MCP calls to `Hugging-Face` (well under the ~25 soft cap).
+- Gmail MCP is not authorized in this sandbox — the digest ships as the PR alone; no email fallback attempted (per routine guidance).
+
+---
+
+## Tier 1 — fixes applied in this PR
+
+Every finding here is committed with the digest. Diff summary:
+
+| File | Fix | Reason |
+|---|---|---|
+| `tools/upgrade_research.py` | **New file** (274 lines). Reads canonical `ARCHITECTURES` registry and emits per-arch HF hints + versioned WebSearch queries, JSON or markdown. | Prior digest runs kept noting this script was referenced by their own prompt but did not exist. Every run degraded to web-only research and lost the arch-registry linkage. First-class contract now checked in. |
+| `README.md:46` | `Status — May 2026` → `Status — August 2026` | The "current status" banner had been stale by 3 months. Prior digests flagged this and never fixed it. |
+| `comfyui-spellcaster/spellcaster_core/architectures.py` and `plugins/gimp/comfyui-connector/spellcaster_core/architectures.py` | Added `_reg("supir", ...)` stub (registered=True, empty `supported_methods` — dispatch is via `build_supir()` in `workflows.py:3090`, not method gating). | `model_detect.py:103` maps SUPIR checkpoint filenames to arch key `"supir"`, but no `_reg("supir", ...)` existed. Consequence: `get_arch("supir")` silently returned the SDXL fallback — exactly the "don't fall back to SDXL, register a stub" design intent stated in the architectures.py comment block at lines ~790-807. Verified before/after: `28` archs registered post-fix (was 27), `get_arch("supir").key == "supir"` (was `"sdxl"`). |
+| `plugins/gimp/comfyui-connector/spellcaster_core/workflows.py`, `preflight.py`, `asset_gallery.py` | Ran `python tests/mirror_drift.py --fix` to sync surface 1 back to canonical surface C. +702 net lines across the three files. | `tests/mirror_drift.py` was red on `main` before this branch: `OK: 23/26  DRIFT: 3`. Confirmed pre-existing by stashing my edits and re-running the check. The `mirror-drift.yml` CI job triggers on any PR touching `spellcaster_core/**`, so the pre-existing drift would have failed this PR's CI regardless. The `--fix` flag is the tool's own auto-sync path (`C → 1`, C being canonical), no logic change — just verbatim mirroring of code that already landed on main via surface C. |
+
+### Verification steps run
+
+```
+$ python -c "…; ARCHITECTURES['supir'].registered, ARCHITECTURES['supir'].key"
+(True, 'supir')
+
+$ python tests/mirror_drift.py
+✓ All surfaces byte-identical    OK: 26/26
+
+$ python tools/upgrade_research.py --group video     # smoke
+# emits 7 video archs with HF hints + Aug-2026 web queries
+
+$ python -c "import ast; ast.parse(open('...architectures.py').read())"
+OK  (both mirrored files)
+```
+
+No test-suite regression suite was runnable in the sandbox (no ComfyUI, no LM Studio, no LAN Theo). The static + import-time checks above are all that this environment can verify. Anything requiring live model dispatch is unverifiable from here — that constraint is unchanged from prior runs.
+
+### Findings noticed but downgraded to Tier 2 (why they weren't auto-applied)
+
+- **`_looks_like_uniform_mask` in `_spellcaster_main.py:8952`** — the routine prompt hinted "uniform classifier mishandles grayscale". Read the function; it handles `LA` (line 8972) and `RGB`/`RGBA`/`P` (line 8974) explicitly, then falls through to `img.getextrema()` for anything else. For mode `L` (already grayscale), the fall-through is correct — the function operates directly on L. For modes `I`, `I;16`, `F` (16/32-bit masks) the histogram bucketing at 8981 assumes an 8-bit range and will silently mis-report uniformity. That's a real edge case but it's unclear whether ComfyUI SAM3/BiRefNet nodes ever emit non-8-bit masks in this codebase's use — needs the human's judgment on whether to widen the check or narrow the input contract. Downgraded to Tier 2 rather than push a speculative fix.
+
+---
+
+## Tier 2 — new-model / new-architecture integration work (needs human judgment)
+
+Ranked by relevance to the currently registered arch surface. All dates are the HF `lastModified` value as of 2026-08-28.
+
+| # | Model | HF repo | Date | Replaces / adds | VRAM (est.) | Risk | Notes |
+|---|---|---|---|---|---|---|---|
+| T2.1 | **LTX-2.5** | [Lightricks/LTX-2.5](https://hf.co/Lightricks/LTX-2.5) | 2026-08-27 | Bumps `_reg("ltx", …)` baseline from LTX-Video 2.0 → 2.5. Adds native audio-to-video + text-to-audio. | ~12 GB fp16 for 720p (per demo Space) | **Med** — gated repo (auto-approve), so download flow needs a token per Spark. Adds a new modality (audio-video) that Spellcaster's `VIDEO_METHODS` tuple doesn't cover. | 912K downloads in <24h — clear adoption signal. Multi-language prompt support (en/de/es/fr/ja/ko/zh/it/pt). Native `diffusion-single-file` for ComfyUI, so no wrapper-pack blocker. Kijai wrapper compatibility unverified from sandbox. |
+| T2.2 | **SeedVR2-3B** | [ByteDance-Seed/SeedVR2-3B](https://hf.co/ByteDance-Seed/SeedVR2-3B) (base) + [mofashiWY/SeedVR2-3B](https://hf.co/mofashiWY/SeedVR2-3B) (mirror, 2026-08-28) | 2026-08-28 | Bump for `_reg("seedvr", …)` — Spellcaster's current entry is version-agnostic, defaults `default_steps=15 default_cfg=1.0`. SeedVR2 is the second-gen model; may want new defaults + a v1 alias. | ~8 GB fp16 (3B params). fp32 VAE also up (Merserk/Seedvr2-vae-fp32, 2026-07-14). | **Low** — Apache-2.0, drop-in-ish for the existing video_upscale method. | Existing `_reg("seedvr", …)` used by `seedv2r` method key in the SDXL autoset_denoise dict. If the arch bump lands, verify the `seedv2r` naming in `autoset_denoise` still resolves the intended pipeline. |
+| T2.3 | **MiniMax-H3** | [MiniMaxAI/MiniMax-H3](https://hf.co/MiniMaxAI/MiniMax-H3) · Comfy-Org fork: [Comfy-Org/MiniMax-H3](https://hf.co/Comfy-Org/MiniMax-H3) (19.1M downloads) | 2026-08-13 | **New architecture, unregistered.** Unified image-text-to-video with **synchronized audio-video** output. Would slot alongside `wan` / `hunyuan_video` in scene_group `video`. Comfy-Org has already packaged it as a single-file for ComfyUI. | ~14 GB fp16 (per Abiray GGUFs also up), int4 nvfp4 variant available for lower-VRAM Sparks. | **High** — new modality (audio-video) means new `supported_methods` entries (`video_gen_with_audio` or similar) and a new builder in `workflows.py`. Not a small addition. | 19.1M downloads on the Comfy-Org fork alone in <1 month → this is where mindshare is. Also has a `lightx2v/Minimax-h3-Turbo` distill (681K dl) for faster inference. Also has `alibaba-pai/MiniMax-H3-Fun-Controlnet-Union` (text-to-video ControlNet). If Spellcaster wants to stay on the "which video arch is the default" wave, this is where the puck is. |
+| T2.4 | **Illustrious-XL v2.0** | [OnomaAIResearch/Illustrious-XL-v2.0](https://hf.co/OnomaAIResearch/Illustrious-XL-v2.0) (referenced as base of SceneWorks mlx port, 2026-08-23) | 2026-07-10 (upstream) | The existing `_reg("illustrious", …)` doesn't distinguish v1 from v2. If v2 becomes the recommended checkpoint, the classifier is fine but the `prompt_guidance` / `default_cfg=5.5` values may need re-tuning per v2's release notes. | ~12 GB fp16 (same as v1 — SDXL-derived). | **Low** — pure model swap, no arch changes. | Downstream `SceneWorks/illustrious-xl-v2-mlx` (Apple Silicon port) and `Mouserat/Illustrious-XL-v2.0-diffusers-mnn` (Android/on-device) both citing v2.0 as the base — the base_model ecosystem has clearly moved. |
+| T2.5 | **Qwen-Image-Edit-2511** | [Qwen/Qwen-Image-Edit-2511](https://hf.co/Qwen/Qwen-Image-Edit-2511) (231K dl) + [lightx2v/Qwen-Image-Edit-2511-Lightning](https://hf.co/lightx2v/Qwen-Image-Edit-2511-Lightning) distill (326K dl) + [Comfy-Org/Qwen-Image-Edit_ComfyUI](https://hf.co/Comfy-Org/Qwen-Image-Edit_ComfyUI) (1.3M dl on earlier vers.) | 2025-12-17 base / 2025-12-22 Lightning | **New architecture, unregistered.** Image editing model in the "type a change, apply it locally" niche. Would go into `IMAGE_METHODS` under a new `image_edit_qwen` method or a new `qwen_image_edit` arch key. Apache-2.0. | ~14 GB fp16 base; GGUF Q4 fits on 8 GB (unsloth quant, 241K dl). | **Med** — new arch + new builder. Overlaps with Klein's edit modes (`klein_edit`, `klein_headswap`) — need to decide if Qwen-Image-Edit is a Klein competitor or a complement (Klein is Flux-2 4B, tuned for portraits; Qwen-Image-Edit is more of a general edit model). | 1.3M-dl Comfy-Org packaging is a strong ComfyUI-ready signal. |
+| T2.6 | **FLUX.2-klein face-restore LoRA** | [happyinhappy/flux2-klein-face-restore-lora](https://hf.co/happyinhappy/flux2-klein-face-restore-lora) | 2026-08-28 | LoRA slot for the existing `flux2klein` arch. Directly usable in `autoset_loras` for the `klein_refine` / `klein_inpaint` method rows. | Adds ~200 MB on top of the 4B base. | **Low** — LoRA, no arch changes. Needs eyeballing on quality first. | Zero-download so-far but tagged with an image-to-image face-restoration workflow. Small-scale finding but exactly the kind of drop-in that ships in a nightly. |
+
+Note on Wan: no `Wan-AI/Wan2.5` or `Wan-AI/Wan2.3` upstream repo on HF as of 2026-08-28 — the current `_reg("wan", …)` for Wan2.2 is still current. One hobby "Hiren122/Wan-2.5" upload exists (0 downloads, unofficial). Kijai's WanVideoWrapper repo lookup returned no HF matches from the sandbox (it's a GitHub project, not an HF model repo) — checking that would need a WebFetch on `github.com/kijai/ComfyUI-WanVideoWrapper` which was not spent.
+
+---
+
+## Tier 3 — local_action_queue (structured, for a local operator / Hermes / local Claude session)
+
+Actions that need LAN + local-FS access this sandbox does not have. Emitted as a fenced YAML block so a downstream process can consume it mechanically — the previous free-text prose bullets were consistently not re-derived into commands.
+
+```yaml
+local_action_queue:
+  - action: download_model_update
+    target_repo: Lightricks/LTX-2.5
+    target_host: unknown           # pick per LTX use-site (Spark that hosts video_upscale?)
+    reason: |
+      Bumps the ltx arch baseline from LTX-Video 2.0 → 2.5.
+      Gated repo — a valid HF token must already be on the target host
+      before this can run. Download the single-file safetensors variant
+      (ComfyUI-compatible per the diffusion-single-file library tag).
+    command_hint: |
+      huggingface-cli login   # if not already tokened
+      huggingface-cli download Lightricks/LTX-2.5 --local-dir D:/LLM/ltx/LTX-2.5 --include "*.safetensors" "*.json"
+    risk: medium
+
+  - action: download_model_update
+    target_repo: ByteDance-Seed/SeedVR2-3B
+    target_host: unknown
+    reason: |
+      Second-generation SeedVR upscaler. Slots into the existing
+      seedvr arch entry — the default_steps/default_cfg in _reg("seedvr", …)
+      may need re-tuning per SeedVR2 recommendations after weights land.
+    command_hint: |
+      huggingface-cli download ByteDance-Seed/SeedVR2-3B --local-dir D:/LLM/seedvr/SeedVR2-3B
+    risk: low
+
+  - action: fetch_lora
+    target_repo: happyinhappy/flux2-klein-face-restore-lora
+    target_host: unknown           # wherever klein_refine LoRA store lives
+    reason: |
+      Face-restoration LoRA sized for the existing flux2klein 4B base.
+      Once fetched, wire into autoset_loras for klein_refine / klein_inpaint
+      in architectures.py (canonical surface C).
+    command_hint: |
+      huggingface-cli download happyinhappy/flux2-klein-face-restore-lora \
+        --local-dir <ComfyUI>/models/loras/Klein/face_restore/
+    risk: low
+
+  - action: evaluate_new_arch
+    target_repo: MiniMaxAI/MiniMax-H3
+    target_host: theo              # only host with enough VRAM headroom for a first-run smoke
+    reason: |
+      New unified image-text-to-video arch with synchronized audio-video output.
+      Not yet in Spellcaster. Before committing to a _reg() + builder, benchmark
+      Comfy-Org/MiniMax-H3 single-file on a 5-second I2V run at 720p and compare
+      to Wan2.2 output on the same input. If output quality wins consistently,
+      escalate to a Tier 2 integration PR in a future digest run.
+    command_hint: |
+      huggingface-cli download Comfy-Org/MiniMax-H3 --local-dir <ComfyUI>/models/checkpoints/MiniMax-H3
+      # Then submit a video_gen job through the standard ComfyUI /prompt path.
+    risk: high
+
+  - action: retirement_pending
+    target_repo: Lightricks/LTX-Video (2.0)
+    target_host: unknown
+    reason: |
+      Once LTX-2.5 is downloaded AND a smoke test confirms parity+ on a real
+      video_gen job, retire LTX-Video 2.0 to D:\LLM\_retired\ to reclaim disk.
+      Blocked on T3.1 landing first.
+    command_hint: |
+      # After T3.1 verified:
+      move D:\LLM\ltx\LTX-Video-2.0 D:\LLM\_retired\LTX-Video-2.0
+    risk: medium
+```
+
+Nothing in this block was executed from this sandbox — cannot be. Consumer end is a local operator or a future Hermes step reading the digest.
+
+---
+
+## Prior operator memory / notes to correct
+
+None this run. The Wan-2.2 → Wan-2.5 rumor track that prior digests may have carried does not have an upstream Wan-AI repo yet (only one 0-download unofficial hobby upload). Keeping the current `wan` arch baseline as-is is correct.
+
+---
+
+## Delivery
+
+- **Primary:** this file + Tier-1 diffs land on branch `claude/adoring-allen-45kzbe`, PR opened via `mcp__github__create_pull_request`.
+- **Fallback (email):** Gmail MCP requires OAuth and is not authorized in this sandbox. Per the routine's guidance, said so plainly here and did not silently drop the notice.
+- **Notification:** none pushed — the completion of the PR IS the notification for a routine that runs while the user is away.
+
+---
+
+_Generated by [Claude Code](https://claude.ai/code)_

--- a/comfyui-spellcaster/spellcaster_core/architectures.py
+++ b/comfyui-spellcaster/spellcaster_core/architectures.py
@@ -994,6 +994,28 @@ _reg("seedvr",
      scene_group="video",
      registered=True)
 
+# SUPIR — Super Image Restoration (paired with an SDXL backbone). Not a
+# standalone base model: `build_supir` in workflows.py loads a SUPIR
+# checkpoint alongside a user-picked SDXL checkpoint and runs a 5-stage
+# restoration pipeline. The model_detect rule
+# (CKPT_ARCH_RULES: ("supir", "supir")) exists to keep a SUPIR .safetensors
+# from being misclassified as SD1.5 and blowing up the diagnostic. Without
+# a matching _reg() entry get_arch("supir") silently fell back to SDXL,
+# defeating the stub-registration design documented above (lines ~790-807).
+# Registered here as an SDXL-scene-group stub with an empty supported_methods
+# tuple + registered=True so check_arch_supports_method treats it as
+# "known-but-empty" (dispatch is via build_supir, not via method gating).
+_reg("supir",
+     loader="checkpoint", sampler="ksampler",
+     clip_mode="bundled", vae_mode="bundled",
+     supports_negative=True,
+     default_resolution=(1024, 1024),
+     default_cfg=6.5, default_steps=30, default_denoise=0.30,
+     default_sampler="dpmpp_2m", default_scheduler="karras",
+     supported_methods=(),   # dispatch is via build_supir + SDXL host, not method gating
+     scene_group="sdxl",
+     registered=True)
+
 _reg("cogvideo",
      loader="custom_wrapper", sampler="custom",  # CogVideoSampler (Kijai wrapper)
      clip_mode="single", vae_mode="separate",  # T5 single CLIP, CogVideoXVAELoader

--- a/plugins/gimp/comfyui-connector/spellcaster_core/architectures.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/architectures.py
@@ -994,6 +994,28 @@ _reg("seedvr",
      scene_group="video",
      registered=True)
 
+# SUPIR — Super Image Restoration (paired with an SDXL backbone). Not a
+# standalone base model: `build_supir` in workflows.py loads a SUPIR
+# checkpoint alongside a user-picked SDXL checkpoint and runs a 5-stage
+# restoration pipeline. The model_detect rule
+# (CKPT_ARCH_RULES: ("supir", "supir")) exists to keep a SUPIR .safetensors
+# from being misclassified as SD1.5 and blowing up the diagnostic. Without
+# a matching _reg() entry get_arch("supir") silently fell back to SDXL,
+# defeating the stub-registration design documented above (lines ~790-807).
+# Registered here as an SDXL-scene-group stub with an empty supported_methods
+# tuple + registered=True so check_arch_supports_method treats it as
+# "known-but-empty" (dispatch is via build_supir, not via method gating).
+_reg("supir",
+     loader="checkpoint", sampler="ksampler",
+     clip_mode="bundled", vae_mode="bundled",
+     supports_negative=True,
+     default_resolution=(1024, 1024),
+     default_cfg=6.5, default_steps=30, default_denoise=0.30,
+     default_sampler="dpmpp_2m", default_scheduler="karras",
+     supported_methods=(),   # dispatch is via build_supir + SDXL host, not method gating
+     scene_group="sdxl",
+     registered=True)
+
 _reg("cogvideo",
      loader="custom_wrapper", sampler="custom",  # CogVideoSampler (Kijai wrapper)
      clip_mode="single", vae_mode="separate",  # T5 single CLIP, CogVideoXVAELoader

--- a/plugins/gimp/comfyui-connector/spellcaster_core/asset_gallery.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/asset_gallery.py
@@ -350,3 +350,318 @@ def _guess_ext(data: bytes, default: str = "bin") -> str:
     if stripped in (b"{", b"["):
         return "json"
     return default
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Whimweaver replay-value bridge surface (proxy helpers)
+# ────────────────────────────────────────────────────────────────────────
+#
+# These three helpers expose just enough of spellcaster's identity-
+# preserving pipeline for whimweaver's "infinite memory + HIGH replay
+# value" character system. Whimweaver owns the on-disk reservoir layout
+# (one JSONL per character at `<reservoir_root>/<character_id>/
+# portraits.jsonl`); these helpers only read/write that file.
+#
+# The functions are deliberately I/O-cheap and import-cheap — no ComfyUI
+# submission happens here. They return a builder-name + builder-kwargs
+# dict that whimweaver passes to its existing spellcaster_proxy +
+# ComfyUI submitter.
+#
+# See `_dev_docs/WHIMWEAVER_REPLAY_BRIDGE_PROPOSAL.md` for full schema +
+# integration notes.
+
+
+_PORTRAITS_FILENAME = "portraits.jsonl"
+
+
+# Builder routing order — best identity preservation first. We prefer
+# PuLID-Flux for face-locked generation, then Klein img2img_ref with
+# identity_lock=True, then Klein headswap, then plain Klein img2img,
+# then SDXL img2img as a last resort.
+_BUILDER_PREFERENCE: tuple[str, ...] = (
+    "build_pulid_flux",
+    "build_klein_img2img_ref",
+    "build_klein_headswap",
+    "build_klein_img2img",
+    "build_sdxl_img2img",
+)
+
+
+def _portraits_path(reservoir_root, character_id: str) -> str:
+    """Resolve the JSONL path for a character. `reservoir_root` may be a
+    Path or a str — we accept either to keep the proxy boundary thin."""
+    root = os.fspath(reservoir_root)
+    return os.path.join(root, character_id, _PORTRAITS_FILENAME)
+
+
+def _read_portrait_records(portraits_path: str) -> list[dict]:
+    """Load every JSON line. Skips blank/corrupt lines silently — the
+    whimweaver writer is append-only and a half-written tail line is
+    expected on crash."""
+    if not os.path.isfile(portraits_path):
+        return []
+    records: list[dict] = []
+    try:
+        with open(portraits_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except (json.JSONDecodeError, ValueError):
+                    # Tolerate one bad tail line (crash mid-write).
+                    continue
+    except OSError:
+        return []
+    return records
+
+
+def _write_portrait_records_atomic(portraits_path: str,
+                                   records: list[dict]) -> bool:
+    """Rewrite the JSONL atomically via tempfile + os.replace."""
+    parent = os.path.dirname(portraits_path)
+    try:
+        os.makedirs(parent, exist_ok=True)
+    except OSError:
+        return False
+    fd, tmp = tempfile.mkstemp(prefix=".tmp_portraits_", dir=parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            for r in records:
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+        os.replace(tmp, portraits_path)
+        return True
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return False
+
+
+def get_character_portrait_history(
+    character_id: str,
+    *,
+    reservoir_root,
+    limit: int = 20,
+) -> list[dict]:
+    """Return portrait records for a character, newest first.
+
+    Each record carries:
+      - portrait_id          (str, unique within the character)
+      - image_path           (str, abs path or gallery-hash:// URI)
+      - builder              (str, one of the build_* names)
+      - model_family         (str, e.g. "flux2_klein", "flux1_dev", "sdxl")
+      - prompt_seed          (int)
+      - parent_portrait_id   (str | None, points to the reference portrait
+                              this one was conditioned on)
+      - generated_at         (float, unix ts)
+      - canonical            (bool, the seed portrait for the consistency
+                              loop — there should be at most one True)
+
+    Returns [] when the reservoir file is missing or empty.
+    """
+    if not character_id:
+        return []
+    portraits_path = _portraits_path(reservoir_root, character_id)
+    records = _read_portrait_records(portraits_path)
+    records.sort(key=lambda r: r.get("generated_at", 0.0), reverse=True)
+    if limit > 0:
+        records = records[:limit]
+    return records
+
+
+def _pick_reference_portrait(records: list[dict]) -> dict | None:
+    """Return the portrait whimweaver should condition on:
+      1. The first record marked canonical=True (newest if multiple).
+      2. Otherwise the newest record overall.
+      3. None if records is empty."""
+    if not records:
+        return None
+    canonical = [r for r in records if r.get("canonical")]
+    if canonical:
+        canonical.sort(key=lambda r: r.get("generated_at", 0.0), reverse=True)
+        return canonical[0]
+    return records[0]  # newest by virtue of caller sorting
+
+
+def _builder_supported(builder: str, feature_caps: dict | None) -> bool:
+    """Cheap capability check. The /v1/capabilities payload exposes a
+    `builders` map (builder_name → {available: bool, ...}) per the
+    spellcaster manifest. We default to True when caps are absent so
+    proxy callers without /v1/capabilities still get a usable result."""
+    if not feature_caps:
+        return True
+    builders = feature_caps.get("builders") or {}
+    if not isinstance(builders, dict):
+        return True
+    entry = builders.get(builder)
+    if entry is None:
+        # Not listed = assume unavailable (caps was provided, builder
+        # missing means the host doesn't ship it).
+        return False
+    if isinstance(entry, dict):
+        return bool(entry.get("available", True))
+    return bool(entry)
+
+
+def build_consistent_portrait_for_character(
+    character_id: str,
+    prompt: str,
+    *,
+    reservoir_root,
+    builder_hint: str | None = None,
+    feature_caps: dict | None = None,
+) -> dict:
+    """Pick the best identity-preserving builder for this character and
+    return a submission packet for whimweaver to dispatch.
+
+    Returns a dict shaped like:
+        {
+          "builder":              "build_pulid_flux" | "build_klein_*" | ...,
+          "builder_args":         {kwargs ready to pass through proxy},
+          "reference_portrait_id": str | None,
+          "reference_image_path": str | None,
+          "fallback_chain":       [str, ...],   # builders considered, in order
+        }
+
+    `builder_hint` (optional) lets the caller force-prefer a specific
+    builder name — it is honored when feature_caps allow it, otherwise
+    we fall through the default preference order.
+
+    This function does NOT submit anything to ComfyUI. The caller is
+    expected to import `spellcaster_proxy.<builder>` and submit the
+    resulting workflow themselves.
+    """
+    if not character_id:
+        raise ValueError("character_id is required")
+    if not prompt:
+        raise ValueError("prompt is required")
+
+    history = get_character_portrait_history(
+        character_id, reservoir_root=reservoir_root, limit=20
+    )
+    ref = _pick_reference_portrait(history)
+    ref_id = ref.get("portrait_id") if ref else None
+    ref_path = ref.get("image_path") if ref else None
+
+    # Build the preference order. Honor builder_hint when supported.
+    pref: list[str] = list(_BUILDER_PREFERENCE)
+    if builder_hint and builder_hint in pref:
+        pref.remove(builder_hint)
+        pref.insert(0, builder_hint)
+
+    # If no reference image is on file, the identity-preserving builders
+    # have nothing to lock onto — fall back to plain image-to-image or
+    # text-to-image. We expose this via the chain anyway so the caller
+    # can decide.
+    if ref_path is None:
+        pref = [b for b in pref if b not in (
+            "build_pulid_flux",
+            "build_klein_img2img_ref",
+            "build_klein_headswap",
+        )]
+        if not pref:
+            pref = ["build_klein_img2img"]
+
+    # Pick the first builder the caps allow.
+    chosen: str | None = None
+    for b in pref:
+        if _builder_supported(b, feature_caps):
+            chosen = b
+            break
+    if chosen is None:
+        # Caps blocked everything in our preference order. Fall back to
+        # the most permissive option so callers can at least try.
+        chosen = pref[0]
+
+    builder_args = _builder_args_for(
+        chosen, prompt=prompt, ref_path=ref_path, ref=ref,
+    )
+
+    return {
+        "builder": chosen,
+        "builder_args": builder_args,
+        "reference_portrait_id": ref_id,
+        "reference_image_path": ref_path,
+        "fallback_chain": pref,
+    }
+
+
+def _builder_args_for(builder: str, *, prompt: str,
+                      ref_path: str | None, ref: dict | None) -> dict:
+    """Translate the chosen builder into a kwargs dict whimweaver can
+    splat onto the proxy call. We pass only minimal fields here — the
+    caller layers their own seed, model, lora, and dimension policy on
+    top. The seed (when ref exists) defaults to the reference portrait's
+    seed so re-rolls tend to converge."""
+    seed = (ref or {}).get("prompt_seed") if ref else None
+
+    if builder == "build_pulid_flux":
+        return {
+            "face_ref_filename": ref_path,
+            "prompt_text": prompt,
+            "negative_text": "",
+            "seed": seed,
+        }
+    if builder == "build_klein_img2img_ref":
+        return {
+            "ref_filename": ref_path,
+            "image_filename": ref_path,  # caller may override with a base
+            "prompt_text": prompt,
+            "seed": seed,
+            "identity_lock": True,
+        }
+    if builder == "build_klein_headswap":
+        return {
+            "target_filename": ref_path,  # caller usually overrides w/ new body
+            "source_filename": ref_path,
+            "prompt": prompt,
+            "seed": seed,
+            "use_identity_lock": True,
+        }
+    if builder == "build_klein_img2img":
+        return {
+            "image_filename": ref_path,
+            "prompt_text": prompt,
+            "seed": seed,
+        }
+    # SDXL fallback — caller wires the actual SDXL builder name in their
+    # workflows module if they want it; we expose a generic shape.
+    return {
+        "image_filename": ref_path,
+        "prompt_text": prompt,
+        "seed": seed,
+    }
+
+
+def mark_canonical_portrait(
+    character_id: str,
+    portrait_id: str,
+    *,
+    reservoir_root,
+) -> bool:
+    """Set canonical=True on the named portrait and canonical=False on
+    every other portrait for the same character.
+
+    Returns True when the target portrait_id was found and the file was
+    rewritten successfully; False otherwise (missing file, missing id,
+    or write failure)."""
+    if not character_id or not portrait_id:
+        return False
+    portraits_path = _portraits_path(reservoir_root, character_id)
+    records = _read_portrait_records(portraits_path)
+    if not records:
+        return False
+    found = False
+    for r in records:
+        if r.get("portrait_id") == portrait_id:
+            r["canonical"] = True
+            found = True
+        else:
+            if r.get("canonical"):
+                r["canonical"] = False
+    if not found:
+        return False
+    return _write_portrait_records_atomic(portraits_path, records)

--- a/plugins/gimp/comfyui-connector/spellcaster_core/preflight.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/preflight.py
@@ -158,6 +158,73 @@ def _fallback_skip(nid, node, workflow):
     return None  # Can't skip safely
 
 
+def _fallback_sam3_optional(nid, node, workflow):
+    """Skip SAM3Segment + its downstream mask-composite chain so the
+    workflow runs without SAM3 region scoping (full-canvas transform).
+
+    SAM3 is used by Spellcaster in two patterns:
+      a) DIRECT (sam3_segment / sam3_extract / klein_sam3_inpaint) -- the
+         whole workflow exists to USE SAM3; can't salvage; this fallback
+         returns None to signal "no graceful skip".
+      b) OPTIONAL (build_sam3_mask inside img2img/iclight/refine/etc) --
+         used to composite the transform output onto the original via a
+         SAM3-masked region. Removing SAM3 + GrowMaskWithBlur +
+         ImageCompositeMasked, then rewiring consumers to use the
+         transformed "source" image directly, degrades gracefully to
+         "transform the whole canvas, no region scoping".
+
+    We detect pattern (b) by looking for an ImageCompositeMasked whose
+    `mask` input traces back to this SAM3Segment.
+    """
+    # Find any ImageCompositeMasked whose mask comes (directly or via
+    # GrowMaskWithBlur) from this SAM3 node.
+    sam3_id_str = str(nid)
+    composites_to_strip = []
+    grow_to_strip = []
+    for cid, cnode in workflow.items():
+        if not isinstance(cnode, dict):
+            continue
+        if cnode.get("class_type") != "ImageCompositeMasked":
+            continue
+        mask_ref = cnode.get("inputs", {}).get("mask")
+        if not (isinstance(mask_ref, list) and len(mask_ref) == 2):
+            continue
+        mask_src = str(mask_ref[0])
+        # Direct: composite.mask <- SAM3
+        if mask_src == sam3_id_str:
+            composites_to_strip.append(cid)
+            continue
+        # Indirect: composite.mask <- GrowMaskWithBlur <- SAM3
+        grow_node = workflow.get(mask_src) or workflow.get(int(mask_src) if mask_src.isdigit() else None)
+        if isinstance(grow_node, dict) and grow_node.get("class_type") == "GrowMaskWithBlur":
+            inner = grow_node.get("inputs", {}).get("mask")
+            if isinstance(inner, list) and len(inner) == 2 and str(inner[0]) == sam3_id_str:
+                composites_to_strip.append(cid)
+                grow_to_strip.append(mask_src)
+
+    if not composites_to_strip:
+        # No composite uses our mask -- this is the DIRECT pattern.
+        # Can't salvage; the workflow is entirely SAM3-based.
+        return None
+
+    # OPTIONAL pattern: rewire each composite's consumers to use the
+    # composite's `source` input (the transformed image) directly, then
+    # delete the composite + grow + sam3 nodes.
+    to_delete = set([sam3_id_str] + [str(g) for g in grow_to_strip])
+    for cid in composites_to_strip:
+        cnode = workflow[cid]
+        source_ref = cnode.get("inputs", {}).get("source")
+        if not (isinstance(source_ref, list) and len(source_ref) == 2):
+            # Can't determine the source; bail with an error
+            return None
+        _rewire_refs(workflow, cid, 0, source_ref[0], source_ref[1])
+        to_delete.add(str(cid))
+
+    # Build the patched dict: drop the stripped nodes
+    patched = {k: v for k, v in workflow.items() if str(k) not in to_delete}
+    return patched
+
+
 # The registry: class_type → (fallback_fn, description, install_hint)
 FALLBACK_REGISTRY = {
     "RIFE_VFI": (
@@ -174,6 +241,11 @@ FALLBACK_REGISTRY = {
         None,
         "LaMa object removal node",
         "Install: comfyui-lama (required for object removal)",
+    ),
+    "SAM3Segment": (
+        _fallback_sam3_optional,
+        "SAM3 region scoping -> skipped (transform applies to full canvas)",
+        "Install: ComfyUI-Segment-Anything-2 for region-scoped edits",
     ),
 }
 
@@ -302,6 +374,207 @@ def check_workflow(workflow, comfy_url):
             if ct and ct not in available and ct not in missing:
                 missing.append(ct)
     return missing
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Model-file substitution (file-level fallback)
+# ═══════════════════════════════════════════════════════════════════════
+#
+#  preflight_workflow() handles MISSING NODE TYPES. This complementary
+#  pass handles MISSING MODEL FILES referenced by nodes that ARE present.
+#  When a workflow names e.g. swap_model="hyperswap_1c_256.onnx" but the
+#  ComfyUI server only has inswapper_128.onnx, validation fails with
+#  "Value not in list" -- accurate but unactionable. This map provides
+#  graceful fallback to the closest available alternative.
+#
+#  Per node-type + input-name, list (missing -> fallback) substitutions.
+#  Substitution only fires when the missing value is referenced AND the
+#  fallback IS in the live picker list.
+_FILE_FALLBACKS = {
+    # ReActor swap-models (only inswapper_128 ships standard)
+    ("ReActorFaceSwapOpt", "swap_model"): {
+        "hyperswap_1c_256.onnx": "inswapper_128.onnx",
+        "reswapper_256.onnx":    "inswapper_128.onnx",
+        "simswap_256.onnx":      "inswapper_128.onnx",
+    },
+    ("ReActorFaceSwap", "swap_model"): {
+        "hyperswap_1c_256.onnx": "inswapper_128.onnx",
+        "reswapper_256.onnx":    "inswapper_128.onnx",
+    },
+    ("ReActorFaceSwapOpt", "face_restore_model"): {
+        "GPEN-BFR-2048.onnx": "GPEN-BFR-512.onnx",
+        "GPEN-BFR-1024.onnx": "GPEN-BFR-512.onnx",
+    },
+    ("ReActorFaceSwap", "face_restore_model"): {
+        "GPEN-BFR-2048.onnx": "GPEN-BFR-512.onnx",
+        "GPEN-BFR-1024.onnx": "GPEN-BFR-512.onnx",
+    },
+    ("ReActorFaceBoost", "boost_model"): {
+        "GPEN-BFR-2048.onnx": "GPEN-BFR-512.onnx",
+        "GPEN-BFR-1024.onnx": "GPEN-BFR-512.onnx",
+    },
+}
+
+
+# Generic picker inputs that should accept ANY-IN-LIST substitution
+# (basename-match -> first available file with matching basename). When the
+# exact filename isn't on disk but a close cousin is, swap to that. This
+# is the same shape as the static _FILE_FALLBACKS but DYNAMIC -- we resolve
+# at preflight time by looking at the live picker list.
+_PICKER_INPUTS_AUTOSUB = {
+    ("CheckpointLoaderSimple", "ckpt_name"),
+    ("CheckpointLoader",       "ckpt_name"),
+    ("UNETLoader",             "unet_name"),
+    ("UnetLoaderGGUF",         "unet_name"),
+    ("VAELoader",              "vae_name"),
+    ("CLIPLoader",             "clip_name"),
+    ("CLIPLoaderGGUF",         "clip_name"),
+    ("DualCLIPLoader",         "clip_name1"),
+    ("DualCLIPLoader",         "clip_name2"),
+    ("ControlNetLoader",       "control_net_name"),
+    ("UpscaleModelLoader",     "model_name"),
+}
+
+
+def _fallback_lora_skip(nid, node, workflow):
+    """Remove a LoraLoader (LoraLoader / LoraLoaderModelOnly) and rewire
+    downstream model+clip references to bypass it. LoRAs are refinement
+    layers -- workflows produce usable output without them, just with
+    slightly different style.
+
+    LoraLoader is `(model, clip, lora_name, strength_model, strength_clip)
+    -> (MODEL, CLIP)`. We rewire [nid, 0] -> inputs.model and [nid, 1] ->
+    inputs.clip on all downstream nodes, then delete the loader.
+    """
+    inputs = node.get("inputs", {})
+    model_ref = inputs.get("model")
+    clip_ref = inputs.get("clip")
+    if not (isinstance(model_ref, list) and len(model_ref) == 2):
+        return None
+    # Rewire model output (slot 0)
+    _rewire_refs(workflow, nid, 0, model_ref[0], model_ref[1])
+    # Rewire clip output (slot 1) if the LoRA has a clip input
+    if isinstance(clip_ref, list) and len(clip_ref) == 2:
+        _rewire_refs(workflow, nid, 1, clip_ref[0], clip_ref[1])
+    return {}  # empty dict = remove this node
+
+
+def substitute_missing_files(workflow, comfy_url):
+    """Swap referenced model filenames for available alternatives.
+
+    Two strategies:
+      1) STATIC: _FILE_FALLBACKS has explicit (missing -> available)
+         entries for known-equivalent pairs (e.g. hyperswap_1c_256 ->
+         inswapper_128). Substitute when the original is missing AND
+         the fallback IS in the live picker list.
+      2) DYNAMIC: For loader nodes in _PICKER_INPUTS_AUTOSUB, when the
+         current value isn't in the picker list, try to find a close
+         basename match in the available list (case-insensitive,
+         extension-aware). When no match, leave alone so the user gets
+         a clear "Value not in list" error.
+      3) LORA-SKIP: If a LoraLoader's lora_name isn't available, REMOVE
+         the loader (rewire model+clip past it). LoRAs are refinement;
+         workflows still produce usable output without them.
+
+    Returns (patched_workflow, substitutions) where substitutions is a
+    list of (node_id, input_name, old_value, new_value | None) tuples.
+    None means the node was removed.
+    """
+    substitutions = []
+    patched = dict(workflow)
+
+    # Pass A: static + dynamic file substitution
+    for nid, node in list(patched.items()):
+        if not isinstance(node, dict):
+            continue
+        ct = node.get("class_type", "")
+        inputs = node.get("inputs", {}) or {}
+        for input_name, value in list(inputs.items()):
+            if not isinstance(value, str):
+                continue
+
+            # Static substitutions first
+            sub_map = _FILE_FALLBACKS.get((ct, input_name))
+            if sub_map and value in sub_map:
+                fallback = sub_map[value]
+                picker = _get_picker_values(comfy_url, ct, input_name)
+                if not picker or fallback in picker:
+                    new_node = dict(node); new_inputs = dict(inputs)
+                    new_inputs[input_name] = fallback
+                    new_node["inputs"] = new_inputs
+                    patched[nid] = new_node
+                    substitutions.append((nid, input_name, value, fallback))
+                    print(f"[Preflight] file-sub {ct}.{input_name}: "
+                           f"{value} -> {fallback}")
+                    continue
+
+            # Dynamic basename-match for picker inputs
+            if (ct, input_name) in _PICKER_INPUTS_AUTOSUB:
+                picker = _get_picker_values(comfy_url, ct, input_name)
+                if picker and value not in picker:
+                    fallback = _closest_filename_match(value, picker)
+                    if fallback and fallback != value:
+                        new_node = dict(node); new_inputs = dict(inputs)
+                        new_inputs[input_name] = fallback
+                        new_node["inputs"] = new_inputs
+                        patched[nid] = new_node
+                        substitutions.append((nid, input_name, value, fallback))
+                        print(f"[Preflight] auto-sub {ct}.{input_name}: "
+                               f"{value} -> {fallback}")
+
+    # Pass B: LoRA-skip
+    for nid in list(patched.keys()):
+        node = patched.get(nid)
+        if not isinstance(node, dict):
+            continue
+        ct = node.get("class_type", "")
+        if ct not in ("LoraLoader", "LoraLoaderModelOnly"):
+            continue
+        lora_name = (node.get("inputs", {}) or {}).get("lora_name", "")
+        if not isinstance(lora_name, str) or not lora_name:
+            continue
+        picker = _get_picker_values(comfy_url, ct, "lora_name")
+        if picker and lora_name not in picker:
+            # LoRA file missing -- remove the loader and rewire past it.
+            res = _fallback_lora_skip(nid, node, patched)
+            if res is not None:
+                del patched[nid]
+                substitutions.append((nid, "lora_name", lora_name, None))
+                print(f"[Preflight] lora-skip {ct}: dropped missing "
+                       f"LoRA '{lora_name}'")
+
+    return patched, substitutions
+
+
+def _closest_filename_match(target, picker):
+    """Find the best match for `target` in `picker` list. Strategy:
+       1) Exact match (case-insensitive).
+       2) Same basename, any subfolder.
+       3) Substring match (largest common substring).
+       4) None.
+    """
+    if not picker:
+        return None
+    target_lower = target.lower()
+    target_base = target_lower.replace("\\", "/").rsplit("/", 1)[-1]
+
+    # Exact case-insensitive
+    for p in picker:
+        if p.lower() == target_lower:
+            return p
+    # Same basename
+    for p in picker:
+        p_base = p.lower().replace("\\", "/").rsplit("/", 1)[-1]
+        if p_base == target_base:
+            return p
+    # Strip extension and retry basename match
+    target_stem = target_base.rsplit(".", 1)[0]
+    for p in picker:
+        p_base = p.lower().replace("\\", "/").rsplit("/", 1)[-1]
+        p_stem = p_base.rsplit(".", 1)[0]
+        if p_stem == target_stem:
+            return p
+    return None
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/plugins/gimp/comfyui-connector/spellcaster_core/workflows.py
+++ b/plugins/gimp/comfyui-connector/spellcaster_core/workflows.py
@@ -1020,6 +1020,17 @@ def build_2d_to_sbs(image_filename,
                     depth_blur=15) -> dict:
     """Convert a 2D image to side-by-side stereoscopic 3D for XREAL Air,
     Quest, Vision Pro, anaglyph glasses, etc.
+
+    Pipeline:
+      1. LoadImage
+      2. DepthAnythingV2Preprocessor -> depth map
+      3. Y7_SideBySide -> SBS stereo image
+      4. SaveImageWebsocket
+
+    Requirements (preflight will catch missing pieces):
+      - comfyui_controlnet_aux (DepthAnythingV2Preprocessor)
+      - ComfyUI-Y7-SBS-2Dto3D (Y7_SideBySide)
+      - depth_anything_v2_*.pth in ComfyUI/models/depthanything/
     """
     nf = NodeFactory()
     img_id = nf.load_image(image_filename, node_id="1")
@@ -1050,8 +1061,15 @@ def build_2d_to_sbs_extreme(image_filename,
                         sbs_mode="left-right") -> dict:
     """MAXED 2D -> SBS using ComfyStereo's StereoImageNode.
 
-    Higher fidelity (vitl depth @ 1024 + GPU warp fill, divergence up to 15)
-    in exchange for VRAM + time.
+    Trades VRAM + time for higher fidelity:
+      - Depth-Anything-V2 LARGE (~1.3 GB) at resolution=1024
+      - ComfyStereo GPU-warping fill for clean disocclusions
+      - divergence up to 15 for strongest stereo effect
+
+    Requirements:
+      - comfyui_controlnet_aux (DepthAnythingV2Preprocessor)
+      - ComfyStereo (StereoImageNode)
+      - depth_anything_v2_vitl.pth in ComfyUI/models/depthanything/
     """
     nf = NodeFactory()
     img_id = nf.load_image(image_filename, node_id="1")
@@ -10260,3 +10278,86 @@ def build_ltx_video(preset, prompt_text, seed,
                           pingpong=pingpong, node_id="50")
 
     return nf.build()
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  Klein Multi-Angle Character Sheet (CivitAI 2642426 / nikhilprasanth)
+# ═══════════════════════════════════════════════════════════════════════════
+
+KLEIN_MULTI_ANGLE_PROMPTS = {
+    'front_45': 'Using the input image as the strict visual reference, create a 45-degree front three-quarter view of the same subject.\n\nThe subject may be a person, character, vehicle, prop, object, creature, or architectural element.\n\nPreserve the exact identity, proportions, shape, silhouette, materials, colors, clothing or surface details, markings, texture, wear, accessories, and design language from the input image.\n\nPreserve the same expression, pose, posture, stance, gesture, object position, and overall attitude from the input image. The subject must remain in the same moment, only viewed from a front three-quarter angle.\n\nCamera angle: front three-quarter view, approximately 45 degrees, eye-level.\nLighting: soft diffused lighting, gentle highlights on visible edges.\nBackground: plain neutral background for easy compositing.\nCamera/lens: 50mm lens, natural perspective, realistic depth.\nComposition: full subject visible, centered, with clear readable front and side depth.\n\nPhotorealistic, same subject, same pose, same expression, same design, only the viewing angle changes.',
+    'side': 'Using the input image as the strict visual reference, create a pure side profile view of the same subject.\n\nThe subject may be a person, character, vehicle, prop, object, creature, or architectural element.\n\nPreserve the exact identity, proportions, shape, silhouette, materials, colors, clothing or surface details, markings, texture, wear, accessories, and design language from the input image.\n\nPreserve the same expression, pose, posture, stance, gesture, object position, and overall attitude from the input image. The subject should not be redesigned or repositioned. It should look like the same subject frozen in the same moment, now seen from the side.\n\nCamera angle: direct side profile view, eye-level, clean perspective.\nLighting: soft diffused lighting, mild rim definition along the edges.\nBackground: plain neutral background for easy compositing.\nCamera/lens: 70mm lens, low distortion, compressed realistic perspective.\nComposition: full subject visible, centered, side silhouette clearly readable.\n\nPhotorealistic, accurate side geometry, same subject, same pose, same expression, no redesign.',
+    'rear': 'Using the input image as the strict visual reference, create a rear view of the same subject.\n\nThe subject may be a person, character, vehicle, prop, object, creature, or architectural element.\n\nPreserve the exact identity, proportions, shape, silhouette, materials, colors, clothing or surface details, markings, texture, wear, accessories, and design language from the input image.\n\nPreserve the same pose, posture, stance, gesture, object position, and overall attitude from the input image. Infer the rear logically from the visible design while keeping the subject consistent. The subject should feel like the same person or object frozen in the same moment, now seen from behind.\n\nCamera angle: straight-on rear view, eye-level, centered perspective.\nLighting: soft diffused lighting, clear rear contours and edge definition.\nBackground: plain neutral background for easy compositing.\nCamera/lens: 50mm lens, natural realistic perspective.\nComposition: full subject visible, centered, enough empty space around it.\n\nPhotorealistic, same subject, same pose, same proportions, believable rear details, no redesign.',
+    'rear_45': 'Using the input image as the strict visual reference, create a 45-degree rear three-quarter view of the same subject.\n\nThe subject may be a person, character, vehicle, prop, object, creature, or architectural element.\n\nPreserve the exact identity, proportions, shape, silhouette, materials, colors, clothing or surface details, markings, texture, wear, accessories, and design language from the input image.\n\nPreserve the same pose, posture, stance, gesture, object position, and overall attitude from the input image. Infer hidden rear-side details logically from the visible design, keeping the same subject consistent.\n\nCamera angle: rear three-quarter view, approximately 45 degrees, eye-level.\nLighting: soft diffused lighting, gentle edge highlights.\nBackground: plain neutral background for easy compositing.\nCamera/lens: 50mm to 70mm lens, natural realistic perspective.\nComposition: full subject visible, centered, rear and side forms clearly readable.\n\nPhotorealistic, same subject, same pose, same expression where visible, same design, only the camera angle changes.',
+    'high_angle': 'Using the input image as the strict visual reference, create a high-angle view of the same subject.\n\nThe subject may be a person, character, vehicle, prop, object, creature, or architectural element.\n\nPreserve the exact identity, proportions, shape, silhouette, materials, colors, clothing or surface details, markings, texture, wear, accessories, and design language from the input image.\n\nPreserve the same expression, pose, posture, stance, gesture, object position, and overall attitude from the input image. The subject should remain frozen in the same moment, only viewed from above.\n\nCamera angle: high-angle view from above, approximately 60 to 75 degrees downward.\nLighting: soft diffused overhead lighting, readable top-plane details.\nBackground: plain neutral background for easy compositing.\nCamera/lens: 35mm to 50mm lens, controlled perspective, realistic scale.\nComposition: full subject visible, centered, top surfaces clearly shown.\n\nPhotorealistic, same subject, same pose, same expression, consistent geometry, no redesign.',
+    'low_angle': 'Using the input image as the strict visual reference, create a low-angle view of the same subject.\n\nThe subject may be a person, character, vehicle, prop, object, creature, or architectural element.\n\nPreserve the exact identity, proportions, shape, silhouette, materials, colors, clothing or surface details, markings, texture, wear, accessories, and design language from the input image.\n\nPreserve the same expression, pose, posture, stance, gesture, object position, and overall attitude from the input image. The subject should feel like the same moment captured from a lower camera position.\n\nCamera angle: low-angle view from below eye level, looking slightly upward.\nLighting: soft diffused lighting, consistent with the input image.\nBackground: plain neutral background for easy compositing.\nCamera/lens: 35mm to 50mm lens, controlled perspective, no extreme distortion.\nComposition: full subject visible, centered, strong readable silhouette.\n\nPhotorealistic, same subject, same pose, same expression, same design, only the camera position changes.',
+    'close_up': 'Using the input image as the strict visual reference, create a close-up detail view of the same subject.\n\nThe subject may be a person, character, vehicle, prop, object, creature, or architectural element.\n\nPreserve the exact identity, materials, colors, clothing or surface details, markings, texture, wear, accessories, and design language from the input image.\n\nPreserve the same expression, pose, posture, gesture, object position, and overall attitude from the input image. The close-up should feel like the same moment, with the camera moved closer.\n\nCamera angle: [front close-up / side close-up / three-quarter close-up].\nLighting: soft diffused lighting, consistent with the input image.\nBackground: plain neutral background or softly blurred matching background.\nCamera/lens: 85mm lens, shallow depth of field, realistic perspective.\nComposition: focus on [FACE / HANDS / WHEELS / SURFACE DETAIL / PROP DETAIL / TEXTURE AREA].\n\nPhotorealistic, same subject, same moment, same pose and expression, only closer framing.',
+}
+
+
+def build_klein_multi_angle(image_filename, klein_model_key="Klein 4B",
+                            seed=0, steps=4, guidance=1.0,
+                            sampler_name="euler", megapixels=1.0,
+                            angle_prompts=None,
+                            klein_models=None) -> dict:
+    """Multi-angle character sheet from a single reference image.
+
+    Adapted from nikhilprasanth's "Flux Klein 4B/9B Multiple Angles"
+    (CivitAI 2642426). Generates one image per camera angle (7 by
+    default) using Klein's reference-latent mechanism. Each output
+    preserves the subject's identity / proportions / outfit / pose /
+    expression -- only the camera angle changes.
+
+    Shared model + CLIP + VAE + reference latent computed once; each
+    angle is a separate KSampler chain reusing them. ~65 nodes total.
+    """
+    if klein_models is None:
+        klein_models = KLEIN_MODELS
+    if angle_prompts is None:
+        angle_prompts = KLEIN_MULTI_ANGLE_PROMPTS
+
+    km = klein_models[klein_model_key]
+    nf = NodeFactory()
+
+    unet_id = nf.unet_loader(km["unet"], node_id="1")
+    clip_id = nf.clip_loader(km["clip"], clip_type="flux2",
+                              device="default", node_id="2")
+    vae_id = nf.vae_loader(FLUX2_VAE, node_id="3")
+    img_id = nf.load_image(image_filename, node_id="4")
+
+    scaled_id = nf.image_scale_to_total_pixels(
+        [img_id, 0], megapixels=megapixels, node_id="5")
+    size_id = nf.get_image_size([scaled_id, 0], node_id="6")
+    ref_lat_id = nf.vae_encode(
+        [scaled_id, 0], [vae_id, 0], node_id="7")
+
+    empty_id = nf.empty_flux2_latent_image(
+        [size_id, 0], [size_id, 1], batch_size=1, node_id="8")
+    sigmas_id = nf.flux2_scheduler(
+        steps, [size_id, 0], [size_id, 1], node_id="9")
+    sampler_id = nf.ksampler_select(sampler_name, node_id="10")
+
+    base = 100
+    for i, (slug, prompt_text) in enumerate(angle_prompts.items()):
+        bid = base + i * 10
+        cond_id = nf.clip_encode(
+            [clip_id, 0], prompt_text, node_id=str(bid))
+        zero_id = nf.conditioning_zero_out(
+            [cond_id, 0], node_id=str(bid + 1))
+        ref_pos = nf.reference_latent(
+            [cond_id, 0], [ref_lat_id, 0], node_id=str(bid + 2))
+        ref_neg = nf.reference_latent(
+            [zero_id, 0], [ref_lat_id, 0], node_id=str(bid + 3))
+        guider_id = nf.cfg_guider(
+            [unet_id, 0], [ref_pos, 0], [ref_neg, 0],
+            guidance, node_id=str(bid + 4))
+        noise_id = nf.random_noise(seed + i, node_id=str(bid + 5))
+        samp_id = nf.sampler_custom_advanced(
+            [noise_id, 0], [guider_id, 0], [sampler_id, 0],
+            [sigmas_id, 0], [empty_id, 0], node_id=str(bid + 6))
+        dec_id = nf.vae_decode(
+            [samp_id, 0], [vae_id, 0], node_id=str(bid + 7))
+        nf.save_image_websocket(
+            [dec_id, 0], label=slug, node_id=str(bid + 8))
+
+    return nf.build()
+

--- a/tools/upgrade_research.py
+++ b/tools/upgrade_research.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Upgrade-research targets — feed for the every-48h ecosystem digest.
+
+Every 48 hours the cloud-side Ecosystem Digest routine (see the
+scheduled prompt in the operator's Claude Code account) sweeps the
+upgrade-opportunity surface: which registered architectures have new
+weights on Hugging Face, which sibling packs Kijai / Comfy-Org have
+shipped, which video models have a new release-of-the-week. Prior
+digest runs kept noting this script was missing and silently
+degrading to open-ended web search; this file is the minimal contract
+those runs asked for.
+
+What it does
+------------
+Read the canonical architecture registry
+(`comfyui-spellcaster/spellcaster_core/architectures.py`) and emit a
+deterministic list of research targets — one per registered arch —
+with:
+
+  * arch key + `registered` flag + `scene_group`
+  * Hugging Face repo hints (owner/name patterns the family typically
+    ships under, based on what already runs in this stack)
+  * candidate web-search queries an LLM agent can plug straight into
+    WebSearch (versioned by the current month so year-old blog posts
+    rank lower)
+
+Nothing here talks to the network — that stays the caller's job — so
+this script is fine to run in CI, on the dev host, and in the
+Anthropic cloud sandbox alike. The point is to give the digest agent
+a stable, checked-in seed of what to research instead of a fresh
+brain-dump each time.
+
+Usage
+-----
+
+    # Human-readable (default):
+    python tools/upgrade_research.py
+
+    # Machine-readable JSON, for the digest agent to consume:
+    python tools/upgrade_research.py --json
+
+    # Restrict to one scene group (image / video / sdxl / …):
+    python tools/upgrade_research.py --group video
+
+Contract for the digest agent
+-----------------------------
+The `targets` list in the JSON output IS the checklist. Each entry
+has an `arch`, a `scene_group`, an `hf_hints` list (partial owner or
+name patterns to search HF with) and a `web_queries` list (each an
+already-versioned WebSearch string). The agent should run each
+`web_queries[0]` first, cache the finding, and only dig deeper on
+archs where the shallow query shows movement in the current or
+previous month.
+
+The script has no side effects and no external deps beyond the Python
+stdlib and the repo's own `spellcaster_core.architectures` module.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+
+# Canonical registry lives under comfyui-spellcaster/. Prefer that over
+# the plugins/gimp mirror so a stale mirror can't skew research targets.
+CANON_CORE = REPO / "comfyui-spellcaster"
+if str(CANON_CORE) not in sys.path:
+    sys.path.insert(0, str(CANON_CORE))
+
+try:
+    from spellcaster_core.architectures import ARCHITECTURES, get_arch  # type: ignore
+except Exception as exc:  # pragma: no cover — surfaces a clear error to the caller
+    print(f"[upgrade_research] failed to import spellcaster_core.architectures: {exc}",
+          file=sys.stderr)
+    sys.exit(2)
+
+
+# Per-arch upstream hints. Keys must match ARCHITECTURES keys. Missing
+# keys degrade to a generic search string derived from the arch key —
+# safe, just less precise. Add a new arch to this table whenever a new
+# `_reg(...)` lands so digests get a targeted query for it.
+#
+# `hf_hints` are HF search fragments (owner or model prefix), not
+# full URLs. The digest agent expands them via the Hugging-Face MCP.
+# `web_queries` are already-versioned WebSearch inputs; put the most
+# discriminating one first — the agent skims that before deciding to
+# spend more of its ~25-call budget on the arch.
+UPSTREAM_HINTS: dict[str, dict[str, list[str]]] = {
+    # Image — SD ancestry
+    "sd15":         {"hf_hints": ["runwayml/stable-diffusion-v1-5", "stable-diffusion-v1-5"]},
+    "sdxl":         {"hf_hints": ["stabilityai/stable-diffusion-xl", "SG161222", "RunDiffusion"]},
+    "sdxl_turbo":   {"hf_hints": ["stabilityai/sdxl-turbo", "ByteDance/SDXL-Lightning", "latent-consistency"]},
+    "illustrious":  {"hf_hints": ["OnomaAIResearch/Illustrious-XL", "illustrious"]},
+    "pony":         {"hf_hints": ["AstraliteHeart/pony-diffusion", "Pony"]},
+    "playground":   {"hf_hints": ["playgroundai/playground-v2", "playgroundai/playground-v3"]},
+    "zit":          {"hf_hints": ["Alpha-VLLM/Lumina-Image", "z_image_turbo", "zit"]},
+    # DiT stubs
+    "sd3":          {"hf_hints": ["stabilityai/stable-diffusion-3", "stabilityai/stable-diffusion-3.5"]},
+    "sd3_turbo":    {"hf_hints": ["stabilityai/stable-diffusion-3.5-large-turbo"]},
+    "hunyuan_dit":  {"hf_hints": ["Tencent-Hunyuan/HunyuanDiT"]},
+    "pixart":       {"hf_hints": ["PixArt-alpha", "PixArt-Sigma"]},
+    "auraflow":     {"hf_hints": ["fal/AuraFlow"]},
+    "kolors":       {"hf_hints": ["Kwai-Kolors/Kolors"]},
+    "lumina2":      {"hf_hints": ["Alpha-VLLM/Lumina-Image-2.0"]},
+    # Flux / Chroma family
+    "flux1dev":     {"hf_hints": ["black-forest-labs/FLUX.1-dev", "FLUX.1"]},
+    "chroma":       {"hf_hints": ["lodestones/Chroma"]},
+    "flux2klein":   {"hf_hints": ["black-forest-labs/FLUX.2-klein", "kaleidoscope"]},
+    "flux_kontext": {"hf_hints": ["black-forest-labs/FLUX.1-Kontext", "kontext"]},
+    # Video / motion
+    "wan":          {"hf_hints": ["Wan-AI/Wan2.2", "Wan-AI/Wan2.1", "Kijai/WanVideo_comfy"]},
+    "ltx":          {"hf_hints": ["Lightricks/LTX-Video"]},
+    "seedvr":       {"hf_hints": ["ByteDance-Seed/SeedVR2", "SeedVR"]},
+    "cogvideo":     {"hf_hints": ["THUDM/CogVideoX", "Kijai/CogVideoX_comfy"]},
+    "framepack":    {"hf_hints": ["lllyasviel/FramePack", "Kijai/FramePackWrapper"]},
+    "hunyuan_video":{"hf_hints": ["tencent/HunyuanVideo", "Kijai/HunyuanVideoWrapper"]},
+    "mochi":        {"hf_hints": ["genmo/mochi-1-preview", "Kijai/MochiWrapper"]},
+    # 3D
+    "hunyuan_3d":   {"hf_hints": ["tencent/Hunyuan3D-2", "tencent/Hunyuan3D-2.1"]},
+    # Restoration
+    "supir":        {"hf_hints": ["camenduru/SUPIR", "Kijai/SUPIR_pruned"]},
+}
+
+
+def _current_month_tag(today: _dt.date | None = None) -> str:
+    d = today or _dt.date.today()
+    return d.strftime("%Y-%m")
+
+
+def _default_web_queries(arch_key: str, month: str) -> list[str]:
+    """Fallback query template for archs the hint table doesn't customise."""
+    return [
+        f"{arch_key} ComfyUI new release {month}",
+        f"{arch_key} model update Hugging Face {month}",
+    ]
+
+
+def _web_queries_for(arch_key: str, month: str) -> list[str]:
+    """Produce discriminating queries for an arch, versioned by month."""
+    key_low = arch_key.lower()
+    # Family-specific patterns land here. Keep them short — the LLM
+    # agent will refine after seeing the first hit page.
+    if key_low.startswith("wan"):
+        return [
+            f"Wan2.2 vs Wan2.5 release notes {month}",
+            f"Kijai WanVideoWrapper changelog {month}",
+        ]
+    if key_low == "seedvr":
+        return [
+            f"SeedVR2 upscale ComfyUI release {month}",
+            f"ByteDance SeedVR benchmark {month}",
+        ]
+    if key_low == "supir":
+        return [
+            f"SUPIR restoration ComfyUI update {month}",
+            f"SUPIR vs SeedVR2 image restoration comparison {month}",
+        ]
+    if key_low.startswith("flux"):
+        return [
+            f"FLUX new release Black Forest Labs {month}",
+            f"FLUX Kontext ComfyUI workflow update {month}",
+        ]
+    if key_low == "chroma":
+        return [f"Chroma diffusion model release {month}"]
+    if key_low == "hunyuan_video":
+        return [f"HunyuanVideo weights update Tencent {month}"]
+    if key_low == "hunyuan_3d":
+        return [f"Hunyuan3D 2.1 vs 2.5 release {month}"]
+    if key_low == "cogvideo":
+        return [f"CogVideoX 1.5 release {month}"]
+    if key_low == "mochi":
+        return [f"Mochi-1 Genmo model update {month}"]
+    if key_low == "framepack":
+        return [f"FramePack low VRAM I2V release {month}"]
+    if key_low == "ltx":
+        return [f"LTX-Video Lightricks release notes {month}"]
+    if key_low == "lumina2":
+        return [f"Lumina-Image 2.0 release ComfyUI {month}"]
+    if key_low.startswith("sd3"):
+        return [f"Stable Diffusion 3.5 medium large release {month}"]
+    if key_low == "sdxl":
+        return [f"SDXL finetune notable release {month}"]
+    if key_low == "sdxl_turbo":
+        return [f"SDXL Turbo Lightning Hyper release {month}"]
+    if key_low == "illustrious":
+        return [f"Illustrious XL new version {month}"]
+    if key_low == "pony":
+        return [f"Pony Diffusion v7 release {month}"]
+    if key_low == "playground":
+        return [f"Playground v3 image model release {month}"]
+    if key_low == "zit":
+        return [f"Z-Image Turbo release ComfyUI {month}"]
+    if key_low == "kolors":
+        return [f"Kolors 2 release Kwai {month}"]
+    if key_low == "pixart":
+        return [f"PixArt-Sigma update {month}"]
+    if key_low == "auraflow":
+        return [f"AuraFlow v3 fal release {month}"]
+    return _default_web_queries(arch_key, month)
+
+
+def build_targets(scene_group: str | None = None,
+                  today: _dt.date | None = None) -> list[dict]:
+    """Return the sorted list of research targets."""
+    month = _current_month_tag(today)
+    out: list[dict] = []
+    for key in sorted(ARCHITECTURES.keys()):
+        arch = ARCHITECTURES[key]
+        if scene_group and getattr(arch, "scene_group", None) != scene_group:
+            continue
+        hints = UPSTREAM_HINTS.get(key, {}).get("hf_hints", [])
+        out.append({
+            "arch": key,
+            "scene_group": getattr(arch, "scene_group", None),
+            "registered": bool(getattr(arch, "registered", True)),
+            "supported_methods": list(getattr(arch, "supported_methods", ()) or ()),
+            "default_steps": getattr(arch, "default_steps", None),
+            "default_cfg": getattr(arch, "default_cfg", None),
+            "hf_hints": hints,
+            "web_queries": _web_queries_for(key, month),
+        })
+    return out
+
+
+def _print_markdown(targets: list[dict], month: str) -> None:
+    print(f"# Upgrade-research targets — {month}\n")
+    print(f"Total archs: **{len(targets)}**  ·  ",
+          f"registered: **{sum(1 for t in targets if t['registered'])}**  ·  ",
+          f"stubs: **{sum(1 for t in targets if not t['registered'])}**\n")
+    by_group: dict[str, list[dict]] = {}
+    for t in targets:
+        by_group.setdefault(t["scene_group"] or "unknown", []).append(t)
+    for group in sorted(by_group.keys()):
+        print(f"## scene_group: `{group}`\n")
+        for t in by_group[group]:
+            flag = "" if t["registered"] else " _(stub)_"
+            print(f"### `{t['arch']}`{flag}")
+            if t["hf_hints"]:
+                print("- **HF hints:** " + ", ".join(f"`{h}`" for h in t["hf_hints"]))
+            print("- **Web queries:**")
+            for q in t["web_queries"]:
+                print(f"  - `{q}`")
+            print()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Emit upgrade-research targets for the ecosystem digest routine.")
+    ap.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of markdown.")
+    ap.add_argument("--group", default=None, help="Restrict to one scene_group (image / video / sdxl / …).")
+    args = ap.parse_args()
+
+    targets = build_targets(scene_group=args.group)
+    if args.json:
+        json.dump({
+            "generated": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+            "month_tag": _current_month_tag(),
+            "arch_count": len(targets),
+            "targets": targets,
+        }, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        _print_markdown(targets, _current_month_tag())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What does this change?

Scheduled every-48h **Ecosystem Research Digest** run (cloud-side, Anthropic sandbox). Instead of only reporting findings, this run applies every Tier-1 fixable finding directly and hands off Tier-2/Tier-3 as structured queue items. See `_dev_docs/ecosystem_digest_2026-08-28.md` for the full digest.

Tier 1 fixes applied here:

- **`tools/upgrade_research.py` (new)** — the digest routine's own prompt has depended on this helper for several prior runs; it did not exist and each run silently degraded to open-ended web search. Minimal working version: reads canonical `ARCHITECTURES` registry, emits per-arch HF hints + versioned WebSearch queries as markdown or JSON.
- **`_reg("supir", ...)` stub in both mirrored `architectures.py`** — `model_detect.py:103` maps SUPIR checkpoints to arch key `"supir"` but no matching `_reg()` existed, so `get_arch("supir")` silently fell back to SDXL. This is exactly what the stub-registration design comment at ~L790-L807 was written to prevent.
- **`README.md:46`** — `Status — May 2026` → `Status — August 2026`. Prior digests flagged this and never fixed it.
- **Mirror auto-sync** (separate commit) — `python tests/mirror_drift.py --fix` on 3 files with pre-existing drift (`workflows.py`, `preflight.py`, `asset_gallery.py`), verified as red on `main` before this branch. The mirror-drift CI job would have blocked this PR otherwise. No logic change; the tool is designed for exactly this sync.

## Type of change

- [x] Bug fix (SUPIR arch registration + stale README date)
- [x] New tool / new preset (`tools/upgrade_research.py`)
- [ ] New ComfyUI architecture support
- [ ] Refactor (no behavior change)
- [x] Docs only (the digest itself)
- [x] Other (mirror auto-sync of 3 files; scheduled routine artifact)

## Checklist

- [x] **No personal data in the diff.** No real IPs, no `C:\Users\...` paths (the digest's `local_action_queue` uses `D:\LLM\...` template paths only), no email addresses, no tokens.
- [x] **No NSFW content in the public repo.**
- [x] **`spellcaster_core/` stays in sync.** Verified with `python tests/mirror_drift.py` post-commit: `OK: 26/26  DRIFT: 0`.
- [x] **No new custom ComfyUI nodes.** Only a `_reg()` stub was added; no manifest change needed.
- [x] **No new GIMP procedures.**
- [ ] **Tested locally against a running ComfyUI server.** Not possible from the Anthropic cloud sandbox (no LAN reach to Theo/Sparks). Static + import-time checks in the digest under "Verification steps run" are all this environment can validate. Anything requiring live model dispatch is unverifiable from here.

## Test plan

- `python -c "from spellcaster_core.architectures import ARCHITECTURES, get_arch; assert 'supir' in ARCHITECTURES; assert get_arch('supir').key == 'supir'"` — passes (was returning `sdxl` before).
- `python tests/mirror_drift.py` — `OK: 26/26  DRIFT: 0` (was `OK: 23/26  DRIFT: 3` before).
- `python tools/upgrade_research.py --json` and `--group video` — emits well-formed output; smoke-tested both formats.
- `python -c "import ast; ast.parse(open('...architectures.py').read())"` — both mirrored files parse.

No live-ComFyUI test possible from the sandbox.

## Screenshots / clips (if UI)

N/A — no UI changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_014ExvEhCZjFwqG3pNvoFMdt)_